### PR TITLE
Switch local assembler label style

### DIFF
--- a/internal/kernel_neon.h
+++ b/internal/kernel_neon.h
@@ -26,10 +26,10 @@
 #include <arm_neon.h>
 
 namespace gemmlowp {
-
+  
 // The kernels here are specifically arm 32bit assembly, not arm 64bit.
 #ifdef GEMMLOWP_NEON_32
-
+  
 // Our main GEMM kernel.
 struct NEON_32_Kernel12x4Depth2 : KernelBase {
   typedef KernelFormat<KernelSideFormat<CellFormat<4, 2>, 3>,
@@ -43,8 +43,14 @@ struct NEON_32_Kernel12x4Depth2 : KernelBase {
            int start_depth, int run_depth) const override {
     ScopedProfilingLabel label("optimized kernel (NEON 12x4)");
 
-    assert(dst_row_stride == 1);
+  // For iOS assembler, the %= style of local labels cause compilation errors,
+  //  so use numerical ones instead. See
+  // http://stackoverflow.com/questions/3898435/labels-in-gcc-inline-assembly
+  // If you add any labels, remember to undef them at the end.
+#define GEMMLOWP_LOOP_NEON_KERNEL_12X4_DEPTH2                              "1"
+#define GEMMLOWP_STORE_RESULT_NEON_KERNEL_12X4_DEPTH2                      "2"
 
+    assert(dst_row_stride == 1);
     asm volatile(
         // Clear accumulator registers (see layout below)
         "vmov.s32 q4, #0\n"
@@ -62,7 +68,7 @@ struct NEON_32_Kernel12x4Depth2 : KernelBase {
 
         /* Main loop */
 
-        "loop_NEONKernel12x4Depth2_%=:\n"
+        GEMMLOWP_LOOP_NEON_KERNEL_12X4_DEPTH2":\n"
 
         // Overview of register layout:
         //
@@ -145,7 +151,7 @@ struct NEON_32_Kernel12x4Depth2 : KernelBase {
         // Loop. Decrement loop index (depth) by 2, since we just handled 2
         // levels of depth (Kernel::kDepth=2).
         "subs %[run_depth], #2\n"
-        "bne loop_NEONKernel12x4Depth2_%=\n"
+        "bne " GEMMLOWP_LOOP_NEON_KERNEL_12X4_DEPTH2 "b\n"
 
         /* end of main loop */
 
@@ -159,7 +165,7 @@ struct NEON_32_Kernel12x4Depth2 : KernelBase {
         // If start_depth == 0, then there is no preexisting accumulator
         // to accumulate, so we can simply store our result.
         "cmp %[start_depth], #0\n"
-        "beq store_result_NEONKernel12x4Depth2_%=\n"
+        "beq " GEMMLOWP_STORE_RESULT_NEON_KERNEL_12X4_DEPTH2 "f\n"
 
         "mov r0, %[dst_ptr]\n"
 
@@ -206,7 +212,7 @@ struct NEON_32_Kernel12x4Depth2 : KernelBase {
         "vadd.s32 q11, q11, q1\n"
         "vadd.s32 q15, q15, q2\n"
 
-        "store_result_NEONKernel12x4Depth2_%=:\n"
+        GEMMLOWP_STORE_RESULT_NEON_KERNEL_12X4_DEPTH2":\n"
 
         "mov r0, %[dst_ptr]\n"
         // Store a column
@@ -247,6 +253,8 @@ struct NEON_32_Kernel12x4Depth2 : KernelBase {
         "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19", "d20",
         "d21", "d22", "d23", "d24", "d25", "d26", "d27", "d28", "d29", "d30",
         "d31");
+#undef GEMMLOWP_LOOP_NEON_KERNEL_12X4_DEPTH2
+#undef GEMMLOWP_STORE_RESULT_NEON_KERNEL_12X4_DEPTH2
   }
 };
 
@@ -267,6 +275,15 @@ struct NEON_32_Kernel12x4Depth2Assuming12BitProducts : KernelBase {
         "optimized kernel (NEON 12x4, assuming 12-bit products)");
     assert(dst_row_stride == 1);
 
+// See comments above for why we need local numerical labels in our asm.
+#define GEMMLOWP_LOOP_NEON_32_KERNEL_12X4_DEPTH2_ASSUMING_12BIT_PRODUCTS   "1"
+#define GEMMLOWP_LOAD_GLOBAL_ACCUMULATORS_NEON_32_KERNEL_12X4_DEPTH2_12BIT "2"
+#define GEMMLOWP_LABEL_32                                                  "3"
+#define GEMMLOWP_LABEL_24                                                  "4"
+#define GEMMLOWP_LABEL_16                                                  "5"
+#define GEMMLOWP_LABEL_8                                                   "6"
+#define GEMMLOWP_LABEL_2                                                   "7"
+    
     // This kernel is special in that it uses local 16-bit accumulators.
     // Because it assumes that each product fits in 12 bits, it can accumulate
     // 16 products into a local 16-bit accumulator without risking overflow.
@@ -283,7 +300,6 @@ struct NEON_32_Kernel12x4Depth2Assuming12BitProducts : KernelBase {
     //
     // and likewise for the 2nd  cell (16--31) and 3rd cell (32--47)
     std::int32_t global_accumulators[3 * 4 * 4];
-
     asm volatile(
         // Compute stride between consecutive columns, in bytes
         "mov r0, #4\n"  // multiply by 4 = sizeof(int32)
@@ -291,9 +307,7 @@ struct NEON_32_Kernel12x4Depth2Assuming12BitProducts : KernelBase {
 
         "cmp %[start_depth], #0\n"
         "bne "
-        "load_global_accumulators_NEON_32_"
-        "Kernel12x4Depth2Assuming12BitProducts_%"
-        "=\n"
+        GEMMLOWP_LOAD_GLOBAL_ACCUMULATORS_NEON_32_KERNEL_12X4_DEPTH2_12BIT "f\n"
 
         // If start_depth==0, we need to clear our global accumulators
         "mov r0, %[global_accumulators]\n"
@@ -305,12 +319,11 @@ struct NEON_32_Kernel12x4Depth2Assuming12BitProducts : KernelBase {
         "vst1.32 {d16,d17,d18,d19}, [r0]!\n"
         "vst1.32 {d16,d17,d18,d19}, [r0]!\n"
         "vst1.32 {d16,d17,d18,d19}, [r0]!\n"
-        "b loop_NEON_32_Kernel12x4Depth2Assuming12BitProducts_%=\n"
+        "b "
+        GEMMLOWP_LOOP_NEON_32_KERNEL_12X4_DEPTH2_ASSUMING_12BIT_PRODUCTS "f\n"
 
         // If start_depth!=0, we need to load our existing global accumulators
-        "load_global_accumulators_NEON_32_"
-        "Kernel12x4Depth2Assuming12BitProducts_%"
-        "=:\n"
+        GEMMLOWP_LOAD_GLOBAL_ACCUMULATORS_NEON_32_KERNEL_12X4_DEPTH2_12BIT":\n"
         // Load global accumulators from destination matrix, column-major
         "mov r1, %[dst_ptr]\n"
         "mov r0, %[dst_col_stride]\n"
@@ -369,7 +382,7 @@ struct NEON_32_Kernel12x4Depth2Assuming12BitProducts : KernelBase {
 
         /* Main loop */
 
-        "loop_NEON_32_Kernel12x4Depth2Assuming12BitProducts_%=:\n"
+        GEMMLOWP_LOOP_NEON_32_KERNEL_12X4_DEPTH2_ASSUMING_12BIT_PRODUCTS":\n"
 
 // Overview of register layout:
 //
@@ -468,22 +481,22 @@ struct NEON_32_Kernel12x4Depth2Assuming12BitProducts : KernelBase {
         // to process at this iteration. TODO (benoitjacob) I guess that
         // someone who really knows asm should make this a jump table.
         "cmp %[run_depth], #32\n"
-        "bge label_32\n"
+        "bge " GEMMLOWP_LABEL_32 "f\n"
         "cmp %[run_depth], #24\n"
-        "bge label_24\n"
+        "bge " GEMMLOWP_LABEL_24 "f\n"
         "cmp %[run_depth], #16\n"
-        "bge label_16\n"
+        "bge " GEMMLOWP_LABEL_16 "f\n"
         "cmp %[run_depth], #8\n"
-        "bge label_8\n"
-        "b label_2\n"
+        "bge " GEMMLOWP_LABEL_8 "f\n"
+        "b " GEMMLOWP_LABEL_2 "f\n"
 
-        "label_32:\n" GEMMLOWP_ACCUMULATE_8_LEVELS_OF_DEPTH
-        "label_24:\n" GEMMLOWP_ACCUMULATE_8_LEVELS_OF_DEPTH
-        "label_16:\n" GEMMLOWP_ACCUMULATE_8_LEVELS_OF_DEPTH
-        "label_8:\n" GEMMLOWP_ACCUMULATE_2_LEVELS_OF_DEPTH
+        GEMMLOWP_LABEL_32 ":\n" GEMMLOWP_ACCUMULATE_8_LEVELS_OF_DEPTH
+        GEMMLOWP_LABEL_24 ":\n" GEMMLOWP_ACCUMULATE_8_LEVELS_OF_DEPTH
+        GEMMLOWP_LABEL_16 ":\n" GEMMLOWP_ACCUMULATE_8_LEVELS_OF_DEPTH
+        GEMMLOWP_LABEL_8 ":\n" GEMMLOWP_ACCUMULATE_2_LEVELS_OF_DEPTH
             GEMMLOWP_ACCUMULATE_2_LEVELS_OF_DEPTH
                 GEMMLOWP_ACCUMULATE_2_LEVELS_OF_DEPTH
-        "label_2:\n" GEMMLOWP_ACCUMULATE_2_LEVELS_OF_DEPTH
+        GEMMLOWP_LABEL_2 ":\n" GEMMLOWP_ACCUMULATE_2_LEVELS_OF_DEPTH
 
         // Accumulate the local accumulators into the global accumulators.
         // This is about summing adjacent pairs of 16-bit scalars into
@@ -517,7 +530,8 @@ struct NEON_32_Kernel12x4Depth2Assuming12BitProducts : KernelBase {
 
         // Loop.
         "cmp %[run_depth], #0\n"
-        "bne loop_NEON_32_Kernel12x4Depth2Assuming12BitProducts_%=\n"
+        "bne "
+        GEMMLOWP_LOOP_NEON_32_KERNEL_12X4_DEPTH2_ASSUMING_12BIT_PRODUCTS "b\n"
 
 #undef GEMMLOWP_CLEAR_LOCAL_ACCUMULATORS
 #undef GEMMLOWP_ACCUMULATE_8_LEVELS_OF_DEPTH
@@ -598,6 +612,14 @@ struct NEON_32_Kernel12x4Depth2Assuming12BitProducts : KernelBase {
         "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19", "d20",
         "d21", "d22", "d23", "d24", "d25", "d26", "d27", "d28", "d29", "d30",
         "d31");
+#undef GEMMLOWP_LOOP_NEON_32_KERNEL_12X4_DEPTH2_ASSUMING_12BIT_PRODUCTS
+#undef GEMMLOWP_LOAD_GLOBAL_ACCUMULATORS_NEON_32_KERNEL_12X4_DEPTH2_12BIT
+#undef GEMMLOWP_LABEL_32
+#undef GEMMLOWP_LABEL_24
+#undef GEMMLOWP_LABEL_16
+#undef GEMMLOWP_LABEL_8
+#undef GEMMLOWP_LABEL_2
+
   }
 };
 
@@ -618,9 +640,11 @@ struct NEON_64_Kernel12x8Depth2 : KernelBase {
            const std::uint8_t* lhs_ptr, const std::uint8_t* rhs_ptr,
            int start_depth, int run_depth) const override {
     ScopedProfilingLabel label("optimized kernel (NEON 12x8)");
+    // See comments above for why we need local numerical labels in our asm.
+#define GEMMLOWP_LOOP_NEON_64_KERNEL_12X8_DEPTH2                           "1"
+#define GEMMLOWP_STORE_RESULT_NEON_64_KERNEL_12x8_DEPTH2                   "2"
 
     assert(dst_row_stride == 1);
-
     asm volatile(
         // Clear accumulator registers (see layout below)
         "dup v8.4s, wzr\n"
@@ -650,7 +674,7 @@ struct NEON_64_Kernel12x8Depth2 : KernelBase {
 
         /* Main loop */
 
-        "loop_NEON_64_Kernel12x8Depth2_%=:\n"
+        GEMMLOWP_LOOP_NEON_64_KERNEL_12X8_DEPTH2":\n"
 
         // Overview of register layout:
         //
@@ -758,7 +782,7 @@ struct NEON_64_Kernel12x8Depth2 : KernelBase {
         // Loop. Decrement loop index (depth) by 2, since we just handled 2
         // levels of depth (Kernel::kDepth=2).
         "subs %[run_depth], %[run_depth], #2\n"
-        "bne loop_NEON_64_Kernel12x8Depth2_%=\n"
+        "bne " GEMMLOWP_LOOP_NEON_64_KERNEL_12X8_DEPTH2 "b\n"
 
         /* end of main loop */
 
@@ -772,7 +796,7 @@ struct NEON_64_Kernel12x8Depth2 : KernelBase {
         // If start_depth == 0, then there is no preexisting accumulator
         // to accumulate, so we can simply store our result.
         "cmp %[start_depth], #0\n"
-        "beq store_result_NEON_64_Kernel12x8Depth2_%=\n"
+        "beq " GEMMLOWP_STORE_RESULT_NEON_64_KERNEL_12x8_DEPTH2 "f\n"
 
         "mov x0, %[dst_ptr]\n"
 
@@ -863,7 +887,7 @@ struct NEON_64_Kernel12x8Depth2 : KernelBase {
         "add v23.4s, v23.4s, v1.4s\n"
         "add v31.4s, v31.4s, v2.4s\n"
 
-        "store_result_NEON_64_Kernel12x8Depth2_%=:\n"
+        GEMMLOWP_STORE_RESULT_NEON_64_KERNEL_12x8_DEPTH2":\n"
 
         "mov x0, %[dst_ptr]\n"
         // Store a column
@@ -925,6 +949,8 @@ struct NEON_64_Kernel12x8Depth2 : KernelBase {
         "v7", "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15", "v16",
         "v17", "v18", "v19", "v20", "v21", "v22", "v23", "v24", "v25", "v26",
         "v27", "v28", "v29", "v30", "v31");
+#undef GEMMLOWP_LOOP_NEON_64_KERNEL_12X8_DEPTH2
+#undef GEMMLOWP_STORE_RESULT_NEON_64_KERNEL_12x8_DEPTH2
   }
 };
 

--- a/test/benchmark.cc
+++ b/test/benchmark.cc
@@ -304,22 +304,20 @@ void benchmark_googlenet(GemmContext* context) {
             << "% best: " << best_mean_latency << "s" << std::endl;
 }
 
-}  // end namespace gemmlowp
-
-int main() {
+void benchmark_all() {
   {
     gemmlowp::GemmContext context;
     std::cout << "Benchmarking typical GoogLeNet GEMMs..." << std::endl;
     gemmlowp::benchmark_googlenet(&context);
   }
-
+  
   {
     gemmlowp::GemmContext context;
     std::cout << "Benchmarking default mode (typically multi-threaded)..."
-              << std::endl;
+    << std::endl;
     gemmlowp::benchmark(&context);
   }
-
+  
   {
     gemmlowp::GemmContext context;
     context.set_max_num_threads(1);
@@ -327,3 +325,10 @@ int main() {
     gemmlowp::benchmark(&context);
   }
 }
+
+}  // end namespace gemmlowp
+
+// For iOS, we need to define our own main(), so skip it here.
+#if !defined(__APPLE__)
+int main() { gemmlowp::benchmark_all(); }
+#endif  // __APPLE__

--- a/test/test.cc
+++ b/test/test.cc
@@ -910,4 +910,8 @@ void test() {
 
 }  // end namespace gemmlowp
 
+// For iOS, we need to define our own main(), so skip it here.
+#if !defined(__APPLE__)
 int main() { gemmlowp::test(); }
+#endif  // __APPLE__
+


### PR DESCRIPTION
To avoid compiler errors on iOS, we need to use the numerical style of local labels in our NEON assembler, rather than the %= version, as documented here:
http://stackoverflow.com/questions/3898435/labels-in-gcc-inline-assembly
I've used preprocessor macros to try to make the results a bit less cryptic. I've tested this on iOS and Android, and all tests still pass.