### PR TITLE
SSE 64bit improvements

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -17,3 +17,4 @@ David Andersen <dga@google.com>
 
 Intel:
 Sagi Marcovich <sagi.marcovich@intel.com>
+Murat Efe Guney <murat.e.guney@intel.com>

--- a/internal/block_params.h
+++ b/internal/block_params.h
@@ -75,7 +75,10 @@ struct BlockParams {
           RoundUp<KernelFormat::kCols>(CeilQuotient(cols, min_l2_cols_blocks));
     }
 
-    {
+    // No L2 blocking in the rows dimension if l2_rhs_factor is 1.0
+    if (l2_rhs_factor == 1.0f) {
+      l2_rows = RoundUp<KernelFormat::kRows>(rows);
+    } else {
       int max_cache_friendly_l2_rows =
           std::max(1, (l2_bytes_to_use - l2_depth * l2_cols) /
                           (num_threads * (l2_depth + 4 * l2_cols)));

--- a/internal/block_params.h
+++ b/internal/block_params.h
@@ -75,7 +75,9 @@ struct BlockParams {
           RoundUp<KernelFormat::kCols>(CeilQuotient(cols, min_l2_cols_blocks));
     }
 
-    // No L2 blocking in the rows dimension if l2_rhs_factor is 1.0
+    // No L2 blocking in the row dimension if l2_rhs_factor is 1.0 as the row
+    // dimension concerns only the LHS. Blocking only RHS matrix for L2 enhances
+    // the performance on x86.
     if (l2_rhs_factor == 1.0f) {
       l2_rows = RoundUp<KernelFormat::kRows>(rows);
     } else {

--- a/internal/common.h
+++ b/internal/common.h
@@ -33,6 +33,14 @@
 #define GEMMLOWP_ALLOW_INLINE_ASM
 #endif
 
+// Define macro statement that avoids inlining for GCC.
+// For non-GCC, define as empty macro.
+#if defined(__GNUC__)
+#define GEMMLOWP_NOINLINE __attribute__((noinline))
+#else
+#define GEMMLOWP_NOINLINE 
+#endif
+
 // Detect ARM, 32-bit or 64-bit
 #ifdef __arm__
 #define GEMMLOWP_ARM_32
@@ -155,7 +163,9 @@ const int kDefaultL2CacheSize = 256 * 1024;
 // RHS blocks. This should be between 0 and 1, and typically closer to 1,
 // as we typically want to use most of the L2 cache for storing a large
 // RHS block.
-#if defined(GEMMLOWP_X86_64) || defined(GEMMLOWP_X86_32)
+#if defined(GEMMLOWP_X86)
+// For IA, use the entire L2 cache for the RHS matrix. LHS matrix is not blocked
+// for L2 cache. 
 const float kDefaultL2RhsFactor = 1.00f;
 #else
 const float kDefaultL2RhsFactor = 0.75f;

--- a/internal/common.h
+++ b/internal/common.h
@@ -155,7 +155,11 @@ const int kDefaultL2CacheSize = 256 * 1024;
 // RHS blocks. This should be between 0 and 1, and typically closer to 1,
 // as we typically want to use most of the L2 cache for storing a large
 // RHS block.
+#if defined(GEMMLOWP_X86_64) || defined(GEMMLOWP_X86_32)
+const float kDefaultL2RhsFactor = 1.00f;
+#else
 const float kDefaultL2RhsFactor = 0.75f;
+#endif
 
 // The number of bytes in a SIMD register. This is used to determine
 // the dimensions of PackingRegisterBlock so that such blocks can

--- a/internal/compute.h
+++ b/internal/compute.h
@@ -48,7 +48,7 @@ class ComputeImpl {
         packed_lhs_(_packed_lhs),
         packed_rhs_(_packed_rhs) {}
 
-  void Compute()  __attribute__((noinline)) {
+  void Compute() {
     for (int d = 0; d < block_params_.l2_depth; d += block_params_.l1_depth) {
       int ds = std::min(block_params_.l1_depth, block_params_.l2_depth - d);
 
@@ -61,7 +61,7 @@ class ComputeImpl {
   }
 
  private:
-  void ComputeRun(int start_row, int start_col, int start_depth, int depth)  __attribute__((noinline))  {
+  void ComputeRun(int start_row, int start_col, int start_depth, int depth)  GEMMLOWP_NOINLINE {
     packed_lhs_.seek_run(start_row, start_depth);
     packed_rhs_.seek_run(start_col, start_depth);
     auto packed_result_block = packed_result_->Map().block(
@@ -72,7 +72,7 @@ class ComputeImpl {
   }
 
   void ComputeL1(int start_row, int rows, int start_col, int cols,
-                 int start_depth, int depth)  __attribute__((noinline)) {
+                 int start_depth, int depth) {
     assert(rows % Format::kRows == 0);
     assert(cols % Format::kCols == 0);
     assert(depth % Format::kDepth == 0);

--- a/internal/compute.h
+++ b/internal/compute.h
@@ -48,7 +48,7 @@ class ComputeImpl {
         packed_lhs_(_packed_lhs),
         packed_rhs_(_packed_rhs) {}
 
-  void Compute() {
+  void Compute()  __attribute__((noinline)) {
     for (int d = 0; d < block_params_.l2_depth; d += block_params_.l1_depth) {
       int ds = std::min(block_params_.l1_depth, block_params_.l2_depth - d);
 
@@ -61,7 +61,7 @@ class ComputeImpl {
   }
 
  private:
-  void ComputeRun(int start_row, int start_col, int start_depth, int depth) {
+  void ComputeRun(int start_row, int start_col, int start_depth, int depth)  __attribute__((noinline))  {
     packed_lhs_.seek_run(start_row, start_depth);
     packed_rhs_.seek_run(start_col, start_depth);
     auto packed_result_block = packed_result_->Map().block(
@@ -72,7 +72,7 @@ class ComputeImpl {
   }
 
   void ComputeL1(int start_row, int rows, int start_col, int cols,
-                 int start_depth, int depth) {
+                 int start_depth, int depth)  __attribute__((noinline)) {
     assert(rows % Format::kRows == 0);
     assert(cols % Format::kCols == 0);
     assert(depth % Format::kDepth == 0);

--- a/internal/kernel_SSE.h
+++ b/internal/kernel_SSE.h
@@ -16,7 +16,7 @@
 // Check in kernel_default.h which one(s) are actually used by default.
 // Others are mere experiments; they are still covered by tests
 // in case they might be useful some day.
-// Writen by: Sagi Marcovich, mail: sagi.marcovich@intel.com
+//
 
 #ifndef GEMMLOWP_INTERNAL_KERNEL_SSE_H_
 #define GEMMLOWP_INTERNAL_KERNEL_SSE_H_

--- a/internal/kernel_SSE.h
+++ b/internal/kernel_SSE.h
@@ -188,7 +188,12 @@ struct SSE4_64_Kernel12x4Depth2 : KernelBase {
 
     asm volatile(
 
-        // set accumulators to zero.
+        // Set registers for destination 
+        "movq  %[dst_col_stride_q], %%r12\n\t"
+        "shlq $2, %%r12\n\t"
+        "leaq (%%r12,%%r12,0x2), %%r13\n\t"
+
+        // Set accumulators to zero.
         "pxor %%xmm4  , %%xmm4 \n\t"
         "pxor %%xmm5  , %%xmm5 \n\t"
         "pxor %%xmm6  , %%xmm6 \n\t"
@@ -202,7 +207,135 @@ struct SSE4_64_Kernel12x4Depth2 : KernelBase {
         "pxor %%xmm14 , %%xmm14\n\t"
         "pxor %%xmm15 , %%xmm15\n\t"
 
-        "outerLoop%=:\n\t"
+        "movq  %[run_depth_cells], %%r14\n\t"
+        "subq $2, %%r14\n\t"
+        "js outerLoop1%=\n\t"
+
+        // Loop for K unrolled by 4
+        "outerLoop2%=:\n\t"
+
+        // K = 1,2
+        // RHS cell to xmm1
+
+        "pmovzxbw (%[rhs_ptr]), %%xmm1\n\t"
+
+        // LHS cell
+        "pmovzxbw 0x00(%[lhs_ptr]), %%xmm0\n\t"
+        "pshufd $0x00,%%xmm1,%%xmm2     \n\t"
+        "pmaddwd %%xmm0, %%xmm2         \n\t"
+        "paddd %%xmm2, %%xmm4           \n\t"
+        "pshufd $0x55,%%xmm1,%%xmm3     \n\t"
+        "pmaddwd %%xmm0, %%xmm3         \n\t"
+        "paddd %%xmm3, %%xmm5           \n\t"
+
+        "prefetcht0 0x80(%[lhs_ptr]) \n\t"
+
+        "pshufd $0xaa,%%xmm1,%%xmm2     \n\t"
+        "pmaddwd %%xmm0, %%xmm2         \n\t"
+        "paddd %%xmm2, %%xmm6           \n\t"
+        "pshufd $0xff,%%xmm1,%%xmm3     \n\t"
+        "pmaddwd %%xmm0, %%xmm3         \n\t"
+        "paddd %%xmm3, %%xmm7           \n\t"
+
+        // next LHS cell
+        "pmovzxbw 0x08(%[lhs_ptr]), %%xmm0\n\t"
+        "pshufd $0x00,%%xmm1,%%xmm2     \n\t"
+        "pmaddwd %%xmm0, %%xmm2         \n\t"
+        "paddd %%xmm2, %%xmm8           \n\t"
+        "pshufd $0x55,%%xmm1,%%xmm3     \n\t"
+        "pmaddwd %%xmm0, %%xmm3         \n\t"
+        "paddd %%xmm3, %%xmm9           \n\t"
+
+        "prefetcht0 0x80(%[rhs_ptr]) \n\t"
+
+        "pshufd $0xaa,%%xmm1,%%xmm2     \n\t"
+        "pmaddwd %%xmm0, %%xmm2         \n\t"
+        "paddd %%xmm2, %%xmm10          \n\t"
+        "pshufd $0xff,%%xmm1,%%xmm3     \n\t"
+        "pmaddwd %%xmm0, %%xmm3         \n\t"
+        "paddd %%xmm3, %%xmm11          \n\t"
+
+        // next LHS cell
+        "pmovzxbw 0x10(%[lhs_ptr]), %%xmm0\n\t"
+        "pshufd $0x00,%%xmm1,%%xmm2     \n\t"
+        "pmaddwd %%xmm0, %%xmm2         \n\t"
+        "paddd %%xmm2, %%xmm12          \n\t"
+        "pshufd $0x55,%%xmm1,%%xmm3     \n\t"
+        "pmaddwd %%xmm0, %%xmm3         \n\t"
+        "paddd %%xmm3, %%xmm13          \n\t"
+
+
+        "pshufd $0xaa,%%xmm1,%%xmm2     \n\t"
+        "pmaddwd %%xmm0, %%xmm2         \n\t"
+        "paddd %%xmm2, %%xmm14          \n\t"
+        "pshufd $0xff,%%xmm1,%%xmm3     \n\t"
+        "pmaddwd %%xmm0, %%xmm3         \n\t"
+        "paddd %%xmm3, %%xmm15          \n\t"
+
+        // K = 3,4
+        // RHS cell to xmm1
+        "pmovzxbw 0x08(%[rhs_ptr]), %%xmm1\n\t"
+
+        // LHS cell
+        "pmovzxbw 0x18(%[lhs_ptr]), %%xmm0\n\t"
+        "pshufd $0x00,%%xmm1,%%xmm2     \n\t"
+        "pmaddwd %%xmm0, %%xmm2         \n\t"
+        "paddd %%xmm2, %%xmm4           \n\t"
+        "pshufd $0x55,%%xmm1,%%xmm3     \n\t"
+        "pmaddwd %%xmm0, %%xmm3         \n\t"
+        "paddd %%xmm3, %%xmm5           \n\t"
+
+        "pshufd $0xaa,%%xmm1,%%xmm2     \n\t"
+        "pmaddwd %%xmm0, %%xmm2         \n\t"
+        "paddd %%xmm2, %%xmm6           \n\t"
+        "pshufd $0xff,%%xmm1,%%xmm3     \n\t"
+        "pmaddwd %%xmm0, %%xmm3         \n\t"
+        "paddd %%xmm3, %%xmm7           \n\t"
+
+        // next LHS cell
+        "pmovzxbw 0x20(%[lhs_ptr]), %%xmm0\n\t"
+        "pshufd $0x00,%%xmm1,%%xmm2     \n\t"
+        "pmaddwd %%xmm0, %%xmm2         \n\t"
+        "paddd %%xmm2, %%xmm8           \n\t"
+        "pshufd $0x55,%%xmm1,%%xmm3     \n\t"
+        "pmaddwd %%xmm0, %%xmm3         \n\t"
+        "paddd %%xmm3, %%xmm9           \n\t"
+
+        "pshufd $0xaa,%%xmm1,%%xmm2     \n\t"
+        "pmaddwd %%xmm0, %%xmm2         \n\t"
+        "paddd %%xmm2, %%xmm10          \n\t"
+        "pshufd $0xff,%%xmm1,%%xmm3     \n\t"
+        "pmaddwd %%xmm0, %%xmm3         \n\t"
+        "paddd %%xmm3, %%xmm11          \n\t"
+
+        // next LHS cell
+        "pmovzxbw 0x28(%[lhs_ptr]), %%xmm0\n\t"
+        "pshufd $0x00,%%xmm1,%%xmm2     \n\t"
+        "pmaddwd %%xmm0, %%xmm2         \n\t"
+        "paddd %%xmm2, %%xmm12          \n\t"
+        "pshufd $0x55,%%xmm1,%%xmm3     \n\t"
+        "pmaddwd %%xmm0, %%xmm3         \n\t"
+        "paddd %%xmm3, %%xmm13          \n\t"
+
+        "pshufd $0xaa,%%xmm1,%%xmm2     \n\t"
+        "pmaddwd %%xmm0, %%xmm2         \n\t"
+        "paddd %%xmm2, %%xmm14          \n\t"
+        "pshufd $0xff,%%xmm1,%%xmm3     \n\t"
+        "pmaddwd %%xmm0, %%xmm3         \n\t"
+        "paddd %%xmm3, %%xmm15          \n\t"
+
+        "addq $0x30, %[lhs_ptr]\n\t"
+        "addq $0x10, %[rhs_ptr]\n\t"
+
+        "subq $2, %[run_depth_cells]\n\t"
+        "jnz outerLoop2%=\n\t"
+
+        "movq %[run_depth_cells], %%r14\n\t"
+        "decq %%r14\n\t"
+        "js finish%=\n\t"
+
+        // Loop for K unrolled by 2 
+        "outerLoop1%=:\n\t"
 
         // RHS cell to xmm1
         "pmovzxbw (%[rhs_ptr]), %%xmm1\n\t"
@@ -210,56 +343,56 @@ struct SSE4_64_Kernel12x4Depth2 : KernelBase {
         // LHS cell
         "pmovzxbw 0x00(%[lhs_ptr]), %%xmm0\n\t"
         "pshufd $0x00,%%xmm1,%%xmm2     \n\t"
-        "pshufd $0x55,%%xmm1,%%xmm3     \n\t"
         "pmaddwd %%xmm0, %%xmm2         \n\t"
-        "pmaddwd %%xmm0, %%xmm3         \n\t"
         "paddd %%xmm2, %%xmm4           \n\t"
+        "pshufd $0x55,%%xmm1,%%xmm3     \n\t"
+        "pmaddwd %%xmm0, %%xmm3         \n\t"
         "paddd %%xmm3, %%xmm5           \n\t"
         "pshufd $0xaa,%%xmm1,%%xmm2     \n\t"
-        "pshufd $0xff,%%xmm1,%%xmm3     \n\t"
         "pmaddwd %%xmm0, %%xmm2         \n\t"
-        "pmaddwd %%xmm0, %%xmm3         \n\t"
         "paddd %%xmm2, %%xmm6           \n\t"
+        "pshufd $0xff,%%xmm1,%%xmm3     \n\t"
+        "pmaddwd %%xmm0, %%xmm3         \n\t"
         "paddd %%xmm3, %%xmm7           \n\t"
 
         // next LHS cell
         "pmovzxbw 0x08(%[lhs_ptr]), %%xmm0\n\t"
         "pshufd $0x00,%%xmm1,%%xmm2     \n\t"
-        "pshufd $0x55,%%xmm1,%%xmm3     \n\t"
         "pmaddwd %%xmm0, %%xmm2         \n\t"
-        "pmaddwd %%xmm0, %%xmm3         \n\t"
         "paddd %%xmm2, %%xmm8           \n\t"
+        "pshufd $0x55,%%xmm1,%%xmm3     \n\t"
+        "pmaddwd %%xmm0, %%xmm3         \n\t"
         "paddd %%xmm3, %%xmm9           \n\t"
         "pshufd $0xaa,%%xmm1,%%xmm2     \n\t"
-        "pshufd $0xff,%%xmm1,%%xmm3     \n\t"
         "pmaddwd %%xmm0, %%xmm2         \n\t"
-        "pmaddwd %%xmm0, %%xmm3         \n\t"
         "paddd %%xmm2, %%xmm10          \n\t"
+        "pshufd $0xff,%%xmm1,%%xmm3     \n\t"
+        "pmaddwd %%xmm0, %%xmm3         \n\t"
         "paddd %%xmm3, %%xmm11          \n\t"
 
         // next LHS cell
         "pmovzxbw 0x10(%[lhs_ptr]), %%xmm0\n\t"
         "pshufd $0x00,%%xmm1,%%xmm2     \n\t"
-        "pshufd $0x55,%%xmm1,%%xmm3     \n\t"
         "pmaddwd %%xmm0, %%xmm2         \n\t"
-        "pmaddwd %%xmm0, %%xmm3         \n\t"
         "paddd %%xmm2, %%xmm12          \n\t"
+        "pshufd $0x55,%%xmm1,%%xmm3     \n\t"
+        "pmaddwd %%xmm0, %%xmm3         \n\t"
         "paddd %%xmm3, %%xmm13          \n\t"
         "pshufd $0xaa,%%xmm1,%%xmm2     \n\t"
-        "pshufd $0xff,%%xmm1,%%xmm3     \n\t"
         "pmaddwd %%xmm0, %%xmm2         \n\t"
-        "pmaddwd %%xmm0, %%xmm3         \n\t"
         "paddd %%xmm2, %%xmm14          \n\t"
+        "pshufd $0xff,%%xmm1,%%xmm3     \n\t"
+        "pmaddwd %%xmm0, %%xmm3         \n\t"
         "paddd %%xmm3, %%xmm15          \n\t"
 
         "addq $0x18, %[lhs_ptr]\n\t"
         "addq $0x08, %[rhs_ptr]\n\t"
-        "decq %[run_depth_cells]\n\t"
-        "jnz outerLoop%=\n\t"
 
-        "movq  %[dst_col_stride_q], %%r12\n\t"
-        "shlq $2, %%r12\n\t"
-        "leaq (%%r12,%%r12,0x2), %%r13\n\t"
+        "decq %[run_depth_cells]\n\t"
+        "jnz outerLoop1%=\n\t"
+
+        "finish%=:\n\t"
+
         "test %[start_depth], %[start_depth]\n\t"
         "jz storeDst%=\n\t"
 
@@ -300,8 +433,10 @@ struct SSE4_64_Kernel12x4Depth2 : KernelBase {
         [run_depth_cells] "r"(run_depth_cells)
         :  // clobbers
         "cc", "memory", "%xmm0", "%xmm1", "%xmm3", "%xmm2", "%xmm4", "%xmm5",
-        "%xmm6", "%xmm7", "%xmm8", "%xmm9", "%xmm10", "%r12", "%r13", "%xmm11",
+        "%xmm6", "%xmm7", "%xmm8", "%xmm9", "%xmm10", "%r12", "%r13", "%r14", "%xmm11",
         "%xmm12", "%xmm13", "%xmm14", "%xmm15");
+
+    
   }
 };
 #endif


### PR DESCRIPTION
SSE4.1 64bit code path improvements including:

* Aggressive kernel unrolling and LHS/RHS prefetching inside kernel
* No L2 blocking for LHS matrix
* No-inline statements at the ComputeRun, which improves the performance on ATOM with gcc 4.9.2
