### PR TITLE
Meta-programmed fastpath for ARM/NEON 8bit x 8bit gemm.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -20,6 +20,7 @@ filegroup(
 
 gemmlowp_headers = glob([
     "internal/*.h",
+    "meta/*.h",
 ]) + gemmlowp_public_headers
 
 filegroup(

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,6 +14,7 @@ Benoit Jacob <benoitjacob@google.com>
 Pete Warden <petewarden@google.com>
 Miao Wang <miaowang@google.com>
 David Andersen <dga@google.com>
+Maciek Chociej <maciekc@google.com>
 
 Intel:
 Sagi Marcovich <sagi.marcovich@intel.com>

--- a/meta/README
+++ b/meta/README
@@ -1,0 +1,81 @@
+METAPROGRAMMED GEMM
+===================
+
+The two main goals of this library are:
+- providing a new matrix multiplication kernel.
+- providing the optimized codepaths for as many possible user scenarios without
+  enforcing additional input data constraints (padding, sizes, strides, layout)
+
+To enable this code add -DGEMMLOWP_USE_META_FASTPATH to your build setup.
+
+The new kernel
+--------------
+
+The multiplication kernel - the most inner loop of the matrix multiplication,
+which is responsible for the row/column products was rewritten. The new code
+produces a 3x3 result patch and processes the row/column arrays in 8 element
+packs (the kernel 'shape' is 3x3x8 compared to the previous 12x4x2). By using
+specialized 8bit multiplication, aggregating to vector aggregators and then
+reduction with parallel horizontal addition we devised code that achieved
+higher arithmetical density (arithmetical operation per assembly instruction).
+The arithmetical performance of the new kernel exceeds 18 GOps/s on a vanilla
+Nexus 5 phone (which is practically peak for this device).
+
+In order to feed the kernel with input data and minimize the number of
+instructions other than the arithmetical operations a different packing
+scheme was used. Three rows (columns) are interweaved every 8 elements so that
+they can be read from continuous memory in one op inside the kernel. Additional
+memory preload hint operations are inserted into the kernel to hide memory
+latency behind arithmetical operations.
+
+Generated code
+--------------
+
+The basic kernel used in this approach is of shape 3x3x8. Obviously this
+kernel can be easily applied to multipications where matrix sizes are:
+M x K, K x N where M and N are multiplies of 3 and K is a multiply of 8.
+
+We rejected two obvious solutions of: padding the matrix sizes to appropriate
+sizes, or using the reference implementation for the leftovers. Neither did
+we consider enforcing extra constraints on the caller.
+
+In order to allow all matrix sizes the kernels processing all combinations of
+1, 2 or 3 rows and 1, 2 or 3 columns are required. Similarily to allow all
+possible depths the leftover values (up to 7 elements) needed to be handled.
+
+Instead of writing those kernels by hand we decided to generate them with
+some python scripts. 9 Versions of the multiplication kernel were prepared.
+Additionally packing and unpacking code for different row/column counts and
+depth leftovers was generated. Finally different code was generated for
+aligned memory reads/writes and unaligned memory reads/writes.
+
+Using those multiplication and packing/unpacking primitives 144 gemm function
+versions were prepared. On top of them one high level gemm function that would
+switch to one of those preoptimized versions.
+
+This approach allowed moving all unnecessary branching and conditional execution
+outside of the inner loops. It also allowed removing of all short loops required
+for leftover handling. Finally aligned memory reads/writes are used everywhere
+where the provided input data allows.
+
+Results
+-------
+
+The library shows up to 35% faster gemm execution in some cases (e.g. ImageNet
+benchmark).
+
+Files
+-----
+
+single_thread_gemm.h
+-- generated ARM/NEON 8bit x 8bit gemm implementation. Contains all the
+   optimized, unrolled and curried pack/unpack, and multiply procedures and
+   a single gemm function that switches between the optimized versions based
+   on the runtime parameters.
+
+multi_thread_gemm.h
+-- a simple parallelization scheme for the gemm function.
+
+generators/gemm_NxMxK_neon.py
+-- script that generates the single_thread_gemm.h header library.
+   Usage: python gemm_NxMxK_neon > single_thread_gemm.h

--- a/meta/generators/cc_emitter.py
+++ b/meta/generators/cc_emitter.py
@@ -1,0 +1,138 @@
+"""CC code emitter.
+
+Used by generators to programatically prepare C++ code. Contains some simple
+tools that allow generating nicely indented code and do basic correctness
+checking.
+"""
+
+
+class Error(Exception):
+  """Module level error."""
+
+
+class NamespaceError(Error):
+  """Invalid namespace operation."""
+
+
+class HeaderError(Error):
+  """Invalid cc header structure."""
+
+
+class CCEmitter(object):
+  """Emits c++ code."""
+
+  def __init__(self, debug=False):
+    self.indent = ''
+    self.debug = debug
+    self.namespaces = []
+    self.header_name = None
+
+  def PushIndent(self):
+    self.indent += '  '
+
+  def PopIndent(self):
+    self.indent = self.indent[:-2]
+
+  def EmitIndented(self, what):
+    print self.indent + what
+
+  def EmitNewline(self):
+    print ''
+
+  def EmitPreprocessor1(self, op, param):
+    print '#%s %s' % (op, param)
+
+  def EmitPreprocessor(self, op):
+    print '#%s' % op
+
+  def EmitInclude(self, include):
+    self.EmitPreprocessor1('include', include)
+
+  def EmitCode(self, code):
+    self.EmitIndented('%s;' % code)
+
+  def EmitCodeNoSemicolon(self, code):
+    self.EmitIndented('%s' % code)
+
+  def EmitCall1(self, function, param):
+    self.EmitIndented('%s(%s);' % (function, param))
+
+  def EmitAssert(self, assert_expression):
+    if self.debug:
+      self.EmitCall1('assert', assert_expression)
+
+  def EmitHeaderBegin(self, header_name, includes=[]):
+    if self.header_name:
+      raise HeaderError('Header already defined.')
+    self.EmitPreprocessor1('ifndef', (header_name + '_H_').upper())
+    self.EmitPreprocessor1('define', (header_name + '_H_').upper())
+    self.EmitNewline()
+    if includes:
+      for include in includes:
+        self.EmitInclude(include)
+      self.EmitNewline()
+    self.header_name = header_name
+
+  def EmitHeaderEnd(self):
+    if not self.header_name:
+      raise HeaderError('Header undefined.')
+    self.EmitPreprocessor1('endif',
+                           ' // %s' % (self.header_name + '_H_').upper())
+    self.header_name = None
+
+  def EmitFunctionBeginA(self, function_name, params, return_type):
+    self.EmitIndented('%s %s(%s) {' % (
+        return_type,
+        function_name,
+        ', '.join(['%s %s' % (t, n) for (t, n) in params])))
+    self.PushIndent()
+
+  def EmitFunctionEnd(self):
+    self.PopIndent()
+    self.EmitIndented('}')
+
+  def EmitNamespaceBegin(self, namespace):
+    self.EmitCodeNoSemicolon('namespace %s {' % namespace)
+    self.namespaces.append(namespace)
+
+  def EmitNamespaceEnd(self):
+    if not self.namespaces:
+      raise NamespaceError('No namespace on stack.')
+    self.EmitCodeNoSemicolon('}  // namespace %s' % self.namespaces.pop())
+
+  def EmitComment(self, comment):
+    self.EmitIndented('// ' + comment)
+
+  def EmitOpenBracket(self, pre_bracket=None):
+    if pre_bracket:
+      self.EmitIndented('%s {' % pre_bracket)
+    else:
+      self.EmitIndented('{')
+    self.PushIndent()
+
+  def EmitCloseBracket(self):
+    self.PopIndent()
+    self.EmitIndented('}')
+
+  def EmitSwitch(self, switch):
+    self.EmitOpenBracket('switch (%s)' % switch)
+
+  def EmitSwitchEnd(self):
+    self.EmitCloseBracket()
+
+  def EmitCase(self, value):
+    self.EmitCodeNoSemicolon('case %s:' % value)
+
+  def EmitBreak(self):
+    self.EmitCode('break')
+
+  def EmitIf(self, condition):
+    self.EmitOpenBracket('if (%s)' % condition)
+
+  def EmitElse(self):
+    self.PopIndent()
+    self.EmitCodeNoSemicolon('} else {')
+    self.PushIndent()
+
+  def EmitEndif(self):
+    self.EmitCloseBracket()

--- a/meta/generators/gemm_NxMxK_neon.py
+++ b/meta/generators/gemm_NxMxK_neon.py
@@ -1,0 +1,364 @@
+"""Generates the whole gemm header.
+
+"""
+
+import cc_emitter
+import mul_Nx8_Mx8_neon
+import neon_emitter
+import qnt_Nx8_neon
+import zip_Nx8_neon
+
+_HEADER_COPYRIGHT = """// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// single_thread_gemm.h: programatically generated GEMM library header.
+"""
+
+
+def GenerateTempsCountersAndConsts(emitter, rows):
+  """Emits constants and variables declarations."""
+  emitter.EmitCode('const std::int32_t row_chunks = n / 3')
+  emitter.EmitCode('const std::int32_t col_chunks = m / 3')
+  emitter.EmitCode('const std::int32_t padded_k = ((k + 7) / 8) * 8')
+  emitter.EmitNewline()
+
+  emitter.EmitCode('const std::int32_t chunk_size = k * 3')
+  emitter.EmitCode('const std::int32_t zipped_chunk_size = (padded_k + 16) * 3')
+  emitter.EmitCode('const std::int32_t zipped_rhs_size = (padded_k + 16) * m')
+  emitter.EmitCode(
+      'const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8')
+  emitter.EmitCode(
+      'const std::int32_t temp_result_size = 3 * temp_result_stride')
+  emitter.EmitCode('const std::int32_t rounding_offset = (1 << (shift - 1))')
+  emitter.EmitCode('const std::int32_t result_chunk_size = m * 3')
+  emitter.EmitNewline()
+
+  emitter.EmitCode('std::uint8_t* zipped_lhs = scratch')
+  emitter.EmitCode('std::int32_t* zipped_lhs_3_offsets = '
+                   'reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3)')
+  leftover_rows = rows % 3
+  if leftover_rows:
+    emitter.EmitCode(
+        ('std::int32_t* zipped_lhs_%d_offsets = '
+         'reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * %d)') % (
+             leftover_rows, leftover_rows))
+
+  emitter.EmitCode('std::uint8_t* zipped_rhs = scratch + zipped_chunk_size')
+  emitter.EmitCode(
+      'std::int32_t* temp_result = reinterpret_cast<std::int32_t*>('
+      'scratch + zipped_chunk_size + zipped_rhs_size)')
+  emitter.EmitNewline()
+
+  emitter.EmitCode('const std::uint8_t* lhs_chunk = lhs')
+  emitter.EmitCode('const std::uint8_t* rhs_chunk = rhs')
+  emitter.EmitCode('std::uint8_t* zipped_rhs_chunk = zipped_rhs')
+  emitter.EmitCode('std::int32_t* temp_result_chunk = temp_result')
+  emitter.EmitCode('std::uint8_t* result_chunk = result')
+  emitter.EmitNewline()
+  emitter.EmitCode('const std::int32_t const_offset = '
+                   'lhs_offset * rhs_offset * k + result_offset')
+
+
+def ZipName(rows, leftovers, aligned):
+  return zip_Nx8_neon.BuildName(rows, leftovers, aligned)
+
+
+def GenerateZipRhs(emitter, aligned, cols, leftovers):
+  """Emits the code responsible for zipping the rhs matrix."""
+  emitter.EmitOpenBracket('for (int i = 0; i < col_chunks; ++i)')
+  emitter.EmitCode(
+      '%s(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0)' % ZipName(
+          3, leftovers, aligned))
+  emitter.EmitCode('rhs_chunk += chunk_size')
+  emitter.EmitCode('zipped_rhs_chunk += zipped_chunk_size')
+  emitter.EmitCloseBracket()
+
+  leftover_cols = cols % 3
+
+  if leftover_cols:
+    emitter.EmitCode(
+        '%s(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0)' % ZipName(
+            leftover_cols, leftovers, aligned))
+  emitter.EmitNewline()
+
+
+def MulName(rows, cols):
+  return mul_Nx8_Mx8_neon.BuildName(rows, cols)
+
+
+def GenerateMulRows(emitter, aligned, rows, cols, leftover):
+  """Emits code responsible for multiplication of one horizontal lhs strip."""
+  emitter.EmitCode(
+      '%s(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset)' % ZipName(
+          rows, leftover, aligned))
+
+  emitter.EmitCode('zipped_rhs_chunk = zipped_rhs')
+  emitter.EmitCode('temp_result_chunk = temp_result')
+  emitter.EmitOpenBracket('for (int j = 0; j < col_chunks; ++j)')
+
+  emitter.EmitCode(
+      ('%s(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk, '
+       'temp_result_stride)') % MulName(rows, 3))
+  emitter.EmitCode('zipped_rhs_chunk += zipped_chunk_size')
+  emitter.EmitCode('temp_result_chunk += 3')
+
+  emitter.EmitCloseBracket()
+
+  leftover_cols = cols % 3
+  if leftover_cols:
+    emitter.EmitCode(
+        ('%s(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk, '
+         'temp_result_stride)') % MulName(rows, leftover_cols))
+
+  emitter.EmitCode(
+      ('%s(temp_result, m, temp_result_stride, zipped_lhs_%d_offsets, '
+       'result_chunk, m, multiplicative_offset, rounding_offset, -shift)') % (
+           BuildMultiQuantizeName(aligned, rows), rows))
+
+
+def GenerateMul(emitter, aligned, rows, cols, leftover):
+  """Emits code for all horizontal lhs strips, plus leftover rows."""
+  emitter.EmitOpenBracket('for (int i = 0; i < row_chunks; ++i)')
+
+  GenerateMulRows(emitter, aligned, 3, cols, leftover)
+  emitter.EmitCode('lhs_chunk += chunk_size')
+  emitter.EmitCode('result_chunk += result_chunk_size')
+
+  emitter.EmitCloseBracket()
+  emitter.EmitNewline()
+
+  leftover_rows = rows % 3
+  if leftover_rows:
+    GenerateMulRows(emitter, aligned, leftover_rows, cols, leftover)
+
+
+def BuildName(aligned, rows, cols, leftover):
+  name = 'gemm_%d_%d_%d' % (rows, cols, leftover)
+  if aligned:
+    name = '%s_aligned' % name
+  return name
+
+
+def GenerateGemm(emitter, aligned, rows, cols, leftover):
+  """Build one gemm function for given row, col, and depth leftovers."""
+  name = BuildName(aligned, rows, cols, leftover)
+
+  emitter.EmitFunctionBeginA(name,
+                             [['std::uint8_t*', 'scratch'],
+                              ['const std::uint8_t*', 'lhs'],
+                              ['const std::uint8_t*', 'rhs'],
+                              ['std::int32_t', 'n'],
+                              ['std::int32_t', 'm'],
+                              ['std::int32_t', 'k'],
+                              ['std::int32_t', 'lhs_offset'],
+                              ['std::int32_t', 'rhs_offset'],
+                              ['std::int32_t', 'result_offset'],
+                              ['std::int32_t', 'multiplicative_offset'],
+                              ['std::int32_t', 'shift'],
+                              ['std::uint8_t*', 'result']],
+                             'void')
+  emitter.EmitAssert('n %% 3 == %d' % rows)
+  emitter.EmitAssert('m %% 3 == %d' % cols)
+  emitter.EmitAssert('k %% 8 == %d' % leftover)
+
+  GenerateTempsCountersAndConsts(emitter, rows)
+  GenerateZipRhs(emitter, aligned, cols, leftover)
+  GenerateMul(emitter, aligned, rows, cols, leftover)
+  emitter.EmitFunctionEnd()
+
+
+def BuildMultiQuantizeName(aligned, rows):
+  name = 'multi_qnt_%dx8' % rows
+  if aligned:
+    name = '%s_aligned' % name
+  return name
+
+
+def GenerateMultiQuantize(emitter, aligned, rows):
+  """Emit main quantization code that switches between optimized versions."""
+  name = BuildMultiQuantizeName(aligned, rows)
+  emitter.EmitFunctionBeginA(name,
+                             [['const std::int32_t*', 'source'],
+                              ['std::int32_t', 'count'],
+                              ['std::int32_t', 'stride'],
+                              ['const std::int32_t*', 'offsets'],
+                              ['std::uint8_t*', 'destination'],
+                              ['std::int32_t', 'destination_stride'],
+                              ['std::int32_t', 'multiplicative_offset'],
+                              ['std::int32_t', 'rounding_offset'],
+                              ['std::int32_t', 'shift']],
+                             'void')
+  emitter.EmitSwitch('count % 8')
+
+  for i in range(0, 8):
+    emitter.EmitCase(i)
+    emitter.PushIndent()
+
+    called_name = qnt_Nx8_neon.BuildName(rows, i, aligned)
+    emitter.EmitCode(
+        ('%s(source, count, stride, offsets, destination, destination_stride, '
+         'multiplicative_offset, rounding_offset, shift)') % called_name)
+    emitter.EmitBreak()
+    emitter.PopIndent()
+
+  emitter.EmitSwitchEnd()
+  emitter.EmitFunctionEnd()
+
+
+def GenerateGemmSwitch3(emitter, aligned, n_mod, m_mod):
+  """Third level of main switch, choose optimized version on depth leftover."""
+  emitter.EmitSwitch('k % 8')
+
+  for i in range(0, 8):
+    emitter.EmitCase(i)
+    emitter.PushIndent()
+    emitter.EmitCode(
+        ('internal::%s(scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset, '
+         'result_offset, multiplicative_offset, shift, result)') % (
+             BuildName(aligned, n_mod, m_mod, i)))
+    emitter.EmitBreak()
+    emitter.PopIndent()
+
+  emitter.EmitSwitchEnd()
+
+
+def GenerateGemmSwitch2(emitter, aligned, n_mod):
+  """Second level of main switch, choose optimized version on cols leftover."""
+  emitter.EmitSwitch('m % 3')
+
+  for i in range(0, 3):
+    emitter.EmitCase(i)
+    emitter.PushIndent()
+    GenerateGemmSwitch3(emitter, aligned, n_mod, i)
+    emitter.EmitBreak()
+    emitter.PopIndent()
+
+  emitter.EmitSwitchEnd()
+
+
+def GenerateGemmSwitch1(emitter, aligned):
+  """First level of main switch, choose optimized version on rows leftover."""
+  emitter.EmitSwitch('n % 3')
+
+  for i in range(0, 3):
+    emitter.EmitCase(i)
+    emitter.PushIndent()
+    GenerateGemmSwitch2(emitter, aligned, i)
+    emitter.EmitBreak()
+    emitter.PopIndent()
+
+  emitter.EmitSwitchEnd()
+
+
+def GenerateMainGemmFunction(emitter):
+  """Emit high level gemm function that switches between optimized versions."""
+  emitter.EmitFunctionBeginA('gemm',
+                             [['std::uint8_t*', 'scratch'],
+                              ['const std::uint8_t*', 'lhs'],
+                              ['const std::uint8_t*', 'rhs'],
+                              ['std::int32_t', 'n'],
+                              ['std::int32_t', 'm'],
+                              ['std::int32_t', 'k'],
+                              ['std::int32_t', 'lhs_offset'],
+                              ['std::int32_t', 'rhs_offset'],
+                              ['std::int32_t', 'result_offset'],
+                              ['std::int32_t', 'multiplicative_offset'],
+                              ['std::int32_t', 'shift'],
+                              ['std::uint8_t*', 'result']],
+                             'void')
+  emitter.EmitCode('const bool lhs_aligned = '
+                   '((reinterpret_cast<std::uintptr_t>(lhs) % 8) == 0)')
+  emitter.EmitCode('const bool rhs_aligned = '
+                   '((reinterpret_cast<std::uintptr_t>(rhs) % 8) == 0)')
+  emitter.EmitCode('const bool result_aligned = '
+                   '((reinterpret_cast<std::uintptr_t>(result) % 8) == 0)')
+  emitter.EmitCode('const bool m_aligned = ((m % 8) == 0)')
+  emitter.EmitCode('const bool k_aligned = ((k % 8) == 0)')
+  emitter.EmitCode(
+      'const bool aligned = '
+      'lhs_aligned && rhs_aligned && result_aligned && m_aligned && k_aligned')
+
+  emitter.EmitIf('aligned')
+  GenerateGemmSwitch1(emitter, True)
+  emitter.EmitElse()
+  GenerateGemmSwitch1(emitter, False)
+  emitter.EmitEndif()
+  emitter.EmitFunctionEnd()
+
+
+def GenerateFunctions(emitter):
+
+  for aligned in [True, False]:
+    for rows in range(1, 4):
+      GenerateMultiQuantize(emitter, aligned, rows)
+      emitter.EmitNewline()
+
+  for aligned in [True, False]:
+    for rows in range(0, 3):
+      for cols in range(0, 3):
+        for leftover in range(0, 8):
+          GenerateGemm(emitter, aligned, rows, cols, leftover)
+          emitter.EmitNewline()
+
+
+def Main():
+  emitter = cc_emitter.CCEmitter()
+
+  emitter.EmitCodeNoSemicolon(_HEADER_COPYRIGHT)
+  emitter.EmitHeaderBegin('gemmlowp_meta_single_thread_gemm')
+
+  emitter.EmitPreprocessor1('ifdef', 'GEMMLOWP_NEON_32')
+  emitter.EmitNewline()
+
+  emitter.EmitInclude('<cassert>')
+  emitter.EmitNewline()
+
+  emitter.EmitNamespaceBegin('gemmlowp')
+  emitter.EmitNamespaceBegin('meta')
+  emitter.EmitNamespaceBegin('internal')
+  emitter.EmitNewline()
+
+  zip_Nx8_neon.GenerateFunctions(neon_emitter.NeonEmitter())
+  emitter.EmitNewline()
+
+  mul_Nx8_Mx8_neon.GenerateFunctions(neon_emitter.NeonEmitter())
+  emitter.EmitNewline()
+
+  qnt_Nx8_neon.GenerateFunctions(neon_emitter.NeonEmitter())
+  emitter.EmitNewline()
+
+  GenerateFunctions(emitter)
+
+  emitter.EmitNewline()
+  emitter.EmitNamespaceEnd()
+  emitter.EmitNewline()
+
+  GenerateMainGemmFunction(emitter)
+  emitter.EmitNewline()
+
+  emitter.EmitNamespaceEnd()
+  emitter.EmitNamespaceEnd()
+  emitter.EmitNewline()
+
+  emitter.EmitPreprocessor('else')
+  emitter.EmitPreprocessor1('warning',
+                            '"Meta gemm fast-path requires GEMMLOWP_NEON_32!"')
+  emitter.EmitPreprocessor('endif')
+  emitter.EmitNewline()
+
+  emitter.EmitHeaderEnd()
+
+
+if __name__ == '__main__':
+  Main()

--- a/meta/generators/mul_Nx8_Mx8_neon.py
+++ b/meta/generators/mul_Nx8_Mx8_neon.py
@@ -1,0 +1,381 @@
+"""Mul primitive used by the GEMM function.
+
+The Mul primitive takes 1-3 zipped rows and 1-3 zipped columns and performs
+matrix multiplication on those resulting in a small 1x1 to 3x3 block of results.
+"""
+
+import neon_emitter
+
+
+class Error(Exception):
+  """Module level error."""
+
+
+class ConfigurationError(Error):
+  """Unsupported configuration."""
+
+
+class MulLanes(object):
+
+  def __init__(self, input_address):
+    self.input_address = input_address
+    self.lanes = []
+
+  def AddLane(self, lane):
+    self.lanes.append(lane)
+
+  def FreeRegisters(self, registers):
+    for i in range(0, len(self.lanes)):
+      registers.FreeRegister(self.lanes[i])
+      self.lanes[i] = None
+
+
+def GenerateMulLanes(registers, lane_count, address):
+  lanes = MulLanes(address)
+  for unused_i in range(0, lane_count):
+    lanes.AddLane(registers.DoubleRegister())
+  return lanes
+
+
+def Generate3MulLanes(quad_register, registers, address):
+  lanes = MulLanes(address)
+  lanes.AddLane(registers.Low(quad_register))
+  lanes.AddLane(registers.High(quad_register))
+  lanes.AddLane(registers.DoubleRegister())
+  return lanes
+
+
+def GenerateAndClearAggregators(emitter, registers, aggregator_count):
+  """Prepare aggregators and emit aggregator clear code."""
+  emitter.EmitComment('Clear aggregators.')
+  aggregators = []
+  for i in range(0, aggregator_count):
+    aggregator = registers.QuadRegister()
+    aggregators.append(aggregator)
+    if i < 3:
+      emitter.EmitVMov('i32', aggregator, emitter.ImmediateConstant(0))
+    else:
+      emitter.EmitVMov('i32', aggregator, aggregators[i - 3])
+  emitter.EmitNewline()
+  return aggregators
+
+
+def GenerateNxMLoadMultiplyAggregate(
+    name, emitter, registers, left_lanes, right_lanes, aggregators, count):
+  """Emit inner loop for N rows x M cols multiplication."""
+  emitter.EmitComment('General NxM lanes loop.')
+  emitter.EmitNumericalLabel(1)
+  emitter.EmitNewline()
+  emitter.EmitComment('Subtract counter.')
+  emitter.EmitSubs(count, count, emitter.ImmediateConstant(8))
+  emitter.EmitNewline()
+
+  emitter.EmitVLoadA('1.8', left_lanes.lanes,
+                     emitter.DereferenceIncrement(left_lanes.input_address, 64))
+  emitter.EmitVLoadA(
+      '1.8', right_lanes.lanes,
+      emitter.DereferenceIncrement(right_lanes.input_address, 64))
+
+  emitter.EmitPldOffset(left_lanes.input_address, emitter.ImmediateConstant(64))
+  emitter.EmitPldOffset(
+      right_lanes.input_address, emitter.ImmediateConstant(64))
+
+  rows = len(left_lanes.lanes)
+  cols = len(right_lanes.lanes)
+
+  multiply_results = []
+  for i in range(0, rows * cols):
+    multiply_results.append(registers.QuadRegister())
+
+  for row in range(0, rows):
+    for col in range(0, cols):
+      index = row * cols + col
+      emitter.EmitVMull('u8',
+                        multiply_results[index],
+                        right_lanes.lanes[col],
+                        left_lanes.lanes[row])
+
+  for i in range(0, rows * cols):
+    emitter.EmitVPadal('u16', aggregators[i], multiply_results[i])
+
+  emitter.EmitNewline()
+  emitter.EmitComment('Loop break.')
+  emitter.EmitBneBack(1)
+  emitter.EmitNewline()
+
+  for register in multiply_results:
+    registers.FreeRegister(register)
+
+
+def Generate3x3LoadMultiplyAggregate(
+    name, emitter, registers, left_lanes, right_lanes, aggregators, count,
+    backup_register):
+  """Emit inner loop for 3 rows x 3 cols multiplication (register trick)."""
+  emitter.EmitComment('3x3 lanes loop.')
+  emitter.EmitNumericalLabel(1)
+  emitter.EmitNewline()
+  emitter.EmitComment('Subtract counter.')
+  emitter.EmitSubs(count, count, emitter.ImmediateConstant(8))
+  emitter.EmitNewline()
+
+  emitter.EmitVLoadA('1.8', left_lanes.lanes,
+                     emitter.DereferenceIncrement(left_lanes.input_address, 64))
+  emitter.EmitVLoadA(
+      '1.8', right_lanes.lanes,
+      emitter.DereferenceIncrement(right_lanes.input_address, 64))
+
+  emitter.EmitPldOffset(left_lanes.input_address, emitter.ImmediateConstant(64))
+  emitter.EmitPldOffset(
+      right_lanes.input_address, emitter.ImmediateConstant(64))
+
+  temp = []
+  for unused_i in range(0, 4):
+    temp.append(registers.QuadRegister())
+
+  emitter.EmitVMull('u8', temp[0], left_lanes.lanes[0], right_lanes.lanes[0])
+  emitter.EmitVMull('u8', temp[1], left_lanes.lanes[0], right_lanes.lanes[1])
+  emitter.EmitVMull('u8', temp[2], left_lanes.lanes[0], right_lanes.lanes[2])
+  emitter.EmitVMull('u8', temp[3], left_lanes.lanes[1], right_lanes.lanes[0])
+
+  emitter.EmitVPadal('u16', aggregators[0], temp[0])
+  emitter.EmitVPadal('u16', aggregators[1], temp[1])
+  emitter.EmitVPadal('u16', aggregators[2], temp[2])
+  emitter.EmitVPadal('u16', aggregators[3], temp[3])
+
+  emitter.EmitVMull('u8', temp[0], left_lanes.lanes[1], right_lanes.lanes[1])
+  emitter.EmitVMull('u8', temp[1], left_lanes.lanes[1], right_lanes.lanes[2])
+  emitter.EmitVMull('u8', temp[2], left_lanes.lanes[2], right_lanes.lanes[0])
+  emitter.EmitVMull('u8', temp[3], left_lanes.lanes[2], right_lanes.lanes[1])
+  emitter.EmitVMull(
+      'u8', backup_register, left_lanes.lanes[2], right_lanes.lanes[2])
+
+  emitter.EmitVPadal('u16', aggregators[4], temp[0])
+  emitter.EmitVPadal('u16', aggregators[5], temp[1])
+  emitter.EmitVPadal('u16', aggregators[6], temp[2])
+  emitter.EmitVPadal('u16', aggregators[7], temp[3])
+  emitter.EmitVPadal('u16', aggregators[8], backup_register)
+
+  emitter.EmitNewline()
+  emitter.EmitComment('Loop break.')
+  emitter.EmitBneBack(1)
+  emitter.EmitNewline()
+
+  for register in temp:
+    registers.FreeRegister(register)
+
+
+def ReadParams(emitter, registers, input_address, elements, min_reg):
+  if elements == 1 or elements == 2:
+    register = registers.DoubleRegister(min_reg * 2)
+    emitter.EmitVLoad('1.32', register, emitter.Dereference(input_address, 64))
+    return register
+  elif elements == 3:
+    register = registers.QuadRegister(min_reg)
+    emitter.EmitVLoad('1.32', register, emitter.Dereference(input_address, 64))
+    return register
+  else:
+    raise ConfigurationError('Unsupported elements no: %d' % elements)
+
+
+def ReduceAggregator(emitter, registers, aggregators, row, cols):
+  if cols == 1:
+    register = registers.DoubleRegister()
+    emitter.EmitVPadd('u32',
+                      register,
+                      registers.Low(aggregators[row]),
+                      registers.Low(aggregators[row]))
+    return register
+  elif cols == 2:
+    register = registers.DoubleRegister()
+    emitter.EmitVPadd('u32',
+                      register,
+                      registers.Low(aggregators[row * 2]),
+                      registers.Low(aggregators[row * 2 + 1]))
+    return register
+  elif cols == 3:
+    register = registers.QuadRegister()
+    emitter.EmitVPadd('u32',
+                      registers.Low(register),
+                      registers.Low(aggregators[row * 3]),
+                      registers.Low(aggregators[row * 3 + 1]))
+    emitter.EmitVPadd('u32',
+                      registers.High(register),
+                      registers.Low(aggregators[row * 3 + 2]),
+                      registers.Low(aggregators[row * 3 + 2]))
+    return register
+  else:
+    raise ConfigurationError('Unsupported columns no: %d' % cols)
+
+
+def StoreAggregator(
+    emitter, registers, aggregator, cols, result_address, result_stride):
+  if cols == 1:
+    emitter.EmitVStoreOffset(
+        '1.32', emitter.Lane(aggregator, 0),
+        emitter.Dereference(result_address, None),
+        result_stride)
+  elif cols == 2:
+    emitter.EmitVStoreOffset(
+        '1.32', aggregator, emitter.Dereference(result_address, None),
+        result_stride)
+  elif cols == 3:
+    emitter.EmitVStore(
+        '1.32', registers.Low(aggregator),
+        emitter.DereferenceIncrement(result_address, None))
+    emitter.EmitVStoreOffset(
+        '1.32', emitter.Lane(registers.High(aggregator), 0),
+        emitter.Dereference(result_address, None),
+        result_stride)
+    emitter.EmitNewline()
+  else:
+    raise ConfigurationError('Unsupported columns no: %d' % cols)
+
+
+def GenerateAggregatorReduceStore(emitter,
+                                  registers,
+                                  aggregators,
+                                  left_lanes,
+                                  right_lanes,
+                                  results,
+                                  results_stride):
+  """Emit code that reduces 4 lane aggregators to 1 value, and stores them."""
+  rows = len(left_lanes.lanes)
+  cols = len(right_lanes.lanes)
+
+  right_offset = ReadParams(
+      emitter, registers, right_lanes.input_address, cols, 4)
+
+  if cols == 3:
+    emitter.EmitNewline()
+    emitter.EmitComment('Change stride because storing in two ops.')
+    emitter.EmitSub(
+        results_stride, results_stride, emitter.ImmediateConstant(8))
+
+  emitter.EmitNewline()
+  emitter.EmitComment('Horizontal reduce aggregators.')
+  for aggregator in aggregators:
+    emitter.EmitVPadd('u32',
+                      registers.Low(aggregator),
+                      registers.Low(aggregator),
+                      registers.High(aggregator))
+
+  emitter.EmitNewline()
+  emitter.EmitComment('Reduce rows.')
+  row_temps = []
+  for i in range(0, rows):
+    row_temps.append(ReduceAggregator(emitter, registers, aggregators, i, cols))
+
+  emitter.EmitNewline()
+  emitter.EmitComment('Add rhs offset to aggregated rows.')
+  for row_temp in row_temps:
+    emitter.EmitVAdd('s32', row_temp, row_temp, right_offset)
+
+  emitter.EmitNewline()
+  emitter.EmitComment('Store reduced (rhs added) rows.')
+  for row_temp in row_temps:
+    StoreAggregator(
+        emitter, registers, row_temp, cols, results, results_stride)
+
+
+def BuildName(left, right):
+  return 'mul_%dx8_%dx8_rhsadd' % (left, right)
+
+
+def GenerateMulNx8Mx8(emitter, left_lanes_count, right_lanes_count):
+  """Emit the multiply code for given rows and cols counts."""
+  if left_lanes_count < 1 or left_lanes_count > 3:
+    raise ConfigurationError('Left_lanes should be: 1, 2 or 3.')
+  if right_lanes_count < 1 or right_lanes_count > 3:
+    raise ConfigurationError('Right_lanes should be: 1, 2 or 3.')
+
+  name = BuildName(left_lanes_count, right_lanes_count)
+
+  emitter.EmitFunctionBeginA(name,
+                             [['const std::uint8_t*', 'left'],
+                              ['const std::uint8_t*', 'right'],
+                              ['std::int32_t', 'count'],
+                              ['std::int32_t*', 'results'],
+                              ['std::int32_t', 'results_stride']],
+                             'inline void')
+  emitter.EmitAssert('count % 8 == 0')
+  emitter.EmitAssert('count >= 8')
+  emitter.EmitAsmBegin()
+
+  registers = neon_emitter.NeonRegisters()
+
+  count = registers.MapParameter('count')
+
+  size = left_lanes_count * right_lanes_count
+
+  if size < 9:
+    left_lanes = GenerateMulLanes(registers,
+                                  left_lanes_count,
+                                  registers.MapParameter('left'))
+    right_lanes = GenerateMulLanes(registers,
+                                   right_lanes_count,
+                                   registers.MapParameter('right'))
+
+    emitter.EmitPld(left_lanes.input_address)
+    emitter.EmitPld(right_lanes.input_address)
+
+    aggregators = GenerateAndClearAggregators(emitter, registers, size)
+
+    GenerateNxMLoadMultiplyAggregate(
+        name, emitter, registers, left_lanes, right_lanes, aggregators, count)
+
+    left_lanes.FreeRegisters(registers)
+    right_lanes.FreeRegisters(registers)
+
+    GenerateAggregatorReduceStore(emitter,
+                                  registers,
+                                  aggregators,
+                                  left_lanes,
+                                  right_lanes,
+                                  registers.MapParameter('results'),
+                                  registers.MapParameter('results_stride'))
+
+  else:  # left == 3 and right == 3
+    backup_register = registers.QuadRegister()
+    left_lanes = Generate3MulLanes(backup_register,
+                                   registers,
+                                   registers.MapParameter('left'))
+    right_lanes = GenerateMulLanes(registers,
+                                   right_lanes_count,
+                                   registers.MapParameter('right'))
+
+    emitter.EmitPld(left_lanes.input_address)
+    emitter.EmitPld(right_lanes.input_address)
+
+    aggregators = GenerateAndClearAggregators(emitter, registers, size)
+
+    Generate3x3LoadMultiplyAggregate(name,
+                                     emitter,
+                                     registers,
+                                     left_lanes,
+                                     right_lanes,
+                                     aggregators,
+                                     count,
+                                     backup_register)
+
+    left_lanes.FreeRegisters(registers)
+    right_lanes.FreeRegisters(registers)
+
+    GenerateAggregatorReduceStore(emitter,
+                                  registers,
+                                  aggregators,
+                                  left_lanes,
+                                  right_lanes,
+                                  registers.MapParameter('results'),
+                                  registers.MapParameter('results_stride'))
+
+  emitter.EmitAsmEnd(registers.MappedParameters(),
+                     [],
+                     registers.Clobbers() + ['cc', 'memory'])
+  emitter.EmitFunctionEnd()
+
+
+def GenerateFunctions(emitter):
+  for right_lanes in range(1, 4):
+    for left_lanes in range(1, 4):
+      GenerateMulNx8Mx8(emitter, right_lanes, left_lanes)
+      emitter.EmitNewline()

--- a/meta/generators/neon_emitter.py
+++ b/meta/generators/neon_emitter.py
@@ -1,0 +1,332 @@
+"""ARM/NEON assembly emitter.
+
+Used by code generators to produce ARM assembly with NEON simd code.
+Provides tools for easier register management: named register variable
+allocation/deallocation, and offers a more procedural/structured approach
+to generating assembly.
+
+TODO: right now neon emitter prints out assembly instructions immediately,
+it might be beneficial to keep the whole structure and emit the assembly after
+applying some optimizations like: instruction reordering or register reuse.
+
+TODO: NeonRegister object assigns explicit registers at allocation time.
+Similarily to emiting code, register mapping and reuse can be performed and
+optimized lazily.
+"""
+
+
+class Error(Exception):
+  """Module level error."""
+
+
+class RegisterAllocationError(Error):
+  """Cannot alocate registers."""
+
+
+class NeonRegisters(object):
+  """Utility that keeps track of used ARM/NEON registers."""
+
+  def __init__(self):
+    self.double = set()
+    self.double_ever = set()
+    self.general = set()
+    self.general_ever = set()
+    self.parameters = set()
+
+  def MapParameter(self, parameter):
+    self.parameters.add(parameter)
+    return '%%[%s]' % parameter
+
+  def DoubleRegister(self, min_val=0):
+    for i in range(min_val, 32):
+      if i not in self.double:
+        self.double.add(i)
+        self.double_ever.add(i)
+        return 'd%d' % i
+    raise RegisterAllocationError('Not enough double registers.')
+
+  def QuadRegister(self, min_val=0):
+    for i in range(min_val, 16):
+      if ((i * 2) not in self.double) and ((i * 2 + 1) not in self.double):
+        self.double.add(i * 2)
+        self.double.add(i * 2 + 1)
+        self.double_ever.add(i * 2)
+        self.double_ever.add(i * 2 + 1)
+        return 'q%d' % i
+    raise RegisterAllocationError('Not enough quad registers.')
+
+  def GeneralRegister(self):
+    for i in range(0, 16):
+      if i not in self.general:
+        self.general.add(i)
+        self.general_ever.add(i)
+        return 'r%d' % i
+    raise RegisterAllocationError('Not enough general registers.')
+
+  def MappedParameters(self):
+    return [x for x in self.parameters]
+
+  def Clobbers(self):
+    return (['r%d' % i for i in self.general_ever] +
+            ['d%d' % i for i in self.DoubleClobbers()])
+
+  def DoubleClobbers(self):
+    return sorted(self.double_ever)
+
+  def Low(self, register):
+    assert register[0] == 'q'
+    num = int(register[1:])
+    return 'd%d' % (num * 2)
+
+  def High(self, register):
+    assert register[0] == 'q'
+    num = int(register[1:])
+    return 'd%d' % (num * 2 + 1)
+
+  def FreeRegister(self, register):
+    assert len(register) > 1
+    num = int(register[1:])
+
+    if register[0] == 'r':
+      assert num in self.general
+      self.general.remove(num)
+    elif register[0] == 'd':
+      assert num in self.double
+      self.double.remove(num)
+    elif register[0] == 'q':
+      assert num * 2 in self.double
+      assert num * 2 + 1 in self.double
+      self.double.remove(num * 2)
+      self.double.remove(num * 2 + 1)
+    else:
+      raise RegisterDeallocationError('Register not allocated: %s' % register)
+
+
+class NeonEmitter(object):
+  """Emits ARM/NEON assembly opcodes."""
+
+  def __init__(self, debug=False):
+    self.ops = {}
+    self.indent = ''
+    self.debug = debug
+
+  def PushIndent(self):
+    self.indent += '  '
+
+  def PopIndent(self):
+    self.indent = self.indent[:-2]
+
+  def EmitIndented(self, what):
+    print self.indent + what
+
+  def PushOp(self, op):
+    if op in self.ops.keys():
+      self.ops[op] += 1
+    else:
+      self.ops[op] = 1
+
+  def ClearCounters(self):
+    self.ops.clear()
+
+  def EmitNewline(self):
+    print ''
+
+  def EmitPreprocessor1(self, op, param):
+    print '#%s %s' % (op, param)
+
+  def EmitPreprocessor(self, op):
+    print '#%s' % op
+
+  def EmitInclude(self, include):
+    self.EmitPreprocessor1('include', include)
+
+  def EmitCall1(self, function, param):
+    self.EmitIndented('%s(%s);' % (function, param))
+
+  def EmitAssert(self, assert_expression):
+    if self.debug:
+      self.EmitCall1('assert', assert_expression)
+
+  def EmitHeaderBegin(self, header_name, includes):
+    self.EmitPreprocessor1('ifndef', (header_name + '_H_').upper())
+    self.EmitPreprocessor1('define', (header_name + '_H_').upper())
+    self.EmitNewline()
+    if includes:
+      for include in includes:
+        self.EmitInclude(include)
+      self.EmitNewline()
+
+  def EmitHeaderEnd(self):
+    self.EmitPreprocessor('endif')
+
+  def EmitCode(self, code):
+    self.EmitIndented('%s;' % code)
+
+  def EmitFunctionBeginA(self, function_name, params, return_type):
+    self.EmitIndented('%s %s(%s) {' % (
+        return_type,
+        function_name,
+        ', '.join(['%s %s' % (t, n) for (t, n) in params])))
+    self.PushIndent()
+
+  def EmitFunctionEnd(self):
+    self.PopIndent()
+    self.EmitIndented('}')
+
+  def EmitAsmBegin(self):
+    self.EmitIndented('asm volatile(')
+    self.PushIndent()
+
+  def EmitAsmMapping(self, elements, modifier):
+    if elements:
+      self.EmitIndented(': ' + ', '.join(
+          ['[%s] "%s"(%s)' % (d, modifier, d) for d in elements]))
+    else:
+      self.EmitIndented(':')
+
+  def EmitClobbers(self, elements):
+    if elements:
+      self.EmitIndented(': ' + ', '.join(['"%s"' % c for c in elements]))
+    else:
+      self.EmitIndented(':')
+
+  def EmitAsmEnd(self, outputs, inputs, clobbers):
+    self.EmitAsmMapping(outputs, '+r')
+    self.EmitAsmMapping(inputs, 'r')
+    self.EmitClobbers(clobbers)
+    self.PopIndent()
+    self.EmitIndented(');')
+
+  def EmitComment(self, comment):
+    self.EmitIndented('// ' + comment)
+
+  def EmitNumericalLabel(self, label):
+    self.EmitIndented('"%d:"' % label)
+
+  def EmitOp1(self, op, param1):
+    self.PushOp(op)
+    self.EmitIndented('"%s %s\\n"' % (op, param1))
+
+  def EmitOp2(self, op, param1, param2):
+    self.PushOp(op)
+    self.EmitIndented('"%s %s, %s\\n"' % (op, param1, param2))
+
+  def EmitOp3(self, op, param1, param2, param3):
+    self.PushOp(op)
+    self.EmitIndented('"%s %s, %s, %s\\n"' % (op, param1, param2, param3))
+
+  def EmitZip(self, size, param1, param2):
+    self.EmitOp2('vzip.%d' % size, param1, param2)
+
+  def EmitZip8(self, param1, param2):
+    self.EmitZip(8, param1, param2)
+
+  def EmitZip16(self, param1, param2):
+    self.EmitZip(16, param1, param2)
+
+  def EmitZip32(self, param1, param2):
+    self.EmitZip(32, param1, param2)
+
+  def EmitAdd(self, destination, source, param):
+    self.EmitOp3('add', destination, source, param)
+
+  def EmitSubs(self, destination, source, param):
+    self.EmitOp3('subs', destination, source, param)
+
+  def EmitSub(self, destination, source, param):
+    self.EmitOp3('sub', destination, source, param)
+
+  def EmitMul(self, destination, source, param):
+    self.EmitOp3('mul', destination, source, param)
+
+  def EmitMov(self, param1, param2):
+    self.EmitOp2('mov', param1, param2)
+
+  def EmitSkip(self, register, skip, stride):
+    self.EmitOp3('add', register, register, '#%d' % (skip * stride))
+
+  def EmitBneBack(self, label):
+    self.EmitOp1('bne', '%db' % label)
+
+  def EmitBneFront(self, label):
+    self.EmitOp1('bne', '%df' % label)
+
+  def EmitVAdd(self, add_type, destination, source_1, source_2):
+    self.EmitOp3('vadd.%s' % add_type, destination, source_1, source_2)
+
+  def EmitVAddw(self, add_type, destination, source_1, source_2):
+    self.EmitOp3('vaddw.%s' % add_type, destination, source_1, source_2)
+
+  def EmitVDup(self, dup_type, destination, source):
+    self.EmitOp2('vdup.%s' % dup_type, destination, source)
+
+  def EmitVMov(self, mov_type, destination, source):
+    self.EmitOp2('vmov.%s' % mov_type, destination, source)
+
+  def EmitVQmovn(self, mov_type, destination, source):
+    self.EmitOp2('vqmovn.%s' % mov_type, destination, source)
+
+  def EmitVQmovun(self, mov_type, destination, source):
+    self.EmitOp2('vqmovun.%s' % mov_type, destination, source)
+
+  def EmitVMul(self, mul_type, destination, source_1, source_2):
+    self.EmitOp3('vmul.%s' % mul_type, destination, source_1, source_2)
+
+  def EmitVMull(self, mul_type, destination, source_1, source_2):
+    self.EmitOp3('vmull.%s' % mul_type, destination, source_1, source_2)
+
+  def EmitVPadd(self, add_type, destination, source_1, source_2):
+    self.EmitOp3('vpadd.%s' % add_type, destination, source_1, source_2)
+
+  def EmitVPaddl(self, add_type, destination, source):
+    self.EmitOp2('vpaddl.%s' % add_type, destination, source)
+
+  def EmitVPadal(self, add_type, destination, source):
+    self.EmitOp2('vpadal.%s' % add_type, destination, source)
+
+  def EmitVLoad(self, load_type, destination, source):
+    self.EmitOp2('vld%s' % load_type,
+                 '{%s}' % destination,
+                 '%s' % source)
+
+  def EmitVLoadA(self, load_type, destinations, source):
+    self.EmitVLoad(load_type, ', '.join(destinations), source)
+
+  def EmitPld(self, load_address_register):
+    self.EmitOp1('pld', '[%s]' % load_address_register)
+
+  def EmitPldOffset(self, load_address_register, offset):
+    self.EmitOp1('pld', '[%s, %s]' % (load_address_register, offset))
+
+  def EmitInstructionPreload(self, label):
+    self.EmitOp1('pli', label)
+
+  def EmitVShl(self, shift_type, destination, source, shift):
+    self.EmitOp3('vshl.%s' % shift_type, destination, source, shift)
+
+  def EmitVStore(self, store_type, source, destination):
+    self.EmitOp2('vst%s' % store_type, '{%s}' % source, destination)
+
+  def EmitVStoreA(self, store_type, sources, destination):
+    self.EmitVStore(store_type, ', '.join(sources), destination)
+
+  def EmitVStoreOffset(self, store_type, source, destination, offset):
+    self.EmitOp3('vst%s' % store_type, '{%s}' % source, destination, offset)
+
+  def Dereference(self, value, alignment):
+    if alignment:
+      return '[%s:%d]' % (value, alignment)
+    else:
+      return '[%s]' % value
+
+  def DereferenceIncrement(self, value, alignment):
+    return '%s!' % self.Dereference(value, alignment)
+
+  def ImmediateConstant(self, value):
+    return '#%d' % value
+
+  def AllLanes(self, value):
+    return '%s[]' % value
+
+  def Lane(self, value, lane):
+    return '%s[%d]' % (value, lane)

--- a/meta/generators/qnt_Nx8_neon.py
+++ b/meta/generators/qnt_Nx8_neon.py
@@ -1,0 +1,395 @@
+"""Qnt primitive used by the GEMM function.
+
+"""
+
+import neon_emitter
+
+
+class Error(Exception):
+  """Module level error."""
+
+
+class ConfigurationError(Error):
+  """Unsupported configuration."""
+
+
+class QntLane(object):
+
+  def __init__(self, source, output, offset, load_1, load_2):
+    self.source = source
+    self.output = output
+    self.offset = offset
+    self.load_1 = load_1
+    self.load_2 = load_2
+
+
+def BuildName(lanes, leftovers, aligned):
+  name = 'qnt_%dx8' % lanes
+  if leftovers:
+    name += '_%d' % leftovers
+  if aligned:
+    name += '_aligned'
+  return name
+
+
+def LoadAndDuplicateOffsets(emitter, registers, lanes, offsets):
+  if lanes == 1 or lanes == 2 or lanes == 3:
+    offset_registers = []
+    for unused_i in range(0, lanes):
+      register = registers.QuadRegister()
+      emitter.EmitVLoadA('1.32',
+                         [emitter.AllLanes(registers.Low(register)),
+                          emitter.AllLanes(registers.High(register))],
+                         emitter.DereferenceIncrement(offsets, 32))
+      offset_registers.append(register)
+    return offset_registers
+  else:
+    raise ConfigurationError('Unsupported number of lanes: %d' % lanes)
+
+
+def GenerateQntLanes(emitter,
+                     registers,
+                     qnt_lanes,
+                     source,
+                     stride,
+                     destination,
+                     destination_stride,
+                     offsets):
+  """Prepare lanes for reading unquantized multiplication results."""
+  offset_registers = LoadAndDuplicateOffsets(
+      emitter, registers, qnt_lanes, offsets)
+
+  lanes = []
+  last_input_register = source
+  last_output_register = destination
+  for i in range(0, qnt_lanes):
+    if not i:
+      lanes.append(QntLane(source,
+                           destination,
+                           offset_registers[i],
+                           registers.QuadRegister(),  # load 1
+                           registers.QuadRegister()))  # load 2
+    else:
+      input_register = registers.GeneralRegister()
+      output_register = registers.GeneralRegister()
+      lanes.append(QntLane(input_register,
+                           output_register,
+                           offset_registers[i],
+                           registers.QuadRegister(),  # load 1
+                           registers.QuadRegister()))  # load 2
+      emitter.EmitAdd(input_register, last_input_register, stride)
+      emitter.EmitAdd(output_register, last_output_register, destination_stride)
+      last_input_register = input_register
+      last_output_register = output_register
+  return lanes
+
+
+def DuplicateRegister(emitter, registers, value):
+  register = registers.QuadRegister()
+  emitter.EmitVDup('32', register, value)
+  return register
+
+
+def GenerateQuantize(emitter,
+                     registers,
+                     lanes,
+                     lane_temps,
+                     multiplicative_offset,
+                     rounding_offset,
+                     shift):
+  """Inner loop for quantization: add offsets, multiply, round, shift."""
+  for lane in lanes:
+    emitter.EmitVAdd('i32', lane[0], lane[0], lane[1])
+
+  for lane in lanes:
+    emitter.EmitVMul('i32', lane[0], lane[0], multiplicative_offset)
+
+  for lane in lanes:
+    emitter.EmitVAdd('i32', lane[0], lane[0], rounding_offset)
+
+  for lane in lanes:
+    emitter.EmitVShl('s32', lane[0], lane[0], shift)
+
+  for lane in lanes:
+    emitter.EmitVQmovn('s32', lane[2], lane[0])
+
+  for lane_temp in lane_temps:
+    emitter.EmitVQmovun('s16', registers.Low(lane_temp), lane_temp)
+
+
+def GenerateLoadQuantizeStore(emitter,
+                              registers,
+                              lanes,
+                              multiplicative_offset,
+                              rounding_offset,
+                              shift,
+                              alignment):
+  """Load unquantized data from lanes, quantize, store final result."""
+  lane_temps = []
+  for lane in lanes:
+    lane_temps.append(registers.QuadRegister())
+
+  for lane in lanes:
+    emitter.EmitVLoadA('1.32',
+                       [registers.Low(lane.load_1),
+                        registers.High(lane.load_1),
+                        registers.Low(lane.load_2),
+                        registers.High(lane.load_2)],
+                       emitter.DereferenceIncrement(lane.source, 64))
+
+  for lane in lanes:
+    emitter.EmitPld(lane.source)
+
+  quantize_setup = []
+  for (lane_temp, lane) in zip(lane_temps, lanes):
+    quantize_setup.append([lane.load_1, lane.offset, registers.Low(lane_temp)])
+    quantize_setup.append([lane.load_2, lane.offset, registers.High(lane_temp)])
+
+  GenerateQuantize(emitter,
+                   registers,
+                   quantize_setup,
+                   lane_temps,
+                   multiplicative_offset,
+                   rounding_offset,
+                   shift)
+
+  for (lane_temp, lane) in zip(lane_temps, lanes):
+    emitter.EmitVStore('1.8',
+                       registers.Low(lane_temp),
+                       emitter.DereferenceIncrement(lane.output, alignment))
+
+  for lane_temp in lane_temps:
+    registers.FreeRegister(lane_temp)
+
+
+def GenerateLoadLeftovers(emitter, registers, leftovers, lanes):
+  """Handle non multiply of 8 leftover loading."""
+  if leftovers == 1:
+    for lane in lanes:
+      emitter.EmitVLoad('1.32',
+                        emitter.Lane(registers.Low(lane.load_1), 0),
+                        emitter.Dereference(lane.source, None))
+  elif leftovers == 2:
+    for lane in lanes:
+      emitter.EmitVLoad('1.32',
+                        registers.Low(lane.load_1),
+                        emitter.Dereference(lane.source, 64))
+  elif leftovers == 3:
+    for lane in lanes:
+      emitter.EmitVLoad('1.32',
+                        registers.Low(lane.load_1),
+                        emitter.DereferenceIncrement(lane.source, 64))
+    for lane in lanes:
+      emitter.EmitVLoad('1.32',
+                        emitter.Lane(registers.High(lane.load_1), 0),
+                        emitter.Dereference(lane.source, None))
+  elif leftovers == 4:
+    for lane in lanes:
+      emitter.EmitVLoadA('1.32',
+                         [registers.Low(lane.load_1),
+                          registers.High(lane.load_1)],
+                         emitter.Dereference(lane.source, 64))
+  elif leftovers == 5:
+    for lane in lanes:
+      emitter.EmitVLoadA('1.32',
+                         [registers.Low(lane.load_1),
+                          registers.High(lane.load_1)],
+                         emitter.DereferenceIncrement(lane.source, 64))
+    for lane in lanes:
+      emitter.EmitVLoad('1.32',
+                        emitter.Lane(registers.Low(lane.load_2), 0),
+                        emitter.Dereference(lane.source, None))
+  elif leftovers == 6:
+    for lane in lanes:
+      emitter.EmitVLoadA('1.32',
+                         [registers.Low(lane.load_1),
+                          registers.High(lane.load_1),
+                          registers.Low(lane.load_2)],
+                         emitter.Dereference(lane.source, 64))
+  elif leftovers == 7:
+    for lane in lanes:
+      emitter.EmitVLoadA('1.32',
+                         [registers.Low(lane.load_1),
+                          registers.High(lane.load_1),
+                          registers.Low(lane.load_2)],
+                         emitter.DereferenceIncrement(lane.source, 64))
+    for lane in lanes:
+      emitter.EmitVLoad('1.32',
+                        emitter.Lane(registers.High(lane.load_2), 0),
+                        emitter.Dereference(lane.source, None))
+  else:
+    raise ConfigurationError('Unsuported leftover count: %d' % leftovers)
+
+
+def GenerateStoreLeftovers(emitter, registers, leftovers, lane_temps, lanes):
+  """Handle non multiply of 8 leftover storing."""
+  setup = []
+  for (temp, lane) in zip(lane_temps, lanes):
+    setup.append([registers.Low(temp), lane.output])
+
+  if leftovers == 1:
+    for lane in setup:
+      emitter.EmitVStore('1.8', emitter.Lane(lane[0], 0),
+                         emitter.Dereference(lane[1], None))
+  elif leftovers == 2:
+    for lane in setup:
+      emitter.EmitVStore('1.16', emitter.Lane(lane[0], 0),
+                         emitter.Dereference(lane[1], None))
+  elif leftovers == 3:
+    for lane in setup:
+      emitter.EmitVStore('1.16', emitter.Lane(lane[0], 0),
+                         emitter.DereferenceIncrement(lane[1], None))
+    for lane in setup:
+      emitter.EmitVStore('1.8', emitter.Lane(lane[0], 2),
+                         emitter.Dereference(lane[1], None))
+  elif leftovers == 4:
+    for lane in setup:
+      emitter.EmitVStore('1.32', emitter.Lane(lane[0], 0),
+                         emitter.Dereference(lane[1], None))
+  elif leftovers == 5:
+    for lane in setup:
+      emitter.EmitVStore('1.32', emitter.Lane(lane[0], 0),
+                         emitter.DereferenceIncrement(lane[1], None))
+    for lane in setup:
+      emitter.EmitVStore('1.8', emitter.Lane(lane[0], 4),
+                         emitter.Dereference(lane[1], None))
+  elif leftovers == 6:
+    for lane in setup:
+      emitter.EmitVStore('1.32', emitter.Lane(lane[0], 0),
+                         emitter.DereferenceIncrement(lane[1], None))
+    for lane in setup:
+      emitter.EmitVStore('1.16', emitter.Lane(lane[0], 2),
+                         emitter.Dereference(lane[1], None))
+  elif leftovers == 7:
+    for lane in setup:
+      emitter.EmitVStore('1.32', emitter.Lane(lane[0], 0),
+                         emitter.DereferenceIncrement(lane[1], None))
+    for lane in setup:
+      emitter.EmitVStore('1.16', emitter.Lane(lane[0], 2),
+                         emitter.DereferenceIncrement(lane[1], None))
+    for lane in setup:
+      emitter.EmitVStore('1.8', emitter.Lane(lane[0], 6),
+                         emitter.DereferenceIncrement(lane[1], None))
+  else:
+    raise ConfigurationError('Unsupported leftovers count: %d' % leftovers)
+
+
+def GenerateLeftoverLoadQuantizeStore(emitter,
+                                      registers,
+                                      leftovers,
+                                      lanes,
+                                      multiplicative_offset,
+                                      rounding_offset,
+                                      shift):
+  """Handle leftovers if row size not a multiply of 8."""
+  lane_temps = []
+  for lane in lanes:
+    lane_temps.append(registers.QuadRegister())
+
+  GenerateLoadLeftovers(emitter, registers, leftovers, lanes)
+
+  quantize_setup = []
+  for (lane_temp, lane) in zip(lane_temps, lanes):
+    quantize_setup.append([lane.load_1, lane.offset, registers.Low(lane_temp)])
+    if leftovers > 4:
+      quantize_setup.append(
+          [lane.load_2, lane.offset, registers.High(lane_temp)])
+
+  GenerateQuantize(emitter,
+                   registers,
+                   quantize_setup,
+                   lane_temps,
+                   multiplicative_offset,
+                   rounding_offset,
+                   shift)
+
+  GenerateStoreLeftovers(emitter, registers, leftovers, lane_temps, lanes)
+
+
+def GenerateQntNx8(emitter, qnt_lanes, leftovers, aligned):
+  """Emits optimized quantization code for given lanes and row size."""
+  if leftovers < 0 or leftovers > 7:
+    raise ConfigurationError('Leftovers should be between 0 and 7 inclusive.')
+  if qnt_lanes < 1 or qnt_lanes > 3:
+    raise ConfigurationError('Qnt_lanes should should be 1, 2 or 3.')
+
+  name = BuildName(qnt_lanes, leftovers, aligned)
+
+  emitter.EmitFunctionBeginA(name,
+                             [['const std::int32_t*', 'source'],
+                              ['std::int32_t', 'count'],
+                              ['std::int32_t', 'stride'],
+                              ['const std::int32_t*', 'offsets'],
+                              ['std::uint8_t*', 'destination'],
+                              ['std::int32_t', 'destination_stride'],
+                              ['std::int32_t', 'multiplicative_offset'],
+                              ['std::int32_t', 'rounding_offset'],
+                              ['std::int32_t', 'shift']],
+                             'void')
+  emitter.EmitAssert('count %% 8 == %d' % leftovers)
+  emitter.EmitAssert('count >= 8')
+  emitter.EmitAssert('reinterpret_cast<std::uintptr_t>(source) % 8 == 0')
+  if aligned:
+    emitter.EmitAssert('reinterpret_cast<std::uintptr_t>(destination) % 8 == 0')
+    if qnt_lanes > 1:
+      emitter.EmitAssert(
+          'destination_stride % 8 == 0')
+  emitter.EmitAsmBegin()
+
+  registers = neon_emitter.NeonRegisters()
+
+  count = registers.MapParameter('count')
+
+  multiplicative_offset = DuplicateRegister(
+      emitter, registers, registers.MapParameter('multiplicative_offset'))
+  rounding_offset = DuplicateRegister(
+      emitter, registers, registers.MapParameter('rounding_offset'))
+  shift = DuplicateRegister(emitter, registers, registers.MapParameter('shift'))
+
+  lanes = GenerateQntLanes(
+      emitter, registers, qnt_lanes,
+      registers.MapParameter('source'),
+      registers.MapParameter('stride'),
+      registers.MapParameter('destination'),
+      registers.MapParameter('destination_stride'),
+      registers.MapParameter('offsets'))
+
+  if leftovers:
+    emitter.EmitSub(count, count, emitter.ImmediateConstant(leftovers))
+
+  emitter.EmitNewline()
+  emitter.EmitNumericalLabel(1)
+  emitter.EmitSubs(count, count, emitter.ImmediateConstant(8))
+
+  GenerateLoadQuantizeStore(emitter,
+                            registers,
+                            lanes,
+                            multiplicative_offset,
+                            rounding_offset,
+                            shift,
+                            64 if aligned else None)
+
+  emitter.EmitNewline()
+  emitter.EmitBneBack(1)
+
+  if leftovers:
+    GenerateLeftoverLoadQuantizeStore(emitter,
+                                      registers,
+                                      leftovers,
+                                      lanes,
+                                      multiplicative_offset,
+                                      rounding_offset,
+                                      shift)
+
+  emitter.EmitAsmEnd(registers.MappedParameters(),
+                     [],
+                     registers.Clobbers() + ['cc', 'memory'])
+  emitter.EmitFunctionEnd()
+
+
+def GenerateFunctions(emitter):
+  for aligned in [True, False]:
+    for lanes in range(1, 4):
+      for leftovers in range(0, 8):
+        GenerateQntNx8(emitter, lanes, leftovers, aligned)
+        emitter.EmitNewline()

--- a/meta/generators/zip_Nx8_neon.py
+++ b/meta/generators/zip_Nx8_neon.py
@@ -1,0 +1,315 @@
+"""Zip primitive used by the GEMM function.
+
+Takes 1 to 3 rows of data and interleaves them in 8 byte chunks. Pads to
+multiply of 8 length with zeros. Calculates row sums and appends those at the
+end.
+"""
+
+
+import neon_emitter
+
+
+class Error(Exception):
+  """Module level error."""
+
+
+class ConfigurationError(Error):
+  """Unsupported configuration."""
+
+
+class ZipLane(object):
+
+  def __init__(self, input_address, load, aggregator):
+    self.input_address = input_address
+    self.load = load
+    self.aggregator = aggregator
+
+
+def GenerateZipLanes(emitter, registers, zip_lanes, input_address, stride):
+  """Prepares read lanes for the zip operation.
+
+  Args:
+    emitter: ARM/NEON emitter.
+    registers: ARM/NEON registers state.
+    zip_lanes: number of lanes to prepare.
+    input_address: register that contains the input address for the first lane.
+    stride: memory stride for lane inputs.
+
+  Returns:
+    Array of ZipLane objects.
+  """
+  lanes = []
+  last_address_register = input_address
+  for i in range(0, zip_lanes):
+    if not i:
+      lanes.append(ZipLane(input_address,
+                           registers.DoubleRegister(),
+                           registers.QuadRegister(2)))
+    else:
+      address_register = registers.GeneralRegister()
+      lanes.append(ZipLane(address_register,
+                           registers.DoubleRegister(),
+                           registers.QuadRegister(2)))
+      emitter.EmitAdd(address_register, last_address_register, stride)
+      last_address_register = address_register
+  return lanes
+
+
+def BuildName(zip_lanes, leftovers, aligned):
+  name = 'zip_%dx8' % zip_lanes
+  if leftovers:
+    name += '_%d' % leftovers
+  if aligned:
+    name += '_aligned'
+  return name
+
+
+def GenerateClearAggregators(emitter, lanes):
+  for lane in lanes:
+    emitter.EmitVMov('i16', lane.aggregator, emitter.ImmediateConstant(0))
+
+
+def GenerateLoadAggregateStore(emitter, lanes, output_address, alignment):
+  """Emit inner loop code for reading N lanes and interweaving them."""
+  emitter.EmitNewline()
+  emitter.EmitComment('Load Aggregate Store.')
+
+  for lane in lanes:
+    emitter.EmitVLoad(
+        '1.8', lane.load,
+        emitter.DereferenceIncrement(lane.input_address, alignment))
+
+  store_registers = []
+  for lane in lanes:
+    emitter.EmitVAddw('u8', lane.aggregator, lane.aggregator, lane.load)
+    store_registers.append(lane.load)
+
+  emitter.EmitVStoreA('1.8', store_registers,
+                      emitter.DereferenceIncrement(output_address, 64))
+
+
+def GenerateLeftoverLoadAggregateStore(
+    emitter, leftovers, lanes, output_address):
+  """Handle leftovers when count is not a multiply of 8."""
+  emitter.EmitNewline()
+  emitter.EmitComment('Leftover Load Aggregate Store.')
+
+  # Clear load registers.
+  for lane in lanes:
+    emitter.EmitVMov('i8', lane.load, emitter.ImmediateConstant(0))
+
+  if leftovers == 1:
+    # Load 8 bits.
+    for lane in lanes:
+      emitter.EmitVLoad('1.8', emitter.Lane(lane.load, 0),
+                        emitter.Dereference(lane.input_address, None))
+  elif leftovers == 2:
+    # Load 16 bits.
+    for lane in lanes:
+      emitter.EmitVLoad('1.16', emitter.Lane(lane.load, 0),
+                        emitter.Dereference(lane.input_address, None))
+  elif leftovers == 3:
+    # Load 16 bits.
+    for lane in lanes:
+      emitter.EmitVLoad(
+          '1.16', emitter.Lane(lane.load, 0),
+          emitter.DereferenceIncrement(lane.input_address, None))
+    # Load 8 bits.
+    for lane in lanes:
+      emitter.EmitVLoad('1.8', emitter.Lane(lane.load, 2),
+                        emitter.Dereference(lane.input_address, None))
+  elif leftovers == 4:
+    # Load 32 bits.
+    for lane in lanes:
+      emitter.EmitVLoad('1.32', emitter.Lane(lane.load, 0),
+                        emitter.Dereference(lane.input_address, None))
+  elif leftovers == 5:
+    # Load 32 bits..
+    for lane in lanes:
+      emitter.EmitVLoad(
+          '1.32', emitter.Lane(lane.load, 0),
+          emitter.DereferenceIncrement(lane.input_address, None))
+    # Load 8 bits.
+    for lane in lanes:
+      emitter.EmitVLoad('1.8', emitter.Lane(lane.load, 4),
+                        emitter.Dereference(lane.input_address, None))
+  elif leftovers == 6:
+    # Load 32 bits..
+    for lane in lanes:
+      emitter.EmitVLoad(
+          '1.32', emitter.Lane(lane.load, 0),
+          emitter.DereferenceIncrement(lane.input_address, None))
+    # Load 16 bits.
+    for lane in lanes:
+      emitter.EmitVLoad('1.16', emitter.Lane(lane.load, 2),
+                        emitter.Dereference(lane.input_address, None))
+  elif leftovers == 7:
+    # Load 32 bits..
+    for lane in lanes:
+      emitter.EmitVLoad(
+          '1.32', emitter.Lane(lane.load, 0),
+          emitter.DereferenceIncrement(lane.input_address, None))
+    # Load 16 bits.
+    for lane in lanes:
+      emitter.EmitVLoad(
+          '1.16', emitter.Lane(lane.load, 2),
+          emitter.DereferenceIncrement(lane.input_address, None))
+    # Load 8 bits.
+    for lane in lanes:
+      emitter.EmitVLoad('1.8', emitter.Lane(lane.load, 6),
+                        emitter.Dereference(lane.input_address, None))
+  else:
+    raise ConfigurationError('Unsupported leftover num: %d' % leftovers)
+
+  # Aggregate.
+  store_registers = []
+  for lane in lanes:
+    emitter.EmitVAddw('u8', lane.aggregator, lane.aggregator, lane.load)
+    store_registers.append(lane.load)
+
+  # Store.
+  emitter.EmitVStoreA('1.8', store_registers,
+                      emitter.DereferenceIncrement(output_address, 64))
+
+
+def GenerateAggregatorReduction(emitter,
+                                registers,
+                                lanes,
+                                output_address,
+                                multiplicative_offset,
+                                additive_offset):
+  """Reduce 4 lane sum aggregators to 1 value and store the sums."""
+  emitter.EmitNewline()
+  emitter.EmitComment('Aggregator Reduction.')
+
+  multiplier = registers.DoubleRegister()
+  emitter.EmitVMov('32', emitter.Lane(multiplier, 0), multiplicative_offset)
+  offset = registers.QuadRegister()
+  emitter.EmitVDup('32', offset, additive_offset)
+
+  lane_temps = []
+  for lane in lanes:
+    emitter.EmitVPaddl('u16', lane.aggregator, lane.aggregator)
+
+  for lane in lanes:
+    lane_temp = registers.DoubleRegister()
+    lane_temps.append(lane_temp)
+    emitter.EmitVPadd('u32',
+                      lane_temp,
+                      registers.Low(lane.aggregator),
+                      registers.High(lane.aggregator))
+
+  temp = registers.QuadRegister()
+  low = registers.Low(temp)
+  high = registers.High(temp)
+
+  if len(lanes) == 1:
+    emitter.EmitVPadd('u32', low, lane_temps[0], lane_temps[0])
+  elif len(lanes) == 2:
+    emitter.EmitVPadd('u32', low, lane_temps[0], lane_temps[1])
+  elif len(lanes) == 3:
+    emitter.EmitVPadd('u32', low, lane_temps[0], lane_temps[1])
+    emitter.EmitVPadd('u32', high, lane_temps[2], lane_temps[2])
+  elif len(lanes) == 4:
+    emitter.EmitVPadd('u32', low, lane_temps[0], lane_temps[1])
+    emitter.EmitVPadd('u32', high, lane_temps[2], lane_temps[3])
+  else:
+    raise ConfigurationError(
+        'Unexpected number of aggregators to reduce: %d' % len(lanes))
+
+  emitter.EmitVMul('i32', temp, temp, emitter.Lane(multiplier, 0))
+  emitter.EmitVAdd('i32', temp, temp, offset)
+
+  if len(lanes) == 1:
+    emitter.EmitVStore(
+        '1.32', emitter.Lane(low, 0), emitter.Dereference(output_address, None))
+  elif len(lanes) == 2:
+    emitter.EmitVStore('1.32', low, emitter.Dereference(output_address, 64))
+  elif len(lanes) == 3:
+    emitter.EmitVStore(
+        '1.32', low, emitter.DereferenceIncrement(output_address, 64))
+    emitter.EmitVStore(
+        '1.32', emitter.Lane(high, 0),
+        emitter.Dereference(output_address, None))
+  elif len(lanes) == 4:
+    emitter.EmitVStore(
+        '1.32', low, emitter.DereferenceIncrement(output_address, 64))
+    emitter.EmitVStore('1.32', high, emitter.Dereference(output_address, 64))
+
+
+def GenerateZipNx8(emitter, zip_lanes, leftovers, aligned):
+  """Emit the zip function for a given number of rows and row size leftovers."""
+  if leftovers < 0 or leftovers > 7:
+    raise ConfigurationError('Leftovers should be between 0 and 7 inclusive.')
+  if zip_lanes < 1 or zip_lanes > 3:
+    raise ConfigurationError('Zip_lanes should should be 1, 2 or 3.')
+
+  name = BuildName(zip_lanes, leftovers, aligned)
+
+  emitter.EmitFunctionBeginA(name,
+                             [['const std::uint8_t*', 'source'],
+                              ['std::int32_t', 'count'],
+                              ['std::int32_t', 'stride'],
+                              ['std::uint8_t*', 'destination'],
+                              ['std::int32_t', 'multiplicative_offset'],
+                              ['std::int32_t', 'additive_offset']],
+                             'void')
+  emitter.EmitAssert('count %% 8 == %d' % leftovers)
+  emitter.EmitAssert('count <= 2048')
+  emitter.EmitAssert('count >= 8')
+  emitter.EmitAssert('reinterpret_cast<std::uintptr_t>(destination) % 8 == 0')
+  if aligned:
+    emitter.EmitAssert('reinterpret_cast<std::uintptr_t>(source) % 8 == 0')
+    if zip_lanes > 1:
+      emitter.EmitAssert('stride % 8 == 0')
+  emitter.EmitAsmBegin()
+
+  registers = neon_emitter.NeonRegisters()
+
+  count = registers.MapParameter('count')
+  output_address = registers.MapParameter('destination')
+
+  lanes = GenerateZipLanes(emitter,
+                           registers,
+                           zip_lanes,
+                           registers.MapParameter('source'),
+                           registers.MapParameter('stride'))
+
+  if leftovers:
+    emitter.EmitSub(count, count, emitter.ImmediateConstant(leftovers))
+
+  GenerateClearAggregators(emitter, lanes)
+
+  emitter.EmitNewline()
+  emitter.EmitNumericalLabel(1)
+  emitter.EmitSubs(count, count, emitter.ImmediateConstant(8))
+
+  GenerateLoadAggregateStore(
+      emitter, lanes, output_address, 64 if aligned else None)
+
+  emitter.EmitNewline()
+  emitter.EmitBneBack(1)
+
+  if leftovers:
+    GenerateLeftoverLoadAggregateStore(
+        emitter, leftovers, lanes, output_address)
+
+  GenerateAggregatorReduction(emitter,
+                              registers,
+                              lanes,
+                              output_address,
+                              registers.MapParameter('multiplicative_offset'),
+                              registers.MapParameter('additive_offset'))
+
+  emitter.EmitAsmEnd(registers.MappedParameters(),
+                     [],
+                     registers.Clobbers() + ['cc', 'memory'])
+  emitter.EmitFunctionEnd()
+
+
+def GenerateFunctions(emitter):
+  for aligned in [True, False]:
+    for lanes in range(1, 4):
+      for leftovers in range(0, 8):
+        GenerateZipNx8(emitter, lanes, leftovers, aligned)
+        emitter.EmitNewline()

--- a/meta/multi_thread_gemm.h
+++ b/meta/multi_thread_gemm.h
@@ -1,0 +1,149 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// multi_thread_gemm.h: Entry point to the multithreaded version of the
+// generated (meta) gemm library.
+
+#ifndef GEMMLOWP_META_MULTI_THREAD_GEMM_H_
+#define GEMMLOWP_META_MULTI_THREAD_GEMM_H_
+
+#ifdef GEMMLOWP_NEON_32
+
+#include "single_thread_gemm.h"
+#include "../internal/multi_thread_gemm.h"
+
+namespace gemmlowp {
+namespace meta {
+namespace internal {
+
+struct MetaTask : gemmlowp::Task {
+  std::uint8_t* scratch;
+  const std::uint8_t* lhs;
+  const std::uint8_t* rhs;
+  std::int32_t n;
+  std::int32_t m;
+  std::int32_t k;
+  std::int32_t lhs_offset;
+  std::int32_t rhs_offset;
+  std::int32_t sum_offset;
+  std::int32_t multiplier;
+  std::int32_t shift;
+  std::uint8_t* result;
+
+  MetaTask(std::uint8_t* scratch, const std::uint8_t* lhs,
+           const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+           std::int32_t k, std::int32_t lhs_offset, std::int32_t rhs_offset,
+           std::int32_t sum_offset, std::int32_t multiplier, std::int32_t shift,
+           std::uint8_t* result)
+      : scratch(scratch),
+        lhs(lhs),
+        rhs(rhs),
+        n(n),
+        m(m),
+        k(k),
+        lhs_offset(lhs_offset),
+        rhs_offset(rhs_offset),
+        sum_offset(sum_offset),
+        multiplier(multiplier),
+        shift(shift),
+        result(result) {}
+
+  void Run() const override {
+    gemm(scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset, sum_offset,
+         multiplier, shift, result);
+  }
+};
+
+std::int32_t ToMegs(std::int32_t bytes) {
+  const std::int32_t MB = 1024 * 1024;
+  return ((bytes + MB - 1) / (MB)) * MB;
+}
+
+std::int32_t ScratchPerThread(std::int32_t n, std::int32_t m, std::int32_t k) {
+  return ToMegs((m + 32) * (k + 32) + 32 * (m + 32));
+}
+
+std::int32_t ResolveMaxThreads(std::int32_t max_threads) {
+  if (max_threads == 0) {
+    static const int hardware_threads_count =
+        static_cast<int>(sysconf(_SC_NPROCESSORS_CONF));
+    return hardware_threads_count;
+  }
+  return max_threads;
+}
+
+}  // namespace internal
+
+std::int32_t RequiredScratch(std::int32_t n, std::int32_t m, std::int32_t k,
+                             std::int32_t max_threads) {
+  return internal::ScratchPerThread(n, m, k) *
+         internal::ResolveMaxThreads(max_threads);
+}
+
+void multi_thread_gemm(gemmlowp::WorkersPool* pool, std::int32_t max_threads,
+                       std::uint8_t* scratch, const std::uint8_t* lhs,
+                       const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                       std::int32_t k, std::int32_t lhs_offset,
+                       std::int32_t rhs_offset, std::int32_t sum_offset,
+                       std::int32_t multiplier, std::int32_t shift,
+                       std::uint8_t* result) {
+  max_threads = internal::ResolveMaxThreads(max_threads);
+  pool->CreateWorkers(max_threads - 1);
+
+  std::int32_t max_tasks_size = (n * m * k) / 100000;
+  std::int32_t max_tasks_n = n / 6;
+
+  std::int32_t real_tasks =
+      std::max(1, std::min(max_threads, std::min(max_tasks_n, max_tasks_size)));
+
+  if (real_tasks == 1) {
+    gemm(scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset, sum_offset,
+         multiplier, shift, result);
+    return;
+  }
+
+  std::int32_t row_chunk_size = n / real_tasks;
+
+  pool->counter_to_decrement_when_ready().Reset(real_tasks - 1);
+
+  std::uint8_t* task_scratch = scratch;
+
+  for (int i = 0; i < real_tasks - 1; ++i) {
+    auto task = new internal::MetaTask(
+        task_scratch, lhs + i * k * row_chunk_size, rhs, row_chunk_size, m, k,
+        lhs_offset, rhs_offset, sum_offset, multiplier, shift,
+        result + i * m * row_chunk_size);
+    pool->StartWorker(i, task);
+    task_scratch += internal::ScratchPerThread(n, m, k);
+  }
+
+  auto task = new internal::MetaTask(
+      task_scratch, lhs + (real_tasks - 1) * k * row_chunk_size, rhs,
+      n - (real_tasks - 1) * row_chunk_size, m, k, lhs_offset, rhs_offset,
+      sum_offset, multiplier, shift,
+      result + (real_tasks - 1) * m * row_chunk_size);
+  task->Run();
+  delete task;
+
+  pool->counter_to_decrement_when_ready().Wait();
+}
+
+}  // namespace meta
+}  // namespace gemmlowp
+
+#else
+#warning "Meta gemm fast-path requires GEMMLOWP_NEON_32!"
+#endif
+
+#endif  // GEMMLOWP_META_MULTI_THREAD_GEMM_H_

--- a/meta/single_thread_gemm.h
+++ b/meta/single_thread_gemm.h
@@ -1,0 +1,17913 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// single_thread_gemm.h: programatically generated GEMM library header.
+
+#ifndef GEMMLOWP_META_SINGLE_THREAD_GEMM_H_
+#define GEMMLOWP_META_SINGLE_THREAD_GEMM_H_
+
+#ifdef GEMMLOWP_NEON_32
+
+#include <cassert>
+
+namespace gemmlowp {
+namespace meta {
+namespace internal {
+
+void zip_1x8_aligned(const std::uint8_t* source, std::int32_t count,
+                     std::int32_t stride, std::uint8_t* destination,
+                     std::int32_t multiplicative_offset,
+                     std::int32_t additive_offset) {
+  asm volatile(
+      "vmov.i16 q2, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d1[0], %[multiplicative_offset]\n"
+      "vdup.32 q1, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpadd.u32 d6, d4, d5\n"
+      "vpadd.u32 d8, d6, d6\n"
+      "vmul.i32 q4, q4, d1[0]\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vst1.32 {d8[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d8", "d9", "cc", "memory");
+}
+
+void zip_1x8_1_aligned(const std::uint8_t* source, std::int32_t count,
+                       std::int32_t stride, std::uint8_t* destination,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t additive_offset) {
+  asm volatile(
+      "sub %[count], %[count], #1\n"
+      "vmov.i16 q2, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vld1.8 {d0[0]}, [%[source]]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d1[0], %[multiplicative_offset]\n"
+      "vdup.32 q1, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpadd.u32 d6, d4, d5\n"
+      "vpadd.u32 d8, d6, d6\n"
+      "vmul.i32 q4, q4, d1[0]\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vst1.32 {d8[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d8", "d9", "cc", "memory");
+}
+
+void zip_1x8_2_aligned(const std::uint8_t* source, std::int32_t count,
+                       std::int32_t stride, std::uint8_t* destination,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t additive_offset) {
+  asm volatile(
+      "sub %[count], %[count], #2\n"
+      "vmov.i16 q2, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vld1.16 {d0[0]}, [%[source]]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d1[0], %[multiplicative_offset]\n"
+      "vdup.32 q1, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpadd.u32 d6, d4, d5\n"
+      "vpadd.u32 d8, d6, d6\n"
+      "vmul.i32 q4, q4, d1[0]\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vst1.32 {d8[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d8", "d9", "cc", "memory");
+}
+
+void zip_1x8_3_aligned(const std::uint8_t* source, std::int32_t count,
+                       std::int32_t stride, std::uint8_t* destination,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t additive_offset) {
+  asm volatile(
+      "sub %[count], %[count], #3\n"
+      "vmov.i16 q2, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vld1.16 {d0[0]}, [%[source]]!\n"
+      "vld1.8 {d0[2]}, [%[source]]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d1[0], %[multiplicative_offset]\n"
+      "vdup.32 q1, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpadd.u32 d6, d4, d5\n"
+      "vpadd.u32 d8, d6, d6\n"
+      "vmul.i32 q4, q4, d1[0]\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vst1.32 {d8[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d8", "d9", "cc", "memory");
+}
+
+void zip_1x8_4_aligned(const std::uint8_t* source, std::int32_t count,
+                       std::int32_t stride, std::uint8_t* destination,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t additive_offset) {
+  asm volatile(
+      "sub %[count], %[count], #4\n"
+      "vmov.i16 q2, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d1[0], %[multiplicative_offset]\n"
+      "vdup.32 q1, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpadd.u32 d6, d4, d5\n"
+      "vpadd.u32 d8, d6, d6\n"
+      "vmul.i32 q4, q4, d1[0]\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vst1.32 {d8[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d8", "d9", "cc", "memory");
+}
+
+void zip_1x8_5_aligned(const std::uint8_t* source, std::int32_t count,
+                       std::int32_t stride, std::uint8_t* destination,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t additive_offset) {
+  asm volatile(
+      "sub %[count], %[count], #5\n"
+      "vmov.i16 q2, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]!\n"
+      "vld1.8 {d0[4]}, [%[source]]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d1[0], %[multiplicative_offset]\n"
+      "vdup.32 q1, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpadd.u32 d6, d4, d5\n"
+      "vpadd.u32 d8, d6, d6\n"
+      "vmul.i32 q4, q4, d1[0]\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vst1.32 {d8[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d8", "d9", "cc", "memory");
+}
+
+void zip_1x8_6_aligned(const std::uint8_t* source, std::int32_t count,
+                       std::int32_t stride, std::uint8_t* destination,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t additive_offset) {
+  asm volatile(
+      "sub %[count], %[count], #6\n"
+      "vmov.i16 q2, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]!\n"
+      "vld1.16 {d0[2]}, [%[source]]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d1[0], %[multiplicative_offset]\n"
+      "vdup.32 q1, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpadd.u32 d6, d4, d5\n"
+      "vpadd.u32 d8, d6, d6\n"
+      "vmul.i32 q4, q4, d1[0]\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vst1.32 {d8[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d8", "d9", "cc", "memory");
+}
+
+void zip_1x8_7_aligned(const std::uint8_t* source, std::int32_t count,
+                       std::int32_t stride, std::uint8_t* destination,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t additive_offset) {
+  asm volatile(
+      "sub %[count], %[count], #7\n"
+      "vmov.i16 q2, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]!\n"
+      "vld1.16 {d0[2]}, [%[source]]!\n"
+      "vld1.8 {d0[6]}, [%[source]]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d1[0], %[multiplicative_offset]\n"
+      "vdup.32 q1, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpadd.u32 d6, d4, d5\n"
+      "vpadd.u32 d8, d6, d6\n"
+      "vmul.i32 q4, q4, d1[0]\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vst1.32 {d8[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d8", "d9", "cc", "memory");
+}
+
+void zip_2x8_aligned(const std::uint8_t* source, std::int32_t count,
+                     std::int32_t stride, std::uint8_t* destination,
+                     std::int32_t multiplicative_offset,
+                     std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vld1.8 {d1}, [r0:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d2[0], %[multiplicative_offset]\n"
+      "vdup.32 q4, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpadd.u32 d3, d4, d5\n"
+      "vpadd.u32 d10, d6, d7\n"
+      "vpadd.u32 d12, d3, d10\n"
+      "vmul.i32 q6, q6, d2[0]\n"
+      "vadd.i32 q6, q6, q4\n"
+      "vst1.32 {d12}, [%[destination]:64]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d12", "d13", "cc", "memory");
+}
+
+void zip_2x8_1_aligned(const std::uint8_t* source, std::int32_t count,
+                       std::int32_t stride, std::uint8_t* destination,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "sub %[count], %[count], #1\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vld1.8 {d1}, [r0:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vld1.8 {d0[0]}, [%[source]]\n"
+      "vld1.8 {d1[0]}, [r0]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d2[0], %[multiplicative_offset]\n"
+      "vdup.32 q4, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpadd.u32 d3, d4, d5\n"
+      "vpadd.u32 d10, d6, d7\n"
+      "vpadd.u32 d12, d3, d10\n"
+      "vmul.i32 q6, q6, d2[0]\n"
+      "vadd.i32 q6, q6, q4\n"
+      "vst1.32 {d12}, [%[destination]:64]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d12", "d13", "cc", "memory");
+}
+
+void zip_2x8_2_aligned(const std::uint8_t* source, std::int32_t count,
+                       std::int32_t stride, std::uint8_t* destination,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "sub %[count], %[count], #2\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vld1.8 {d1}, [r0:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vld1.16 {d0[0]}, [%[source]]\n"
+      "vld1.16 {d1[0]}, [r0]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d2[0], %[multiplicative_offset]\n"
+      "vdup.32 q4, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpadd.u32 d3, d4, d5\n"
+      "vpadd.u32 d10, d6, d7\n"
+      "vpadd.u32 d12, d3, d10\n"
+      "vmul.i32 q6, q6, d2[0]\n"
+      "vadd.i32 q6, q6, q4\n"
+      "vst1.32 {d12}, [%[destination]:64]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d12", "d13", "cc", "memory");
+}
+
+void zip_2x8_3_aligned(const std::uint8_t* source, std::int32_t count,
+                       std::int32_t stride, std::uint8_t* destination,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "sub %[count], %[count], #3\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vld1.8 {d1}, [r0:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vld1.16 {d0[0]}, [%[source]]!\n"
+      "vld1.16 {d1[0]}, [r0]!\n"
+      "vld1.8 {d0[2]}, [%[source]]\n"
+      "vld1.8 {d1[2]}, [r0]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d2[0], %[multiplicative_offset]\n"
+      "vdup.32 q4, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpadd.u32 d3, d4, d5\n"
+      "vpadd.u32 d10, d6, d7\n"
+      "vpadd.u32 d12, d3, d10\n"
+      "vmul.i32 q6, q6, d2[0]\n"
+      "vadd.i32 q6, q6, q4\n"
+      "vst1.32 {d12}, [%[destination]:64]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d12", "d13", "cc", "memory");
+}
+
+void zip_2x8_4_aligned(const std::uint8_t* source, std::int32_t count,
+                       std::int32_t stride, std::uint8_t* destination,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "sub %[count], %[count], #4\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vld1.8 {d1}, [r0:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]\n"
+      "vld1.32 {d1[0]}, [r0]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d2[0], %[multiplicative_offset]\n"
+      "vdup.32 q4, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpadd.u32 d3, d4, d5\n"
+      "vpadd.u32 d10, d6, d7\n"
+      "vpadd.u32 d12, d3, d10\n"
+      "vmul.i32 q6, q6, d2[0]\n"
+      "vadd.i32 q6, q6, q4\n"
+      "vst1.32 {d12}, [%[destination]:64]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d12", "d13", "cc", "memory");
+}
+
+void zip_2x8_5_aligned(const std::uint8_t* source, std::int32_t count,
+                       std::int32_t stride, std::uint8_t* destination,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "sub %[count], %[count], #5\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vld1.8 {d1}, [r0:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]!\n"
+      "vld1.32 {d1[0]}, [r0]!\n"
+      "vld1.8 {d0[4]}, [%[source]]\n"
+      "vld1.8 {d1[4]}, [r0]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d2[0], %[multiplicative_offset]\n"
+      "vdup.32 q4, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpadd.u32 d3, d4, d5\n"
+      "vpadd.u32 d10, d6, d7\n"
+      "vpadd.u32 d12, d3, d10\n"
+      "vmul.i32 q6, q6, d2[0]\n"
+      "vadd.i32 q6, q6, q4\n"
+      "vst1.32 {d12}, [%[destination]:64]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d12", "d13", "cc", "memory");
+}
+
+void zip_2x8_6_aligned(const std::uint8_t* source, std::int32_t count,
+                       std::int32_t stride, std::uint8_t* destination,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "sub %[count], %[count], #6\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vld1.8 {d1}, [r0:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]!\n"
+      "vld1.32 {d1[0]}, [r0]!\n"
+      "vld1.16 {d0[2]}, [%[source]]\n"
+      "vld1.16 {d1[2]}, [r0]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d2[0], %[multiplicative_offset]\n"
+      "vdup.32 q4, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpadd.u32 d3, d4, d5\n"
+      "vpadd.u32 d10, d6, d7\n"
+      "vpadd.u32 d12, d3, d10\n"
+      "vmul.i32 q6, q6, d2[0]\n"
+      "vadd.i32 q6, q6, q4\n"
+      "vst1.32 {d12}, [%[destination]:64]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d12", "d13", "cc", "memory");
+}
+
+void zip_2x8_7_aligned(const std::uint8_t* source, std::int32_t count,
+                       std::int32_t stride, std::uint8_t* destination,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "sub %[count], %[count], #7\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vld1.8 {d1}, [r0:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]!\n"
+      "vld1.32 {d1[0]}, [r0]!\n"
+      "vld1.16 {d0[2]}, [%[source]]!\n"
+      "vld1.16 {d1[2]}, [r0]!\n"
+      "vld1.8 {d0[6]}, [%[source]]\n"
+      "vld1.8 {d1[6]}, [r0]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d2[0], %[multiplicative_offset]\n"
+      "vdup.32 q4, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpadd.u32 d3, d4, d5\n"
+      "vpadd.u32 d10, d6, d7\n"
+      "vpadd.u32 d12, d3, d10\n"
+      "vmul.i32 q6, q6, d2[0]\n"
+      "vadd.i32 q6, q6, q4\n"
+      "vst1.32 {d12}, [%[destination]:64]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d12", "d13", "cc", "memory");
+}
+
+void zip_3x8_aligned(const std::uint8_t* source, std::int32_t count,
+                     std::int32_t stride, std::uint8_t* destination,
+                     std::int32_t multiplicative_offset,
+                     std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "add r1, r0, %[stride]\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+      "vmov.i16 q4, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vld1.8 {d1}, [r0:64]!\n"
+      "vld1.8 {d2}, [r1:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d3[0], %[multiplicative_offset]\n"
+      "vdup.32 q5, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpaddl.u16 q4, q4\n"
+      "vpadd.u32 d12, d4, d5\n"
+      "vpadd.u32 d13, d6, d7\n"
+      "vpadd.u32 d14, d8, d9\n"
+      "vpadd.u32 d16, d12, d13\n"
+      "vpadd.u32 d17, d14, d14\n"
+      "vmul.i32 q8, q8, d3[0]\n"
+      "vadd.i32 q8, q8, q5\n"
+      "vst1.32 {d16}, [%[destination]:64]!\n"
+      "vst1.32 {d17[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d16", "d17", "cc", "memory");
+}
+
+void zip_3x8_1_aligned(const std::uint8_t* source, std::int32_t count,
+                       std::int32_t stride, std::uint8_t* destination,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "add r1, r0, %[stride]\n"
+      "sub %[count], %[count], #1\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+      "vmov.i16 q4, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vld1.8 {d1}, [r0:64]!\n"
+      "vld1.8 {d2}, [r1:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vmov.i8 d2, #0\n"
+      "vld1.8 {d0[0]}, [%[source]]\n"
+      "vld1.8 {d1[0]}, [r0]\n"
+      "vld1.8 {d2[0]}, [r1]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d3[0], %[multiplicative_offset]\n"
+      "vdup.32 q5, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpaddl.u16 q4, q4\n"
+      "vpadd.u32 d12, d4, d5\n"
+      "vpadd.u32 d13, d6, d7\n"
+      "vpadd.u32 d14, d8, d9\n"
+      "vpadd.u32 d16, d12, d13\n"
+      "vpadd.u32 d17, d14, d14\n"
+      "vmul.i32 q8, q8, d3[0]\n"
+      "vadd.i32 q8, q8, q5\n"
+      "vst1.32 {d16}, [%[destination]:64]!\n"
+      "vst1.32 {d17[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d16", "d17", "cc", "memory");
+}
+
+void zip_3x8_2_aligned(const std::uint8_t* source, std::int32_t count,
+                       std::int32_t stride, std::uint8_t* destination,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "add r1, r0, %[stride]\n"
+      "sub %[count], %[count], #2\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+      "vmov.i16 q4, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vld1.8 {d1}, [r0:64]!\n"
+      "vld1.8 {d2}, [r1:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vmov.i8 d2, #0\n"
+      "vld1.16 {d0[0]}, [%[source]]\n"
+      "vld1.16 {d1[0]}, [r0]\n"
+      "vld1.16 {d2[0]}, [r1]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d3[0], %[multiplicative_offset]\n"
+      "vdup.32 q5, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpaddl.u16 q4, q4\n"
+      "vpadd.u32 d12, d4, d5\n"
+      "vpadd.u32 d13, d6, d7\n"
+      "vpadd.u32 d14, d8, d9\n"
+      "vpadd.u32 d16, d12, d13\n"
+      "vpadd.u32 d17, d14, d14\n"
+      "vmul.i32 q8, q8, d3[0]\n"
+      "vadd.i32 q8, q8, q5\n"
+      "vst1.32 {d16}, [%[destination]:64]!\n"
+      "vst1.32 {d17[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d16", "d17", "cc", "memory");
+}
+
+void zip_3x8_3_aligned(const std::uint8_t* source, std::int32_t count,
+                       std::int32_t stride, std::uint8_t* destination,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "add r1, r0, %[stride]\n"
+      "sub %[count], %[count], #3\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+      "vmov.i16 q4, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vld1.8 {d1}, [r0:64]!\n"
+      "vld1.8 {d2}, [r1:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vmov.i8 d2, #0\n"
+      "vld1.16 {d0[0]}, [%[source]]!\n"
+      "vld1.16 {d1[0]}, [r0]!\n"
+      "vld1.16 {d2[0]}, [r1]!\n"
+      "vld1.8 {d0[2]}, [%[source]]\n"
+      "vld1.8 {d1[2]}, [r0]\n"
+      "vld1.8 {d2[2]}, [r1]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d3[0], %[multiplicative_offset]\n"
+      "vdup.32 q5, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpaddl.u16 q4, q4\n"
+      "vpadd.u32 d12, d4, d5\n"
+      "vpadd.u32 d13, d6, d7\n"
+      "vpadd.u32 d14, d8, d9\n"
+      "vpadd.u32 d16, d12, d13\n"
+      "vpadd.u32 d17, d14, d14\n"
+      "vmul.i32 q8, q8, d3[0]\n"
+      "vadd.i32 q8, q8, q5\n"
+      "vst1.32 {d16}, [%[destination]:64]!\n"
+      "vst1.32 {d17[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d16", "d17", "cc", "memory");
+}
+
+void zip_3x8_4_aligned(const std::uint8_t* source, std::int32_t count,
+                       std::int32_t stride, std::uint8_t* destination,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "add r1, r0, %[stride]\n"
+      "sub %[count], %[count], #4\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+      "vmov.i16 q4, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vld1.8 {d1}, [r0:64]!\n"
+      "vld1.8 {d2}, [r1:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vmov.i8 d2, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]\n"
+      "vld1.32 {d1[0]}, [r0]\n"
+      "vld1.32 {d2[0]}, [r1]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d3[0], %[multiplicative_offset]\n"
+      "vdup.32 q5, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpaddl.u16 q4, q4\n"
+      "vpadd.u32 d12, d4, d5\n"
+      "vpadd.u32 d13, d6, d7\n"
+      "vpadd.u32 d14, d8, d9\n"
+      "vpadd.u32 d16, d12, d13\n"
+      "vpadd.u32 d17, d14, d14\n"
+      "vmul.i32 q8, q8, d3[0]\n"
+      "vadd.i32 q8, q8, q5\n"
+      "vst1.32 {d16}, [%[destination]:64]!\n"
+      "vst1.32 {d17[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d16", "d17", "cc", "memory");
+}
+
+void zip_3x8_5_aligned(const std::uint8_t* source, std::int32_t count,
+                       std::int32_t stride, std::uint8_t* destination,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "add r1, r0, %[stride]\n"
+      "sub %[count], %[count], #5\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+      "vmov.i16 q4, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vld1.8 {d1}, [r0:64]!\n"
+      "vld1.8 {d2}, [r1:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vmov.i8 d2, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]!\n"
+      "vld1.32 {d1[0]}, [r0]!\n"
+      "vld1.32 {d2[0]}, [r1]!\n"
+      "vld1.8 {d0[4]}, [%[source]]\n"
+      "vld1.8 {d1[4]}, [r0]\n"
+      "vld1.8 {d2[4]}, [r1]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d3[0], %[multiplicative_offset]\n"
+      "vdup.32 q5, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpaddl.u16 q4, q4\n"
+      "vpadd.u32 d12, d4, d5\n"
+      "vpadd.u32 d13, d6, d7\n"
+      "vpadd.u32 d14, d8, d9\n"
+      "vpadd.u32 d16, d12, d13\n"
+      "vpadd.u32 d17, d14, d14\n"
+      "vmul.i32 q8, q8, d3[0]\n"
+      "vadd.i32 q8, q8, q5\n"
+      "vst1.32 {d16}, [%[destination]:64]!\n"
+      "vst1.32 {d17[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d16", "d17", "cc", "memory");
+}
+
+void zip_3x8_6_aligned(const std::uint8_t* source, std::int32_t count,
+                       std::int32_t stride, std::uint8_t* destination,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "add r1, r0, %[stride]\n"
+      "sub %[count], %[count], #6\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+      "vmov.i16 q4, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vld1.8 {d1}, [r0:64]!\n"
+      "vld1.8 {d2}, [r1:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vmov.i8 d2, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]!\n"
+      "vld1.32 {d1[0]}, [r0]!\n"
+      "vld1.32 {d2[0]}, [r1]!\n"
+      "vld1.16 {d0[2]}, [%[source]]\n"
+      "vld1.16 {d1[2]}, [r0]\n"
+      "vld1.16 {d2[2]}, [r1]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d3[0], %[multiplicative_offset]\n"
+      "vdup.32 q5, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpaddl.u16 q4, q4\n"
+      "vpadd.u32 d12, d4, d5\n"
+      "vpadd.u32 d13, d6, d7\n"
+      "vpadd.u32 d14, d8, d9\n"
+      "vpadd.u32 d16, d12, d13\n"
+      "vpadd.u32 d17, d14, d14\n"
+      "vmul.i32 q8, q8, d3[0]\n"
+      "vadd.i32 q8, q8, q5\n"
+      "vst1.32 {d16}, [%[destination]:64]!\n"
+      "vst1.32 {d17[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d16", "d17", "cc", "memory");
+}
+
+void zip_3x8_7_aligned(const std::uint8_t* source, std::int32_t count,
+                       std::int32_t stride, std::uint8_t* destination,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "add r1, r0, %[stride]\n"
+      "sub %[count], %[count], #7\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+      "vmov.i16 q4, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]:64]!\n"
+      "vld1.8 {d1}, [r0:64]!\n"
+      "vld1.8 {d2}, [r1:64]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vmov.i8 d2, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]!\n"
+      "vld1.32 {d1[0]}, [r0]!\n"
+      "vld1.32 {d2[0]}, [r1]!\n"
+      "vld1.16 {d0[2]}, [%[source]]!\n"
+      "vld1.16 {d1[2]}, [r0]!\n"
+      "vld1.16 {d2[2]}, [r1]!\n"
+      "vld1.8 {d0[6]}, [%[source]]\n"
+      "vld1.8 {d1[6]}, [r0]\n"
+      "vld1.8 {d2[6]}, [r1]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d3[0], %[multiplicative_offset]\n"
+      "vdup.32 q5, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpaddl.u16 q4, q4\n"
+      "vpadd.u32 d12, d4, d5\n"
+      "vpadd.u32 d13, d6, d7\n"
+      "vpadd.u32 d14, d8, d9\n"
+      "vpadd.u32 d16, d12, d13\n"
+      "vpadd.u32 d17, d14, d14\n"
+      "vmul.i32 q8, q8, d3[0]\n"
+      "vadd.i32 q8, q8, q5\n"
+      "vst1.32 {d16}, [%[destination]:64]!\n"
+      "vst1.32 {d17[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d16", "d17", "cc", "memory");
+}
+
+void zip_1x8(const std::uint8_t* source, std::int32_t count,
+             std::int32_t stride, std::uint8_t* destination,
+             std::int32_t multiplicative_offset, std::int32_t additive_offset) {
+  asm volatile(
+      "vmov.i16 q2, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d1[0], %[multiplicative_offset]\n"
+      "vdup.32 q1, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpadd.u32 d6, d4, d5\n"
+      "vpadd.u32 d8, d6, d6\n"
+      "vmul.i32 q4, q4, d1[0]\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vst1.32 {d8[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d8", "d9", "cc", "memory");
+}
+
+void zip_1x8_1(const std::uint8_t* source, std::int32_t count,
+               std::int32_t stride, std::uint8_t* destination,
+               std::int32_t multiplicative_offset,
+               std::int32_t additive_offset) {
+  asm volatile(
+      "sub %[count], %[count], #1\n"
+      "vmov.i16 q2, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vld1.8 {d0[0]}, [%[source]]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d1[0], %[multiplicative_offset]\n"
+      "vdup.32 q1, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpadd.u32 d6, d4, d5\n"
+      "vpadd.u32 d8, d6, d6\n"
+      "vmul.i32 q4, q4, d1[0]\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vst1.32 {d8[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d8", "d9", "cc", "memory");
+}
+
+void zip_1x8_2(const std::uint8_t* source, std::int32_t count,
+               std::int32_t stride, std::uint8_t* destination,
+               std::int32_t multiplicative_offset,
+               std::int32_t additive_offset) {
+  asm volatile(
+      "sub %[count], %[count], #2\n"
+      "vmov.i16 q2, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vld1.16 {d0[0]}, [%[source]]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d1[0], %[multiplicative_offset]\n"
+      "vdup.32 q1, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpadd.u32 d6, d4, d5\n"
+      "vpadd.u32 d8, d6, d6\n"
+      "vmul.i32 q4, q4, d1[0]\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vst1.32 {d8[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d8", "d9", "cc", "memory");
+}
+
+void zip_1x8_3(const std::uint8_t* source, std::int32_t count,
+               std::int32_t stride, std::uint8_t* destination,
+               std::int32_t multiplicative_offset,
+               std::int32_t additive_offset) {
+  asm volatile(
+      "sub %[count], %[count], #3\n"
+      "vmov.i16 q2, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vld1.16 {d0[0]}, [%[source]]!\n"
+      "vld1.8 {d0[2]}, [%[source]]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d1[0], %[multiplicative_offset]\n"
+      "vdup.32 q1, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpadd.u32 d6, d4, d5\n"
+      "vpadd.u32 d8, d6, d6\n"
+      "vmul.i32 q4, q4, d1[0]\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vst1.32 {d8[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d8", "d9", "cc", "memory");
+}
+
+void zip_1x8_4(const std::uint8_t* source, std::int32_t count,
+               std::int32_t stride, std::uint8_t* destination,
+               std::int32_t multiplicative_offset,
+               std::int32_t additive_offset) {
+  asm volatile(
+      "sub %[count], %[count], #4\n"
+      "vmov.i16 q2, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d1[0], %[multiplicative_offset]\n"
+      "vdup.32 q1, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpadd.u32 d6, d4, d5\n"
+      "vpadd.u32 d8, d6, d6\n"
+      "vmul.i32 q4, q4, d1[0]\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vst1.32 {d8[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d8", "d9", "cc", "memory");
+}
+
+void zip_1x8_5(const std::uint8_t* source, std::int32_t count,
+               std::int32_t stride, std::uint8_t* destination,
+               std::int32_t multiplicative_offset,
+               std::int32_t additive_offset) {
+  asm volatile(
+      "sub %[count], %[count], #5\n"
+      "vmov.i16 q2, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]!\n"
+      "vld1.8 {d0[4]}, [%[source]]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d1[0], %[multiplicative_offset]\n"
+      "vdup.32 q1, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpadd.u32 d6, d4, d5\n"
+      "vpadd.u32 d8, d6, d6\n"
+      "vmul.i32 q4, q4, d1[0]\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vst1.32 {d8[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d8", "d9", "cc", "memory");
+}
+
+void zip_1x8_6(const std::uint8_t* source, std::int32_t count,
+               std::int32_t stride, std::uint8_t* destination,
+               std::int32_t multiplicative_offset,
+               std::int32_t additive_offset) {
+  asm volatile(
+      "sub %[count], %[count], #6\n"
+      "vmov.i16 q2, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]!\n"
+      "vld1.16 {d0[2]}, [%[source]]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d1[0], %[multiplicative_offset]\n"
+      "vdup.32 q1, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpadd.u32 d6, d4, d5\n"
+      "vpadd.u32 d8, d6, d6\n"
+      "vmul.i32 q4, q4, d1[0]\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vst1.32 {d8[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d8", "d9", "cc", "memory");
+}
+
+void zip_1x8_7(const std::uint8_t* source, std::int32_t count,
+               std::int32_t stride, std::uint8_t* destination,
+               std::int32_t multiplicative_offset,
+               std::int32_t additive_offset) {
+  asm volatile(
+      "sub %[count], %[count], #7\n"
+      "vmov.i16 q2, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]!\n"
+      "vld1.16 {d0[2]}, [%[source]]!\n"
+      "vld1.8 {d0[6]}, [%[source]]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vst1.8 {d0}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d1[0], %[multiplicative_offset]\n"
+      "vdup.32 q1, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpadd.u32 d6, d4, d5\n"
+      "vpadd.u32 d8, d6, d6\n"
+      "vmul.i32 q4, q4, d1[0]\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vst1.32 {d8[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d8", "d9", "cc", "memory");
+}
+
+void zip_2x8(const std::uint8_t* source, std::int32_t count,
+             std::int32_t stride, std::uint8_t* destination,
+             std::int32_t multiplicative_offset, std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vld1.8 {d1}, [r0]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d2[0], %[multiplicative_offset]\n"
+      "vdup.32 q4, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpadd.u32 d3, d4, d5\n"
+      "vpadd.u32 d10, d6, d7\n"
+      "vpadd.u32 d12, d3, d10\n"
+      "vmul.i32 q6, q6, d2[0]\n"
+      "vadd.i32 q6, q6, q4\n"
+      "vst1.32 {d12}, [%[destination]:64]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d12", "d13", "cc", "memory");
+}
+
+void zip_2x8_1(const std::uint8_t* source, std::int32_t count,
+               std::int32_t stride, std::uint8_t* destination,
+               std::int32_t multiplicative_offset,
+               std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "sub %[count], %[count], #1\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vld1.8 {d1}, [r0]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vld1.8 {d0[0]}, [%[source]]\n"
+      "vld1.8 {d1[0]}, [r0]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d2[0], %[multiplicative_offset]\n"
+      "vdup.32 q4, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpadd.u32 d3, d4, d5\n"
+      "vpadd.u32 d10, d6, d7\n"
+      "vpadd.u32 d12, d3, d10\n"
+      "vmul.i32 q6, q6, d2[0]\n"
+      "vadd.i32 q6, q6, q4\n"
+      "vst1.32 {d12}, [%[destination]:64]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d12", "d13", "cc", "memory");
+}
+
+void zip_2x8_2(const std::uint8_t* source, std::int32_t count,
+               std::int32_t stride, std::uint8_t* destination,
+               std::int32_t multiplicative_offset,
+               std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "sub %[count], %[count], #2\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vld1.8 {d1}, [r0]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vld1.16 {d0[0]}, [%[source]]\n"
+      "vld1.16 {d1[0]}, [r0]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d2[0], %[multiplicative_offset]\n"
+      "vdup.32 q4, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpadd.u32 d3, d4, d5\n"
+      "vpadd.u32 d10, d6, d7\n"
+      "vpadd.u32 d12, d3, d10\n"
+      "vmul.i32 q6, q6, d2[0]\n"
+      "vadd.i32 q6, q6, q4\n"
+      "vst1.32 {d12}, [%[destination]:64]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d12", "d13", "cc", "memory");
+}
+
+void zip_2x8_3(const std::uint8_t* source, std::int32_t count,
+               std::int32_t stride, std::uint8_t* destination,
+               std::int32_t multiplicative_offset,
+               std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "sub %[count], %[count], #3\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vld1.8 {d1}, [r0]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vld1.16 {d0[0]}, [%[source]]!\n"
+      "vld1.16 {d1[0]}, [r0]!\n"
+      "vld1.8 {d0[2]}, [%[source]]\n"
+      "vld1.8 {d1[2]}, [r0]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d2[0], %[multiplicative_offset]\n"
+      "vdup.32 q4, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpadd.u32 d3, d4, d5\n"
+      "vpadd.u32 d10, d6, d7\n"
+      "vpadd.u32 d12, d3, d10\n"
+      "vmul.i32 q6, q6, d2[0]\n"
+      "vadd.i32 q6, q6, q4\n"
+      "vst1.32 {d12}, [%[destination]:64]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d12", "d13", "cc", "memory");
+}
+
+void zip_2x8_4(const std::uint8_t* source, std::int32_t count,
+               std::int32_t stride, std::uint8_t* destination,
+               std::int32_t multiplicative_offset,
+               std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "sub %[count], %[count], #4\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vld1.8 {d1}, [r0]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]\n"
+      "vld1.32 {d1[0]}, [r0]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d2[0], %[multiplicative_offset]\n"
+      "vdup.32 q4, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpadd.u32 d3, d4, d5\n"
+      "vpadd.u32 d10, d6, d7\n"
+      "vpadd.u32 d12, d3, d10\n"
+      "vmul.i32 q6, q6, d2[0]\n"
+      "vadd.i32 q6, q6, q4\n"
+      "vst1.32 {d12}, [%[destination]:64]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d12", "d13", "cc", "memory");
+}
+
+void zip_2x8_5(const std::uint8_t* source, std::int32_t count,
+               std::int32_t stride, std::uint8_t* destination,
+               std::int32_t multiplicative_offset,
+               std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "sub %[count], %[count], #5\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vld1.8 {d1}, [r0]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]!\n"
+      "vld1.32 {d1[0]}, [r0]!\n"
+      "vld1.8 {d0[4]}, [%[source]]\n"
+      "vld1.8 {d1[4]}, [r0]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d2[0], %[multiplicative_offset]\n"
+      "vdup.32 q4, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpadd.u32 d3, d4, d5\n"
+      "vpadd.u32 d10, d6, d7\n"
+      "vpadd.u32 d12, d3, d10\n"
+      "vmul.i32 q6, q6, d2[0]\n"
+      "vadd.i32 q6, q6, q4\n"
+      "vst1.32 {d12}, [%[destination]:64]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d12", "d13", "cc", "memory");
+}
+
+void zip_2x8_6(const std::uint8_t* source, std::int32_t count,
+               std::int32_t stride, std::uint8_t* destination,
+               std::int32_t multiplicative_offset,
+               std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "sub %[count], %[count], #6\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vld1.8 {d1}, [r0]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]!\n"
+      "vld1.32 {d1[0]}, [r0]!\n"
+      "vld1.16 {d0[2]}, [%[source]]\n"
+      "vld1.16 {d1[2]}, [r0]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d2[0], %[multiplicative_offset]\n"
+      "vdup.32 q4, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpadd.u32 d3, d4, d5\n"
+      "vpadd.u32 d10, d6, d7\n"
+      "vpadd.u32 d12, d3, d10\n"
+      "vmul.i32 q6, q6, d2[0]\n"
+      "vadd.i32 q6, q6, q4\n"
+      "vst1.32 {d12}, [%[destination]:64]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d12", "d13", "cc", "memory");
+}
+
+void zip_2x8_7(const std::uint8_t* source, std::int32_t count,
+               std::int32_t stride, std::uint8_t* destination,
+               std::int32_t multiplicative_offset,
+               std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "sub %[count], %[count], #7\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vld1.8 {d1}, [r0]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]!\n"
+      "vld1.32 {d1[0]}, [r0]!\n"
+      "vld1.16 {d0[2]}, [%[source]]!\n"
+      "vld1.16 {d1[2]}, [r0]!\n"
+      "vld1.8 {d0[6]}, [%[source]]\n"
+      "vld1.8 {d1[6]}, [r0]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vst1.8 {d0, d1}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d2[0], %[multiplicative_offset]\n"
+      "vdup.32 q4, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpadd.u32 d3, d4, d5\n"
+      "vpadd.u32 d10, d6, d7\n"
+      "vpadd.u32 d12, d3, d10\n"
+      "vmul.i32 q6, q6, d2[0]\n"
+      "vadd.i32 q6, q6, q4\n"
+      "vst1.32 {d12}, [%[destination]:64]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d12", "d13", "cc", "memory");
+}
+
+void zip_3x8(const std::uint8_t* source, std::int32_t count,
+             std::int32_t stride, std::uint8_t* destination,
+             std::int32_t multiplicative_offset, std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "add r1, r0, %[stride]\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+      "vmov.i16 q4, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vld1.8 {d1}, [r0]!\n"
+      "vld1.8 {d2}, [r1]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d3[0], %[multiplicative_offset]\n"
+      "vdup.32 q5, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpaddl.u16 q4, q4\n"
+      "vpadd.u32 d12, d4, d5\n"
+      "vpadd.u32 d13, d6, d7\n"
+      "vpadd.u32 d14, d8, d9\n"
+      "vpadd.u32 d16, d12, d13\n"
+      "vpadd.u32 d17, d14, d14\n"
+      "vmul.i32 q8, q8, d3[0]\n"
+      "vadd.i32 q8, q8, q5\n"
+      "vst1.32 {d16}, [%[destination]:64]!\n"
+      "vst1.32 {d17[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d16", "d17", "cc", "memory");
+}
+
+void zip_3x8_1(const std::uint8_t* source, std::int32_t count,
+               std::int32_t stride, std::uint8_t* destination,
+               std::int32_t multiplicative_offset,
+               std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "add r1, r0, %[stride]\n"
+      "sub %[count], %[count], #1\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+      "vmov.i16 q4, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vld1.8 {d1}, [r0]!\n"
+      "vld1.8 {d2}, [r1]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vmov.i8 d2, #0\n"
+      "vld1.8 {d0[0]}, [%[source]]\n"
+      "vld1.8 {d1[0]}, [r0]\n"
+      "vld1.8 {d2[0]}, [r1]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d3[0], %[multiplicative_offset]\n"
+      "vdup.32 q5, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpaddl.u16 q4, q4\n"
+      "vpadd.u32 d12, d4, d5\n"
+      "vpadd.u32 d13, d6, d7\n"
+      "vpadd.u32 d14, d8, d9\n"
+      "vpadd.u32 d16, d12, d13\n"
+      "vpadd.u32 d17, d14, d14\n"
+      "vmul.i32 q8, q8, d3[0]\n"
+      "vadd.i32 q8, q8, q5\n"
+      "vst1.32 {d16}, [%[destination]:64]!\n"
+      "vst1.32 {d17[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d16", "d17", "cc", "memory");
+}
+
+void zip_3x8_2(const std::uint8_t* source, std::int32_t count,
+               std::int32_t stride, std::uint8_t* destination,
+               std::int32_t multiplicative_offset,
+               std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "add r1, r0, %[stride]\n"
+      "sub %[count], %[count], #2\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+      "vmov.i16 q4, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vld1.8 {d1}, [r0]!\n"
+      "vld1.8 {d2}, [r1]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vmov.i8 d2, #0\n"
+      "vld1.16 {d0[0]}, [%[source]]\n"
+      "vld1.16 {d1[0]}, [r0]\n"
+      "vld1.16 {d2[0]}, [r1]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d3[0], %[multiplicative_offset]\n"
+      "vdup.32 q5, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpaddl.u16 q4, q4\n"
+      "vpadd.u32 d12, d4, d5\n"
+      "vpadd.u32 d13, d6, d7\n"
+      "vpadd.u32 d14, d8, d9\n"
+      "vpadd.u32 d16, d12, d13\n"
+      "vpadd.u32 d17, d14, d14\n"
+      "vmul.i32 q8, q8, d3[0]\n"
+      "vadd.i32 q8, q8, q5\n"
+      "vst1.32 {d16}, [%[destination]:64]!\n"
+      "vst1.32 {d17[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d16", "d17", "cc", "memory");
+}
+
+void zip_3x8_3(const std::uint8_t* source, std::int32_t count,
+               std::int32_t stride, std::uint8_t* destination,
+               std::int32_t multiplicative_offset,
+               std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "add r1, r0, %[stride]\n"
+      "sub %[count], %[count], #3\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+      "vmov.i16 q4, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vld1.8 {d1}, [r0]!\n"
+      "vld1.8 {d2}, [r1]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vmov.i8 d2, #0\n"
+      "vld1.16 {d0[0]}, [%[source]]!\n"
+      "vld1.16 {d1[0]}, [r0]!\n"
+      "vld1.16 {d2[0]}, [r1]!\n"
+      "vld1.8 {d0[2]}, [%[source]]\n"
+      "vld1.8 {d1[2]}, [r0]\n"
+      "vld1.8 {d2[2]}, [r1]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d3[0], %[multiplicative_offset]\n"
+      "vdup.32 q5, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpaddl.u16 q4, q4\n"
+      "vpadd.u32 d12, d4, d5\n"
+      "vpadd.u32 d13, d6, d7\n"
+      "vpadd.u32 d14, d8, d9\n"
+      "vpadd.u32 d16, d12, d13\n"
+      "vpadd.u32 d17, d14, d14\n"
+      "vmul.i32 q8, q8, d3[0]\n"
+      "vadd.i32 q8, q8, q5\n"
+      "vst1.32 {d16}, [%[destination]:64]!\n"
+      "vst1.32 {d17[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d16", "d17", "cc", "memory");
+}
+
+void zip_3x8_4(const std::uint8_t* source, std::int32_t count,
+               std::int32_t stride, std::uint8_t* destination,
+               std::int32_t multiplicative_offset,
+               std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "add r1, r0, %[stride]\n"
+      "sub %[count], %[count], #4\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+      "vmov.i16 q4, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vld1.8 {d1}, [r0]!\n"
+      "vld1.8 {d2}, [r1]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vmov.i8 d2, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]\n"
+      "vld1.32 {d1[0]}, [r0]\n"
+      "vld1.32 {d2[0]}, [r1]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d3[0], %[multiplicative_offset]\n"
+      "vdup.32 q5, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpaddl.u16 q4, q4\n"
+      "vpadd.u32 d12, d4, d5\n"
+      "vpadd.u32 d13, d6, d7\n"
+      "vpadd.u32 d14, d8, d9\n"
+      "vpadd.u32 d16, d12, d13\n"
+      "vpadd.u32 d17, d14, d14\n"
+      "vmul.i32 q8, q8, d3[0]\n"
+      "vadd.i32 q8, q8, q5\n"
+      "vst1.32 {d16}, [%[destination]:64]!\n"
+      "vst1.32 {d17[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d16", "d17", "cc", "memory");
+}
+
+void zip_3x8_5(const std::uint8_t* source, std::int32_t count,
+               std::int32_t stride, std::uint8_t* destination,
+               std::int32_t multiplicative_offset,
+               std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "add r1, r0, %[stride]\n"
+      "sub %[count], %[count], #5\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+      "vmov.i16 q4, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vld1.8 {d1}, [r0]!\n"
+      "vld1.8 {d2}, [r1]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vmov.i8 d2, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]!\n"
+      "vld1.32 {d1[0]}, [r0]!\n"
+      "vld1.32 {d2[0]}, [r1]!\n"
+      "vld1.8 {d0[4]}, [%[source]]\n"
+      "vld1.8 {d1[4]}, [r0]\n"
+      "vld1.8 {d2[4]}, [r1]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d3[0], %[multiplicative_offset]\n"
+      "vdup.32 q5, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpaddl.u16 q4, q4\n"
+      "vpadd.u32 d12, d4, d5\n"
+      "vpadd.u32 d13, d6, d7\n"
+      "vpadd.u32 d14, d8, d9\n"
+      "vpadd.u32 d16, d12, d13\n"
+      "vpadd.u32 d17, d14, d14\n"
+      "vmul.i32 q8, q8, d3[0]\n"
+      "vadd.i32 q8, q8, q5\n"
+      "vst1.32 {d16}, [%[destination]:64]!\n"
+      "vst1.32 {d17[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d16", "d17", "cc", "memory");
+}
+
+void zip_3x8_6(const std::uint8_t* source, std::int32_t count,
+               std::int32_t stride, std::uint8_t* destination,
+               std::int32_t multiplicative_offset,
+               std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "add r1, r0, %[stride]\n"
+      "sub %[count], %[count], #6\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+      "vmov.i16 q4, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vld1.8 {d1}, [r0]!\n"
+      "vld1.8 {d2}, [r1]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vmov.i8 d2, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]!\n"
+      "vld1.32 {d1[0]}, [r0]!\n"
+      "vld1.32 {d2[0]}, [r1]!\n"
+      "vld1.16 {d0[2]}, [%[source]]\n"
+      "vld1.16 {d1[2]}, [r0]\n"
+      "vld1.16 {d2[2]}, [r1]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d3[0], %[multiplicative_offset]\n"
+      "vdup.32 q5, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpaddl.u16 q4, q4\n"
+      "vpadd.u32 d12, d4, d5\n"
+      "vpadd.u32 d13, d6, d7\n"
+      "vpadd.u32 d14, d8, d9\n"
+      "vpadd.u32 d16, d12, d13\n"
+      "vpadd.u32 d17, d14, d14\n"
+      "vmul.i32 q8, q8, d3[0]\n"
+      "vadd.i32 q8, q8, q5\n"
+      "vst1.32 {d16}, [%[destination]:64]!\n"
+      "vst1.32 {d17[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d16", "d17", "cc", "memory");
+}
+
+void zip_3x8_7(const std::uint8_t* source, std::int32_t count,
+               std::int32_t stride, std::uint8_t* destination,
+               std::int32_t multiplicative_offset,
+               std::int32_t additive_offset) {
+  asm volatile(
+      "add r0, %[source], %[stride]\n"
+      "add r1, r0, %[stride]\n"
+      "sub %[count], %[count], #7\n"
+      "vmov.i16 q2, #0\n"
+      "vmov.i16 q3, #0\n"
+      "vmov.i16 q4, #0\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+
+      // Load Aggregate Store.
+      "vld1.8 {d0}, [%[source]]!\n"
+      "vld1.8 {d1}, [r0]!\n"
+      "vld1.8 {d2}, [r1]!\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+
+      // Leftover Load Aggregate Store.
+      "vmov.i8 d0, #0\n"
+      "vmov.i8 d1, #0\n"
+      "vmov.i8 d2, #0\n"
+      "vld1.32 {d0[0]}, [%[source]]!\n"
+      "vld1.32 {d1[0]}, [r0]!\n"
+      "vld1.32 {d2[0]}, [r1]!\n"
+      "vld1.16 {d0[2]}, [%[source]]!\n"
+      "vld1.16 {d1[2]}, [r0]!\n"
+      "vld1.16 {d2[2]}, [r1]!\n"
+      "vld1.8 {d0[6]}, [%[source]]\n"
+      "vld1.8 {d1[6]}, [r0]\n"
+      "vld1.8 {d2[6]}, [r1]\n"
+      "vaddw.u8 q2, q2, d0\n"
+      "vaddw.u8 q3, q3, d1\n"
+      "vaddw.u8 q4, q4, d2\n"
+      "vst1.8 {d0, d1, d2}, [%[destination]:64]!\n"
+
+      // Aggregator Reduction.
+      "vmov.32 d3[0], %[multiplicative_offset]\n"
+      "vdup.32 q5, %[additive_offset]\n"
+      "vpaddl.u16 q2, q2\n"
+      "vpaddl.u16 q3, q3\n"
+      "vpaddl.u16 q4, q4\n"
+      "vpadd.u32 d12, d4, d5\n"
+      "vpadd.u32 d13, d6, d7\n"
+      "vpadd.u32 d14, d8, d9\n"
+      "vpadd.u32 d16, d12, d13\n"
+      "vpadd.u32 d17, d14, d14\n"
+      "vmul.i32 q8, q8, d3[0]\n"
+      "vadd.i32 q8, q8, q5\n"
+      "vst1.32 {d16}, [%[destination]:64]!\n"
+      "vst1.32 {d17[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [additive_offset] "+r"(additive_offset), [stride] "+r"(stride),
+        [destination] "+r"(destination), [source] "+r"(source)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d16", "d17", "cc", "memory");
+}
+
+inline void mul_1x8_1x8_rhsadd(const std::uint8_t* left,
+                               const std::uint8_t* right, std::int32_t count,
+                               std::int32_t* results,
+                               std::int32_t results_stride) {
+  asm volatile(
+      "pld [%[left]]\n"
+      "pld [%[right]]\n"
+      // Clear aggregators.
+      "vmov.i32 q1, #0\n"
+
+      // General NxM lanes loop.
+      "1:"
+
+      // Subtract counter.
+      "subs %[count], %[count], #8\n"
+
+      "vld1.8 {d0}, [%[left]:64]!\n"
+      "vld1.8 {d1}, [%[right]:64]!\n"
+      "pld [%[left], #64]\n"
+      "pld [%[right], #64]\n"
+      "vmull.u8 q2, d1, d0\n"
+      "vpadal.u16 q1, q2\n"
+
+      // Loop break.
+      "bne 1b\n"
+
+      "vld1.32 {d8}, [%[right]:64]\n"
+
+      // Horizontal reduce aggregators.
+      "vpadd.u32 d2, d2, d3\n"
+
+      // Reduce rows.
+      "vpadd.u32 d0, d2, d2\n"
+
+      // Add rhs offset to aggregated rows.
+      "vadd.s32 d0, d0, d8\n"
+
+      // Store reduced (rhs added) rows.
+      "vst1.32 {d0[0]}, [%[results]], %[results_stride]\n"
+      : [count] "+r"(count), [right] "+r"(right),
+        [results_stride] "+r"(results_stride), [results] "+r"(results),
+        [left] "+r"(left)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d8", "cc", "memory");
+}
+
+inline void mul_1x8_2x8_rhsadd(const std::uint8_t* left,
+                               const std::uint8_t* right, std::int32_t count,
+                               std::int32_t* results,
+                               std::int32_t results_stride) {
+  asm volatile(
+      "pld [%[left]]\n"
+      "pld [%[right]]\n"
+      // Clear aggregators.
+      "vmov.i32 q2, #0\n"
+      "vmov.i32 q3, #0\n"
+
+      // General NxM lanes loop.
+      "1:"
+
+      // Subtract counter.
+      "subs %[count], %[count], #8\n"
+
+      "vld1.8 {d0}, [%[left]:64]!\n"
+      "vld1.8 {d1, d2}, [%[right]:64]!\n"
+      "pld [%[left], #64]\n"
+      "pld [%[right], #64]\n"
+      "vmull.u8 q4, d1, d0\n"
+      "vmull.u8 q5, d2, d0\n"
+      "vpadal.u16 q2, q4\n"
+      "vpadal.u16 q3, q5\n"
+
+      // Loop break.
+      "bne 1b\n"
+
+      "vld1.32 {d8}, [%[right]:64]\n"
+
+      // Horizontal reduce aggregators.
+      "vpadd.u32 d4, d4, d5\n"
+      "vpadd.u32 d6, d6, d7\n"
+
+      // Reduce rows.
+      "vpadd.u32 d0, d4, d6\n"
+
+      // Add rhs offset to aggregated rows.
+      "vadd.s32 d0, d0, d8\n"
+
+      // Store reduced (rhs added) rows.
+      "vst1.32 {d0}, [%[results]], %[results_stride]\n"
+      : [count] "+r"(count), [right] "+r"(right),
+        [results_stride] "+r"(results_stride), [results] "+r"(results),
+        [left] "+r"(left)
+      :
+      : "d0", "d1", "d2", "d4", "d5", "d6", "d7", "d8", "d9", "d10", "d11",
+        "cc", "memory");
+}
+
+inline void mul_1x8_3x8_rhsadd(const std::uint8_t* left,
+                               const std::uint8_t* right, std::int32_t count,
+                               std::int32_t* results,
+                               std::int32_t results_stride) {
+  asm volatile(
+      "pld [%[left]]\n"
+      "pld [%[right]]\n"
+      // Clear aggregators.
+      "vmov.i32 q2, #0\n"
+      "vmov.i32 q3, #0\n"
+      "vmov.i32 q4, #0\n"
+
+      // General NxM lanes loop.
+      "1:"
+
+      // Subtract counter.
+      "subs %[count], %[count], #8\n"
+
+      "vld1.8 {d0}, [%[left]:64]!\n"
+      "vld1.8 {d1, d2, d3}, [%[right]:64]!\n"
+      "pld [%[left], #64]\n"
+      "pld [%[right], #64]\n"
+      "vmull.u8 q5, d1, d0\n"
+      "vmull.u8 q6, d2, d0\n"
+      "vmull.u8 q7, d3, d0\n"
+      "vpadal.u16 q2, q5\n"
+      "vpadal.u16 q3, q6\n"
+      "vpadal.u16 q4, q7\n"
+
+      // Loop break.
+      "bne 1b\n"
+
+      "vld1.32 {q5}, [%[right]:64]\n"
+
+      // Change stride because storing in two ops.
+      "sub %[results_stride], %[results_stride], #8\n"
+
+      // Horizontal reduce aggregators.
+      "vpadd.u32 d4, d4, d5\n"
+      "vpadd.u32 d6, d6, d7\n"
+      "vpadd.u32 d8, d8, d9\n"
+
+      // Reduce rows.
+      "vpadd.u32 d0, d4, d6\n"
+      "vpadd.u32 d1, d8, d8\n"
+
+      // Add rhs offset to aggregated rows.
+      "vadd.s32 q0, q0, q5\n"
+
+      // Store reduced (rhs added) rows.
+      "vst1.32 {d0}, [%[results]]!\n"
+      "vst1.32 {d1[0]}, [%[results]], %[results_stride]\n"
+
+      : [count] "+r"(count), [right] "+r"(right),
+        [results_stride] "+r"(results_stride), [results] "+r"(results),
+        [left] "+r"(left)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "d14", "d15", "cc", "memory");
+}
+
+inline void mul_2x8_1x8_rhsadd(const std::uint8_t* left,
+                               const std::uint8_t* right, std::int32_t count,
+                               std::int32_t* results,
+                               std::int32_t results_stride) {
+  asm volatile(
+      "pld [%[left]]\n"
+      "pld [%[right]]\n"
+      // Clear aggregators.
+      "vmov.i32 q2, #0\n"
+      "vmov.i32 q3, #0\n"
+
+      // General NxM lanes loop.
+      "1:"
+
+      // Subtract counter.
+      "subs %[count], %[count], #8\n"
+
+      "vld1.8 {d0, d1}, [%[left]:64]!\n"
+      "vld1.8 {d2}, [%[right]:64]!\n"
+      "pld [%[left], #64]\n"
+      "pld [%[right], #64]\n"
+      "vmull.u8 q4, d2, d0\n"
+      "vmull.u8 q5, d2, d1\n"
+      "vpadal.u16 q2, q4\n"
+      "vpadal.u16 q3, q5\n"
+
+      // Loop break.
+      "bne 1b\n"
+
+      "vld1.32 {d8}, [%[right]:64]\n"
+
+      // Horizontal reduce aggregators.
+      "vpadd.u32 d4, d4, d5\n"
+      "vpadd.u32 d6, d6, d7\n"
+
+      // Reduce rows.
+      "vpadd.u32 d0, d4, d4\n"
+      "vpadd.u32 d1, d6, d6\n"
+
+      // Add rhs offset to aggregated rows.
+      "vadd.s32 d0, d0, d8\n"
+      "vadd.s32 d1, d1, d8\n"
+
+      // Store reduced (rhs added) rows.
+      "vst1.32 {d0[0]}, [%[results]], %[results_stride]\n"
+      "vst1.32 {d1[0]}, [%[results]], %[results_stride]\n"
+      : [count] "+r"(count), [right] "+r"(right),
+        [results_stride] "+r"(results_stride), [results] "+r"(results),
+        [left] "+r"(left)
+      :
+      : "d0", "d1", "d2", "d4", "d5", "d6", "d7", "d8", "d9", "d10", "d11",
+        "cc", "memory");
+}
+
+inline void mul_2x8_2x8_rhsadd(const std::uint8_t* left,
+                               const std::uint8_t* right, std::int32_t count,
+                               std::int32_t* results,
+                               std::int32_t results_stride) {
+  asm volatile(
+      "pld [%[left]]\n"
+      "pld [%[right]]\n"
+      // Clear aggregators.
+      "vmov.i32 q2, #0\n"
+      "vmov.i32 q3, #0\n"
+      "vmov.i32 q4, #0\n"
+      "vmov.i32 q5, q2\n"
+
+      // General NxM lanes loop.
+      "1:"
+
+      // Subtract counter.
+      "subs %[count], %[count], #8\n"
+
+      "vld1.8 {d0, d1}, [%[left]:64]!\n"
+      "vld1.8 {d2, d3}, [%[right]:64]!\n"
+      "pld [%[left], #64]\n"
+      "pld [%[right], #64]\n"
+      "vmull.u8 q6, d2, d0\n"
+      "vmull.u8 q7, d3, d0\n"
+      "vmull.u8 q8, d2, d1\n"
+      "vmull.u8 q9, d3, d1\n"
+      "vpadal.u16 q2, q6\n"
+      "vpadal.u16 q3, q7\n"
+      "vpadal.u16 q4, q8\n"
+      "vpadal.u16 q5, q9\n"
+
+      // Loop break.
+      "bne 1b\n"
+
+      "vld1.32 {d12}, [%[right]:64]\n"
+
+      // Horizontal reduce aggregators.
+      "vpadd.u32 d4, d4, d5\n"
+      "vpadd.u32 d6, d6, d7\n"
+      "vpadd.u32 d8, d8, d9\n"
+      "vpadd.u32 d10, d10, d11\n"
+
+      // Reduce rows.
+      "vpadd.u32 d0, d4, d6\n"
+      "vpadd.u32 d1, d8, d10\n"
+
+      // Add rhs offset to aggregated rows.
+      "vadd.s32 d0, d0, d12\n"
+      "vadd.s32 d1, d1, d12\n"
+
+      // Store reduced (rhs added) rows.
+      "vst1.32 {d0}, [%[results]], %[results_stride]\n"
+      "vst1.32 {d1}, [%[results]], %[results_stride]\n"
+      : [count] "+r"(count), [right] "+r"(right),
+        [results_stride] "+r"(results_stride), [results] "+r"(results),
+        [left] "+r"(left)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19", "cc",
+        "memory");
+}
+
+inline void mul_2x8_3x8_rhsadd(const std::uint8_t* left,
+                               const std::uint8_t* right, std::int32_t count,
+                               std::int32_t* results,
+                               std::int32_t results_stride) {
+  asm volatile(
+      "pld [%[left]]\n"
+      "pld [%[right]]\n"
+      // Clear aggregators.
+      "vmov.i32 q3, #0\n"
+      "vmov.i32 q4, #0\n"
+      "vmov.i32 q5, #0\n"
+      "vmov.i32 q6, q3\n"
+      "vmov.i32 q7, q4\n"
+      "vmov.i32 q8, q5\n"
+
+      // General NxM lanes loop.
+      "1:"
+
+      // Subtract counter.
+      "subs %[count], %[count], #8\n"
+
+      "vld1.8 {d0, d1}, [%[left]:64]!\n"
+      "vld1.8 {d2, d3, d4}, [%[right]:64]!\n"
+      "pld [%[left], #64]\n"
+      "pld [%[right], #64]\n"
+      "vmull.u8 q9, d2, d0\n"
+      "vmull.u8 q10, d3, d0\n"
+      "vmull.u8 q11, d4, d0\n"
+      "vmull.u8 q12, d2, d1\n"
+      "vmull.u8 q13, d3, d1\n"
+      "vmull.u8 q14, d4, d1\n"
+      "vpadal.u16 q3, q9\n"
+      "vpadal.u16 q4, q10\n"
+      "vpadal.u16 q5, q11\n"
+      "vpadal.u16 q6, q12\n"
+      "vpadal.u16 q7, q13\n"
+      "vpadal.u16 q8, q14\n"
+
+      // Loop break.
+      "bne 1b\n"
+
+      "vld1.32 {q9}, [%[right]:64]\n"
+
+      // Change stride because storing in two ops.
+      "sub %[results_stride], %[results_stride], #8\n"
+
+      // Horizontal reduce aggregators.
+      "vpadd.u32 d6, d6, d7\n"
+      "vpadd.u32 d8, d8, d9\n"
+      "vpadd.u32 d10, d10, d11\n"
+      "vpadd.u32 d12, d12, d13\n"
+      "vpadd.u32 d14, d14, d15\n"
+      "vpadd.u32 d16, d16, d17\n"
+
+      // Reduce rows.
+      "vpadd.u32 d0, d6, d8\n"
+      "vpadd.u32 d1, d10, d10\n"
+      "vpadd.u32 d2, d12, d14\n"
+      "vpadd.u32 d3, d16, d16\n"
+
+      // Add rhs offset to aggregated rows.
+      "vadd.s32 q0, q0, q9\n"
+      "vadd.s32 q1, q1, q9\n"
+
+      // Store reduced (rhs added) rows.
+      "vst1.32 {d0}, [%[results]]!\n"
+      "vst1.32 {d1[0]}, [%[results]], %[results_stride]\n"
+
+      "vst1.32 {d2}, [%[results]]!\n"
+      "vst1.32 {d3[0]}, [%[results]], %[results_stride]\n"
+
+      : [count] "+r"(count), [right] "+r"(right),
+        [results_stride] "+r"(results_stride), [results] "+r"(results),
+        [left] "+r"(left)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d6", "d7", "d8", "d9", "d10", "d11",
+        "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19", "d20", "d21",
+        "d22", "d23", "d24", "d25", "d26", "d27", "d28", "d29", "cc", "memory");
+}
+
+inline void mul_3x8_1x8_rhsadd(const std::uint8_t* left,
+                               const std::uint8_t* right, std::int32_t count,
+                               std::int32_t* results,
+                               std::int32_t results_stride) {
+  asm volatile(
+      "pld [%[left]]\n"
+      "pld [%[right]]\n"
+      // Clear aggregators.
+      "vmov.i32 q2, #0\n"
+      "vmov.i32 q3, #0\n"
+      "vmov.i32 q4, #0\n"
+
+      // General NxM lanes loop.
+      "1:"
+
+      // Subtract counter.
+      "subs %[count], %[count], #8\n"
+
+      "vld1.8 {d0, d1, d2}, [%[left]:64]!\n"
+      "vld1.8 {d3}, [%[right]:64]!\n"
+      "pld [%[left], #64]\n"
+      "pld [%[right], #64]\n"
+      "vmull.u8 q5, d3, d0\n"
+      "vmull.u8 q6, d3, d1\n"
+      "vmull.u8 q7, d3, d2\n"
+      "vpadal.u16 q2, q5\n"
+      "vpadal.u16 q3, q6\n"
+      "vpadal.u16 q4, q7\n"
+
+      // Loop break.
+      "bne 1b\n"
+
+      "vld1.32 {d10}, [%[right]:64]\n"
+
+      // Horizontal reduce aggregators.
+      "vpadd.u32 d4, d4, d5\n"
+      "vpadd.u32 d6, d6, d7\n"
+      "vpadd.u32 d8, d8, d9\n"
+
+      // Reduce rows.
+      "vpadd.u32 d0, d4, d4\n"
+      "vpadd.u32 d1, d6, d6\n"
+      "vpadd.u32 d2, d8, d8\n"
+
+      // Add rhs offset to aggregated rows.
+      "vadd.s32 d0, d0, d10\n"
+      "vadd.s32 d1, d1, d10\n"
+      "vadd.s32 d2, d2, d10\n"
+
+      // Store reduced (rhs added) rows.
+      "vst1.32 {d0[0]}, [%[results]], %[results_stride]\n"
+      "vst1.32 {d1[0]}, [%[results]], %[results_stride]\n"
+      "vst1.32 {d2[0]}, [%[results]], %[results_stride]\n"
+      : [count] "+r"(count), [right] "+r"(right),
+        [results_stride] "+r"(results_stride), [results] "+r"(results),
+        [left] "+r"(left)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "d14", "d15", "cc", "memory");
+}
+
+inline void mul_3x8_2x8_rhsadd(const std::uint8_t* left,
+                               const std::uint8_t* right, std::int32_t count,
+                               std::int32_t* results,
+                               std::int32_t results_stride) {
+  asm volatile(
+      "pld [%[left]]\n"
+      "pld [%[right]]\n"
+      // Clear aggregators.
+      "vmov.i32 q3, #0\n"
+      "vmov.i32 q4, #0\n"
+      "vmov.i32 q5, #0\n"
+      "vmov.i32 q6, q3\n"
+      "vmov.i32 q7, q4\n"
+      "vmov.i32 q8, q5\n"
+
+      // General NxM lanes loop.
+      "1:"
+
+      // Subtract counter.
+      "subs %[count], %[count], #8\n"
+
+      "vld1.8 {d0, d1, d2}, [%[left]:64]!\n"
+      "vld1.8 {d3, d4}, [%[right]:64]!\n"
+      "pld [%[left], #64]\n"
+      "pld [%[right], #64]\n"
+      "vmull.u8 q9, d3, d0\n"
+      "vmull.u8 q10, d4, d0\n"
+      "vmull.u8 q11, d3, d1\n"
+      "vmull.u8 q12, d4, d1\n"
+      "vmull.u8 q13, d3, d2\n"
+      "vmull.u8 q14, d4, d2\n"
+      "vpadal.u16 q3, q9\n"
+      "vpadal.u16 q4, q10\n"
+      "vpadal.u16 q5, q11\n"
+      "vpadal.u16 q6, q12\n"
+      "vpadal.u16 q7, q13\n"
+      "vpadal.u16 q8, q14\n"
+
+      // Loop break.
+      "bne 1b\n"
+
+      "vld1.32 {d18}, [%[right]:64]\n"
+
+      // Horizontal reduce aggregators.
+      "vpadd.u32 d6, d6, d7\n"
+      "vpadd.u32 d8, d8, d9\n"
+      "vpadd.u32 d10, d10, d11\n"
+      "vpadd.u32 d12, d12, d13\n"
+      "vpadd.u32 d14, d14, d15\n"
+      "vpadd.u32 d16, d16, d17\n"
+
+      // Reduce rows.
+      "vpadd.u32 d0, d6, d8\n"
+      "vpadd.u32 d1, d10, d12\n"
+      "vpadd.u32 d2, d14, d16\n"
+
+      // Add rhs offset to aggregated rows.
+      "vadd.s32 d0, d0, d18\n"
+      "vadd.s32 d1, d1, d18\n"
+      "vadd.s32 d2, d2, d18\n"
+
+      // Store reduced (rhs added) rows.
+      "vst1.32 {d0}, [%[results]], %[results_stride]\n"
+      "vst1.32 {d1}, [%[results]], %[results_stride]\n"
+      "vst1.32 {d2}, [%[results]], %[results_stride]\n"
+      : [count] "+r"(count), [right] "+r"(right),
+        [results_stride] "+r"(results_stride), [results] "+r"(results),
+        [left] "+r"(left)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d6", "d7", "d8", "d9", "d10", "d11",
+        "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19", "d20", "d21",
+        "d22", "d23", "d24", "d25", "d26", "d27", "d28", "d29", "cc", "memory");
+}
+
+inline void mul_3x8_3x8_rhsadd(const std::uint8_t* left,
+                               const std::uint8_t* right, std::int32_t count,
+                               std::int32_t* results,
+                               std::int32_t results_stride) {
+  asm volatile(
+      "pld [%[left]]\n"
+      "pld [%[right]]\n"
+      // Clear aggregators.
+      "vmov.i32 q3, #0\n"
+      "vmov.i32 q4, #0\n"
+      "vmov.i32 q5, #0\n"
+      "vmov.i32 q6, q3\n"
+      "vmov.i32 q7, q4\n"
+      "vmov.i32 q8, q5\n"
+      "vmov.i32 q9, q6\n"
+      "vmov.i32 q10, q7\n"
+      "vmov.i32 q11, q8\n"
+
+      // 3x3 lanes loop.
+      "1:"
+
+      // Subtract counter.
+      "subs %[count], %[count], #8\n"
+
+      "vld1.8 {d0, d1, d2}, [%[left]:64]!\n"
+      "vld1.8 {d3, d4, d5}, [%[right]:64]!\n"
+      "pld [%[left], #64]\n"
+      "pld [%[right], #64]\n"
+      "vmull.u8 q12, d0, d3\n"
+      "vmull.u8 q13, d0, d4\n"
+      "vmull.u8 q14, d0, d5\n"
+      "vmull.u8 q15, d1, d3\n"
+      "vpadal.u16 q3, q12\n"
+      "vpadal.u16 q4, q13\n"
+      "vpadal.u16 q5, q14\n"
+      "vpadal.u16 q6, q15\n"
+      "vmull.u8 q12, d1, d4\n"
+      "vmull.u8 q13, d1, d5\n"
+      "vmull.u8 q14, d2, d3\n"
+      "vmull.u8 q15, d2, d4\n"
+      "vmull.u8 q0, d2, d5\n"
+      "vpadal.u16 q7, q12\n"
+      "vpadal.u16 q8, q13\n"
+      "vpadal.u16 q9, q14\n"
+      "vpadal.u16 q10, q15\n"
+      "vpadal.u16 q11, q0\n"
+
+      // Loop break.
+      "bne 1b\n"
+
+      "vld1.32 {q12}, [%[right]:64]\n"
+
+      // Change stride because storing in two ops.
+      "sub %[results_stride], %[results_stride], #8\n"
+
+      // Horizontal reduce aggregators.
+      "vpadd.u32 d6, d6, d7\n"
+      "vpadd.u32 d8, d8, d9\n"
+      "vpadd.u32 d10, d10, d11\n"
+      "vpadd.u32 d12, d12, d13\n"
+      "vpadd.u32 d14, d14, d15\n"
+      "vpadd.u32 d16, d16, d17\n"
+      "vpadd.u32 d18, d18, d19\n"
+      "vpadd.u32 d20, d20, d21\n"
+      "vpadd.u32 d22, d22, d23\n"
+
+      // Reduce rows.
+      "vpadd.u32 d0, d6, d8\n"
+      "vpadd.u32 d1, d10, d10\n"
+      "vpadd.u32 d2, d12, d14\n"
+      "vpadd.u32 d3, d16, d16\n"
+      "vpadd.u32 d4, d18, d20\n"
+      "vpadd.u32 d5, d22, d22\n"
+
+      // Add rhs offset to aggregated rows.
+      "vadd.s32 q0, q0, q12\n"
+      "vadd.s32 q1, q1, q12\n"
+      "vadd.s32 q2, q2, q12\n"
+
+      // Store reduced (rhs added) rows.
+      "vst1.32 {d0}, [%[results]]!\n"
+      "vst1.32 {d1[0]}, [%[results]], %[results_stride]\n"
+
+      "vst1.32 {d2}, [%[results]]!\n"
+      "vst1.32 {d3[0]}, [%[results]], %[results_stride]\n"
+
+      "vst1.32 {d4}, [%[results]]!\n"
+      "vst1.32 {d5[0]}, [%[results]], %[results_stride]\n"
+
+      : [count] "+r"(count), [right] "+r"(right),
+        [results_stride] "+r"(results_stride), [results] "+r"(results),
+        [left] "+r"(left)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19", "d20",
+        "d21", "d22", "d23", "d24", "d25", "d26", "d27", "d28", "d29", "d30",
+        "d31", "cc", "memory");
+}
+
+void qnt_1x8_aligned(const std::int32_t* source, std::int32_t count,
+                     std::int32_t stride, const std::int32_t* offsets,
+                     std::uint8_t* destination, std::int32_t destination_stride,
+                     std::int32_t multiplicative_offset,
+                     std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d8, d9, d10, d11}, [%[source]:64]!\n"
+      "pld [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovn.s32 d13, q5\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.8 {d12}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+void qnt_1x8_1_aligned(const std::int32_t* source, std::int32_t count,
+                       std::int32_t stride, const std::int32_t* offsets,
+                       std::uint8_t* destination,
+                       std::int32_t destination_stride,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "sub %[count], %[count], #1\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d8, d9, d10, d11}, [%[source]:64]!\n"
+      "pld [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovn.s32 d13, q5\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.8 {d12}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d8[0]}, [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.8 {d12[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+void qnt_1x8_2_aligned(const std::int32_t* source, std::int32_t count,
+                       std::int32_t stride, const std::int32_t* offsets,
+                       std::uint8_t* destination,
+                       std::int32_t destination_stride,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "sub %[count], %[count], #2\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d8, d9, d10, d11}, [%[source]:64]!\n"
+      "pld [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovn.s32 d13, q5\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.8 {d12}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d8}, [%[source]:64]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.16 {d12[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+void qnt_1x8_3_aligned(const std::int32_t* source, std::int32_t count,
+                       std::int32_t stride, const std::int32_t* offsets,
+                       std::uint8_t* destination,
+                       std::int32_t destination_stride,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "sub %[count], %[count], #3\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d8, d9, d10, d11}, [%[source]:64]!\n"
+      "pld [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovn.s32 d13, q5\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.8 {d12}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d8}, [%[source]:64]!\n"
+      "vld1.32 {d9[0]}, [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.16 {d12[0]}, [%[destination]]!\n"
+      "vst1.8 {d12[2]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+void qnt_1x8_4_aligned(const std::int32_t* source, std::int32_t count,
+                       std::int32_t stride, const std::int32_t* offsets,
+                       std::uint8_t* destination,
+                       std::int32_t destination_stride,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "sub %[count], %[count], #4\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d8, d9, d10, d11}, [%[source]:64]!\n"
+      "pld [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovn.s32 d13, q5\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.8 {d12}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d8, d9}, [%[source]:64]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.32 {d12[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+void qnt_1x8_5_aligned(const std::int32_t* source, std::int32_t count,
+                       std::int32_t stride, const std::int32_t* offsets,
+                       std::uint8_t* destination,
+                       std::int32_t destination_stride,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "sub %[count], %[count], #5\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d8, d9, d10, d11}, [%[source]:64]!\n"
+      "pld [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovn.s32 d13, q5\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.8 {d12}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d8, d9}, [%[source]:64]!\n"
+      "vld1.32 {d10[0]}, [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovn.s32 d13, q5\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.32 {d12[0]}, [%[destination]]!\n"
+      "vst1.8 {d12[4]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+void qnt_1x8_6_aligned(const std::int32_t* source, std::int32_t count,
+                       std::int32_t stride, const std::int32_t* offsets,
+                       std::uint8_t* destination,
+                       std::int32_t destination_stride,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "sub %[count], %[count], #6\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d8, d9, d10, d11}, [%[source]:64]!\n"
+      "pld [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovn.s32 d13, q5\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.8 {d12}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d8, d9, d10}, [%[source]:64]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovn.s32 d13, q5\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.32 {d12[0]}, [%[destination]]!\n"
+      "vst1.16 {d12[2]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+void qnt_1x8_7_aligned(const std::int32_t* source, std::int32_t count,
+                       std::int32_t stride, const std::int32_t* offsets,
+                       std::uint8_t* destination,
+                       std::int32_t destination_stride,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "sub %[count], %[count], #7\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d8, d9, d10, d11}, [%[source]:64]!\n"
+      "pld [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovn.s32 d13, q5\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.8 {d12}, [%[destination]:64]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d8, d9, d10}, [%[source]:64]!\n"
+      "vld1.32 {d11[0]}, [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovn.s32 d13, q5\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.32 {d12[0]}, [%[destination]]!\n"
+      "vst1.16 {d12[2]}, [%[destination]]!\n"
+      "vst1.8 {d12[6]}, [%[destination]]!\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+void qnt_2x8_aligned(const std::int32_t* source, std::int32_t count,
+                     std::int32_t stride, const std::int32_t* offsets,
+                     std::uint8_t* destination, std::int32_t destination_stride,
+                     std::int32_t multiplicative_offset,
+                     std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d10, d11, d12, d13}, [%[source]:64]!\n"
+      "vld1.32 {d14, d15, d16, d17}, [r0:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d19, q6\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovn.s32 d21, q8\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.8 {d18}, [%[destination]:64]!\n"
+      "vst1.8 {d20}, [r1:64]!\n"
+
+      "bne 1b\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "cc", "memory");
+}
+
+void qnt_2x8_1_aligned(const std::int32_t* source, std::int32_t count,
+                       std::int32_t stride, const std::int32_t* offsets,
+                       std::uint8_t* destination,
+                       std::int32_t destination_stride,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "sub %[count], %[count], #1\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d10, d11, d12, d13}, [%[source]:64]!\n"
+      "vld1.32 {d14, d15, d16, d17}, [r0:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d19, q6\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovn.s32 d21, q8\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.8 {d18}, [%[destination]:64]!\n"
+      "vst1.8 {d20}, [r1:64]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d10[0]}, [%[source]]\n"
+      "vld1.32 {d14[0]}, [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.8 {d18[0]}, [%[destination]]\n"
+      "vst1.8 {d20[0]}, [r1]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "cc", "memory");
+}
+
+void qnt_2x8_2_aligned(const std::int32_t* source, std::int32_t count,
+                       std::int32_t stride, const std::int32_t* offsets,
+                       std::uint8_t* destination,
+                       std::int32_t destination_stride,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "sub %[count], %[count], #2\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d10, d11, d12, d13}, [%[source]:64]!\n"
+      "vld1.32 {d14, d15, d16, d17}, [r0:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d19, q6\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovn.s32 d21, q8\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.8 {d18}, [%[destination]:64]!\n"
+      "vst1.8 {d20}, [r1:64]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d10}, [%[source]:64]\n"
+      "vld1.32 {d14}, [r0:64]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.16 {d18[0]}, [%[destination]]\n"
+      "vst1.16 {d20[0]}, [r1]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "cc", "memory");
+}
+
+void qnt_2x8_3_aligned(const std::int32_t* source, std::int32_t count,
+                       std::int32_t stride, const std::int32_t* offsets,
+                       std::uint8_t* destination,
+                       std::int32_t destination_stride,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "sub %[count], %[count], #3\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d10, d11, d12, d13}, [%[source]:64]!\n"
+      "vld1.32 {d14, d15, d16, d17}, [r0:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d19, q6\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovn.s32 d21, q8\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.8 {d18}, [%[destination]:64]!\n"
+      "vst1.8 {d20}, [r1:64]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d10}, [%[source]:64]!\n"
+      "vld1.32 {d14}, [r0:64]!\n"
+      "vld1.32 {d11[0]}, [%[source]]\n"
+      "vld1.32 {d15[0]}, [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.16 {d18[0]}, [%[destination]]!\n"
+      "vst1.16 {d20[0]}, [r1]!\n"
+      "vst1.8 {d18[2]}, [%[destination]]\n"
+      "vst1.8 {d20[2]}, [r1]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "cc", "memory");
+}
+
+void qnt_2x8_4_aligned(const std::int32_t* source, std::int32_t count,
+                       std::int32_t stride, const std::int32_t* offsets,
+                       std::uint8_t* destination,
+                       std::int32_t destination_stride,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "sub %[count], %[count], #4\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d10, d11, d12, d13}, [%[source]:64]!\n"
+      "vld1.32 {d14, d15, d16, d17}, [r0:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d19, q6\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovn.s32 d21, q8\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.8 {d18}, [%[destination]:64]!\n"
+      "vst1.8 {d20}, [r1:64]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d10, d11}, [%[source]:64]\n"
+      "vld1.32 {d14, d15}, [r0:64]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.32 {d18[0]}, [%[destination]]\n"
+      "vst1.32 {d20[0]}, [r1]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "cc", "memory");
+}
+
+void qnt_2x8_5_aligned(const std::int32_t* source, std::int32_t count,
+                       std::int32_t stride, const std::int32_t* offsets,
+                       std::uint8_t* destination,
+                       std::int32_t destination_stride,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "sub %[count], %[count], #5\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d10, d11, d12, d13}, [%[source]:64]!\n"
+      "vld1.32 {d14, d15, d16, d17}, [r0:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d19, q6\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovn.s32 d21, q8\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.8 {d18}, [%[destination]:64]!\n"
+      "vst1.8 {d20}, [r1:64]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d10, d11}, [%[source]:64]!\n"
+      "vld1.32 {d14, d15}, [r0:64]!\n"
+      "vld1.32 {d12[0]}, [%[source]]\n"
+      "vld1.32 {d16[0]}, [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d19, q6\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovn.s32 d21, q8\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.32 {d18[0]}, [%[destination]]!\n"
+      "vst1.32 {d20[0]}, [r1]!\n"
+      "vst1.8 {d18[4]}, [%[destination]]\n"
+      "vst1.8 {d20[4]}, [r1]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "cc", "memory");
+}
+
+void qnt_2x8_6_aligned(const std::int32_t* source, std::int32_t count,
+                       std::int32_t stride, const std::int32_t* offsets,
+                       std::uint8_t* destination,
+                       std::int32_t destination_stride,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "sub %[count], %[count], #6\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d10, d11, d12, d13}, [%[source]:64]!\n"
+      "vld1.32 {d14, d15, d16, d17}, [r0:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d19, q6\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovn.s32 d21, q8\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.8 {d18}, [%[destination]:64]!\n"
+      "vst1.8 {d20}, [r1:64]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d10, d11, d12}, [%[source]:64]\n"
+      "vld1.32 {d14, d15, d16}, [r0:64]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d19, q6\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovn.s32 d21, q8\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.32 {d18[0]}, [%[destination]]!\n"
+      "vst1.32 {d20[0]}, [r1]!\n"
+      "vst1.16 {d18[2]}, [%[destination]]\n"
+      "vst1.16 {d20[2]}, [r1]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "cc", "memory");
+}
+
+void qnt_2x8_7_aligned(const std::int32_t* source, std::int32_t count,
+                       std::int32_t stride, const std::int32_t* offsets,
+                       std::uint8_t* destination,
+                       std::int32_t destination_stride,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "sub %[count], %[count], #7\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d10, d11, d12, d13}, [%[source]:64]!\n"
+      "vld1.32 {d14, d15, d16, d17}, [r0:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d19, q6\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovn.s32 d21, q8\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.8 {d18}, [%[destination]:64]!\n"
+      "vst1.8 {d20}, [r1:64]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d10, d11, d12}, [%[source]:64]!\n"
+      "vld1.32 {d14, d15, d16}, [r0:64]!\n"
+      "vld1.32 {d13[0]}, [%[source]]\n"
+      "vld1.32 {d17[0]}, [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d19, q6\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovn.s32 d21, q8\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.32 {d18[0]}, [%[destination]]!\n"
+      "vst1.32 {d20[0]}, [r1]!\n"
+      "vst1.16 {d18[2]}, [%[destination]]!\n"
+      "vst1.16 {d20[2]}, [r1]!\n"
+      "vst1.8 {d18[6]}, [%[destination]]!\n"
+      "vst1.8 {d20[6]}, [r1]!\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "cc", "memory");
+}
+
+void qnt_3x8_aligned(const std::int32_t* source, std::int32_t count,
+                     std::int32_t stride, const std::int32_t* offsets,
+                     std::uint8_t* destination, std::int32_t destination_stride,
+                     std::int32_t multiplicative_offset,
+                     std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d10[], d11[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "add r2, r0, %[stride]\n"
+      "add r3, r1, %[destination_stride]\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d12, d13, d14, d15}, [%[source]:64]!\n"
+      "vld1.32 {d16, d17, d18, d19}, [r0:64]!\n"
+      "vld1.32 {d20, d21, d22, d23}, [r2:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "pld [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q9, q9, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vadd.i32 q11, q11, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q9, q9, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vmul.i32 q11, q11, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q9, q9, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vadd.i32 q11, q11, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q9, q9, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vshl.s32 q11, q11, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d25, q7\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d27, q9\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovn.s32 d29, q11\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.8 {d24}, [%[destination]:64]!\n"
+      "vst1.8 {d26}, [r1:64]!\n"
+      "vst1.8 {d28}, [r3:64]!\n"
+
+      "bne 1b\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "r2", "r3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7",
+        "d8", "d9", "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17",
+        "d18", "d19", "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27",
+        "d28", "d29", "cc", "memory");
+}
+
+void qnt_3x8_1_aligned(const std::int32_t* source, std::int32_t count,
+                       std::int32_t stride, const std::int32_t* offsets,
+                       std::uint8_t* destination,
+                       std::int32_t destination_stride,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d10[], d11[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "add r2, r0, %[stride]\n"
+      "add r3, r1, %[destination_stride]\n"
+      "sub %[count], %[count], #1\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d12, d13, d14, d15}, [%[source]:64]!\n"
+      "vld1.32 {d16, d17, d18, d19}, [r0:64]!\n"
+      "vld1.32 {d20, d21, d22, d23}, [r2:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "pld [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q9, q9, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vadd.i32 q11, q11, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q9, q9, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vmul.i32 q11, q11, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q9, q9, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vadd.i32 q11, q11, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q9, q9, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vshl.s32 q11, q11, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d25, q7\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d27, q9\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovn.s32 d29, q11\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.8 {d24}, [%[destination]:64]!\n"
+      "vst1.8 {d26}, [r1:64]!\n"
+      "vst1.8 {d28}, [r3:64]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d12[0]}, [%[source]]\n"
+      "vld1.32 {d16[0]}, [r0]\n"
+      "vld1.32 {d20[0]}, [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.8 {d24[0]}, [%[destination]]\n"
+      "vst1.8 {d26[0]}, [r1]\n"
+      "vst1.8 {d28[0]}, [r3]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "r2", "r3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7",
+        "d8", "d9", "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17",
+        "d18", "d19", "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27",
+        "d28", "d29", "cc", "memory");
+}
+
+void qnt_3x8_2_aligned(const std::int32_t* source, std::int32_t count,
+                       std::int32_t stride, const std::int32_t* offsets,
+                       std::uint8_t* destination,
+                       std::int32_t destination_stride,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d10[], d11[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "add r2, r0, %[stride]\n"
+      "add r3, r1, %[destination_stride]\n"
+      "sub %[count], %[count], #2\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d12, d13, d14, d15}, [%[source]:64]!\n"
+      "vld1.32 {d16, d17, d18, d19}, [r0:64]!\n"
+      "vld1.32 {d20, d21, d22, d23}, [r2:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "pld [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q9, q9, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vadd.i32 q11, q11, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q9, q9, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vmul.i32 q11, q11, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q9, q9, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vadd.i32 q11, q11, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q9, q9, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vshl.s32 q11, q11, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d25, q7\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d27, q9\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovn.s32 d29, q11\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.8 {d24}, [%[destination]:64]!\n"
+      "vst1.8 {d26}, [r1:64]!\n"
+      "vst1.8 {d28}, [r3:64]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d12}, [%[source]:64]\n"
+      "vld1.32 {d16}, [r0:64]\n"
+      "vld1.32 {d20}, [r2:64]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.16 {d24[0]}, [%[destination]]\n"
+      "vst1.16 {d26[0]}, [r1]\n"
+      "vst1.16 {d28[0]}, [r3]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "r2", "r3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7",
+        "d8", "d9", "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17",
+        "d18", "d19", "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27",
+        "d28", "d29", "cc", "memory");
+}
+
+void qnt_3x8_3_aligned(const std::int32_t* source, std::int32_t count,
+                       std::int32_t stride, const std::int32_t* offsets,
+                       std::uint8_t* destination,
+                       std::int32_t destination_stride,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d10[], d11[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "add r2, r0, %[stride]\n"
+      "add r3, r1, %[destination_stride]\n"
+      "sub %[count], %[count], #3\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d12, d13, d14, d15}, [%[source]:64]!\n"
+      "vld1.32 {d16, d17, d18, d19}, [r0:64]!\n"
+      "vld1.32 {d20, d21, d22, d23}, [r2:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "pld [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q9, q9, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vadd.i32 q11, q11, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q9, q9, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vmul.i32 q11, q11, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q9, q9, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vadd.i32 q11, q11, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q9, q9, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vshl.s32 q11, q11, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d25, q7\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d27, q9\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovn.s32 d29, q11\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.8 {d24}, [%[destination]:64]!\n"
+      "vst1.8 {d26}, [r1:64]!\n"
+      "vst1.8 {d28}, [r3:64]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d12}, [%[source]:64]!\n"
+      "vld1.32 {d16}, [r0:64]!\n"
+      "vld1.32 {d20}, [r2:64]!\n"
+      "vld1.32 {d13[0]}, [%[source]]\n"
+      "vld1.32 {d17[0]}, [r0]\n"
+      "vld1.32 {d21[0]}, [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.16 {d24[0]}, [%[destination]]!\n"
+      "vst1.16 {d26[0]}, [r1]!\n"
+      "vst1.16 {d28[0]}, [r3]!\n"
+      "vst1.8 {d24[2]}, [%[destination]]\n"
+      "vst1.8 {d26[2]}, [r1]\n"
+      "vst1.8 {d28[2]}, [r3]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "r2", "r3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7",
+        "d8", "d9", "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17",
+        "d18", "d19", "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27",
+        "d28", "d29", "cc", "memory");
+}
+
+void qnt_3x8_4_aligned(const std::int32_t* source, std::int32_t count,
+                       std::int32_t stride, const std::int32_t* offsets,
+                       std::uint8_t* destination,
+                       std::int32_t destination_stride,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d10[], d11[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "add r2, r0, %[stride]\n"
+      "add r3, r1, %[destination_stride]\n"
+      "sub %[count], %[count], #4\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d12, d13, d14, d15}, [%[source]:64]!\n"
+      "vld1.32 {d16, d17, d18, d19}, [r0:64]!\n"
+      "vld1.32 {d20, d21, d22, d23}, [r2:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "pld [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q9, q9, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vadd.i32 q11, q11, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q9, q9, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vmul.i32 q11, q11, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q9, q9, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vadd.i32 q11, q11, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q9, q9, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vshl.s32 q11, q11, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d25, q7\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d27, q9\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovn.s32 d29, q11\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.8 {d24}, [%[destination]:64]!\n"
+      "vst1.8 {d26}, [r1:64]!\n"
+      "vst1.8 {d28}, [r3:64]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d12, d13}, [%[source]:64]\n"
+      "vld1.32 {d16, d17}, [r0:64]\n"
+      "vld1.32 {d20, d21}, [r2:64]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.32 {d24[0]}, [%[destination]]\n"
+      "vst1.32 {d26[0]}, [r1]\n"
+      "vst1.32 {d28[0]}, [r3]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "r2", "r3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7",
+        "d8", "d9", "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17",
+        "d18", "d19", "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27",
+        "d28", "d29", "cc", "memory");
+}
+
+void qnt_3x8_5_aligned(const std::int32_t* source, std::int32_t count,
+                       std::int32_t stride, const std::int32_t* offsets,
+                       std::uint8_t* destination,
+                       std::int32_t destination_stride,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d10[], d11[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "add r2, r0, %[stride]\n"
+      "add r3, r1, %[destination_stride]\n"
+      "sub %[count], %[count], #5\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d12, d13, d14, d15}, [%[source]:64]!\n"
+      "vld1.32 {d16, d17, d18, d19}, [r0:64]!\n"
+      "vld1.32 {d20, d21, d22, d23}, [r2:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "pld [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q9, q9, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vadd.i32 q11, q11, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q9, q9, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vmul.i32 q11, q11, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q9, q9, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vadd.i32 q11, q11, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q9, q9, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vshl.s32 q11, q11, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d25, q7\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d27, q9\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovn.s32 d29, q11\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.8 {d24}, [%[destination]:64]!\n"
+      "vst1.8 {d26}, [r1:64]!\n"
+      "vst1.8 {d28}, [r3:64]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d12, d13}, [%[source]:64]!\n"
+      "vld1.32 {d16, d17}, [r0:64]!\n"
+      "vld1.32 {d20, d21}, [r2:64]!\n"
+      "vld1.32 {d14[0]}, [%[source]]\n"
+      "vld1.32 {d18[0]}, [r0]\n"
+      "vld1.32 {d22[0]}, [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q9, q9, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vadd.i32 q11, q11, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q9, q9, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vmul.i32 q11, q11, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q9, q9, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vadd.i32 q11, q11, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q9, q9, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vshl.s32 q11, q11, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d25, q7\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d27, q9\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovn.s32 d29, q11\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.32 {d24[0]}, [%[destination]]!\n"
+      "vst1.32 {d26[0]}, [r1]!\n"
+      "vst1.32 {d28[0]}, [r3]!\n"
+      "vst1.8 {d24[4]}, [%[destination]]\n"
+      "vst1.8 {d26[4]}, [r1]\n"
+      "vst1.8 {d28[4]}, [r3]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "r2", "r3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7",
+        "d8", "d9", "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17",
+        "d18", "d19", "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27",
+        "d28", "d29", "cc", "memory");
+}
+
+void qnt_3x8_6_aligned(const std::int32_t* source, std::int32_t count,
+                       std::int32_t stride, const std::int32_t* offsets,
+                       std::uint8_t* destination,
+                       std::int32_t destination_stride,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d10[], d11[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "add r2, r0, %[stride]\n"
+      "add r3, r1, %[destination_stride]\n"
+      "sub %[count], %[count], #6\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d12, d13, d14, d15}, [%[source]:64]!\n"
+      "vld1.32 {d16, d17, d18, d19}, [r0:64]!\n"
+      "vld1.32 {d20, d21, d22, d23}, [r2:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "pld [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q9, q9, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vadd.i32 q11, q11, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q9, q9, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vmul.i32 q11, q11, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q9, q9, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vadd.i32 q11, q11, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q9, q9, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vshl.s32 q11, q11, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d25, q7\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d27, q9\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovn.s32 d29, q11\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.8 {d24}, [%[destination]:64]!\n"
+      "vst1.8 {d26}, [r1:64]!\n"
+      "vst1.8 {d28}, [r3:64]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d12, d13, d14}, [%[source]:64]\n"
+      "vld1.32 {d16, d17, d18}, [r0:64]\n"
+      "vld1.32 {d20, d21, d22}, [r2:64]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q9, q9, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vadd.i32 q11, q11, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q9, q9, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vmul.i32 q11, q11, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q9, q9, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vadd.i32 q11, q11, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q9, q9, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vshl.s32 q11, q11, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d25, q7\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d27, q9\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovn.s32 d29, q11\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.32 {d24[0]}, [%[destination]]!\n"
+      "vst1.32 {d26[0]}, [r1]!\n"
+      "vst1.32 {d28[0]}, [r3]!\n"
+      "vst1.16 {d24[2]}, [%[destination]]\n"
+      "vst1.16 {d26[2]}, [r1]\n"
+      "vst1.16 {d28[2]}, [r3]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "r2", "r3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7",
+        "d8", "d9", "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17",
+        "d18", "d19", "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27",
+        "d28", "d29", "cc", "memory");
+}
+
+void qnt_3x8_7_aligned(const std::int32_t* source, std::int32_t count,
+                       std::int32_t stride, const std::int32_t* offsets,
+                       std::uint8_t* destination,
+                       std::int32_t destination_stride,
+                       std::int32_t multiplicative_offset,
+                       std::int32_t rounding_offset, std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d10[], d11[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "add r2, r0, %[stride]\n"
+      "add r3, r1, %[destination_stride]\n"
+      "sub %[count], %[count], #7\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d12, d13, d14, d15}, [%[source]:64]!\n"
+      "vld1.32 {d16, d17, d18, d19}, [r0:64]!\n"
+      "vld1.32 {d20, d21, d22, d23}, [r2:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "pld [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q9, q9, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vadd.i32 q11, q11, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q9, q9, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vmul.i32 q11, q11, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q9, q9, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vadd.i32 q11, q11, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q9, q9, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vshl.s32 q11, q11, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d25, q7\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d27, q9\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovn.s32 d29, q11\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.8 {d24}, [%[destination]:64]!\n"
+      "vst1.8 {d26}, [r1:64]!\n"
+      "vst1.8 {d28}, [r3:64]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d12, d13, d14}, [%[source]:64]!\n"
+      "vld1.32 {d16, d17, d18}, [r0:64]!\n"
+      "vld1.32 {d20, d21, d22}, [r2:64]!\n"
+      "vld1.32 {d15[0]}, [%[source]]\n"
+      "vld1.32 {d19[0]}, [r0]\n"
+      "vld1.32 {d23[0]}, [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q9, q9, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vadd.i32 q11, q11, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q9, q9, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vmul.i32 q11, q11, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q9, q9, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vadd.i32 q11, q11, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q9, q9, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vshl.s32 q11, q11, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d25, q7\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d27, q9\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovn.s32 d29, q11\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.32 {d24[0]}, [%[destination]]!\n"
+      "vst1.32 {d26[0]}, [r1]!\n"
+      "vst1.32 {d28[0]}, [r3]!\n"
+      "vst1.16 {d24[2]}, [%[destination]]!\n"
+      "vst1.16 {d26[2]}, [r1]!\n"
+      "vst1.16 {d28[2]}, [r3]!\n"
+      "vst1.8 {d24[6]}, [%[destination]]!\n"
+      "vst1.8 {d26[6]}, [r1]!\n"
+      "vst1.8 {d28[6]}, [r3]!\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "r2", "r3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7",
+        "d8", "d9", "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17",
+        "d18", "d19", "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27",
+        "d28", "d29", "cc", "memory");
+}
+
+void qnt_1x8(const std::int32_t* source, std::int32_t count,
+             std::int32_t stride, const std::int32_t* offsets,
+             std::uint8_t* destination, std::int32_t destination_stride,
+             std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+             std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d8, d9, d10, d11}, [%[source]:64]!\n"
+      "pld [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovn.s32 d13, q5\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.8 {d12}, [%[destination]]!\n"
+
+      "bne 1b\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+void qnt_1x8_1(const std::int32_t* source, std::int32_t count,
+               std::int32_t stride, const std::int32_t* offsets,
+               std::uint8_t* destination, std::int32_t destination_stride,
+               std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+               std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "sub %[count], %[count], #1\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d8, d9, d10, d11}, [%[source]:64]!\n"
+      "pld [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovn.s32 d13, q5\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.8 {d12}, [%[destination]]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d8[0]}, [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.8 {d12[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+void qnt_1x8_2(const std::int32_t* source, std::int32_t count,
+               std::int32_t stride, const std::int32_t* offsets,
+               std::uint8_t* destination, std::int32_t destination_stride,
+               std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+               std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "sub %[count], %[count], #2\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d8, d9, d10, d11}, [%[source]:64]!\n"
+      "pld [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovn.s32 d13, q5\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.8 {d12}, [%[destination]]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d8}, [%[source]:64]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.16 {d12[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+void qnt_1x8_3(const std::int32_t* source, std::int32_t count,
+               std::int32_t stride, const std::int32_t* offsets,
+               std::uint8_t* destination, std::int32_t destination_stride,
+               std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+               std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "sub %[count], %[count], #3\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d8, d9, d10, d11}, [%[source]:64]!\n"
+      "pld [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovn.s32 d13, q5\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.8 {d12}, [%[destination]]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d8}, [%[source]:64]!\n"
+      "vld1.32 {d9[0]}, [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.16 {d12[0]}, [%[destination]]!\n"
+      "vst1.8 {d12[2]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+void qnt_1x8_4(const std::int32_t* source, std::int32_t count,
+               std::int32_t stride, const std::int32_t* offsets,
+               std::uint8_t* destination, std::int32_t destination_stride,
+               std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+               std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "sub %[count], %[count], #4\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d8, d9, d10, d11}, [%[source]:64]!\n"
+      "pld [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovn.s32 d13, q5\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.8 {d12}, [%[destination]]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d8, d9}, [%[source]:64]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.32 {d12[0]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+void qnt_1x8_5(const std::int32_t* source, std::int32_t count,
+               std::int32_t stride, const std::int32_t* offsets,
+               std::uint8_t* destination, std::int32_t destination_stride,
+               std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+               std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "sub %[count], %[count], #5\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d8, d9, d10, d11}, [%[source]:64]!\n"
+      "pld [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovn.s32 d13, q5\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.8 {d12}, [%[destination]]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d8, d9}, [%[source]:64]!\n"
+      "vld1.32 {d10[0]}, [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovn.s32 d13, q5\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.32 {d12[0]}, [%[destination]]!\n"
+      "vst1.8 {d12[4]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+void qnt_1x8_6(const std::int32_t* source, std::int32_t count,
+               std::int32_t stride, const std::int32_t* offsets,
+               std::uint8_t* destination, std::int32_t destination_stride,
+               std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+               std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "sub %[count], %[count], #6\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d8, d9, d10, d11}, [%[source]:64]!\n"
+      "pld [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovn.s32 d13, q5\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.8 {d12}, [%[destination]]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d8, d9, d10}, [%[source]:64]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovn.s32 d13, q5\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.32 {d12[0]}, [%[destination]]!\n"
+      "vst1.16 {d12[2]}, [%[destination]]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+void qnt_1x8_7(const std::int32_t* source, std::int32_t count,
+               std::int32_t stride, const std::int32_t* offsets,
+               std::uint8_t* destination, std::int32_t destination_stride,
+               std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+               std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "sub %[count], %[count], #7\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d8, d9, d10, d11}, [%[source]:64]!\n"
+      "pld [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovn.s32 d13, q5\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.8 {d12}, [%[destination]]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d8, d9, d10}, [%[source]:64]!\n"
+      "vld1.32 {d11[0]}, [%[source]]\n"
+      "vadd.i32 q4, q4, q3\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vmul.i32 q4, q4, q0\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vadd.i32 q4, q4, q1\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vshl.s32 q4, q4, q2\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vqmovn.s32 d12, q4\n"
+      "vqmovn.s32 d13, q5\n"
+      "vqmovun.s16 d12, q6\n"
+      "vst1.32 {d12[0]}, [%[destination]]!\n"
+      "vst1.16 {d12[2]}, [%[destination]]!\n"
+      "vst1.8 {d12[6]}, [%[destination]]!\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+void qnt_2x8(const std::int32_t* source, std::int32_t count,
+             std::int32_t stride, const std::int32_t* offsets,
+             std::uint8_t* destination, std::int32_t destination_stride,
+             std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+             std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d10, d11, d12, d13}, [%[source]:64]!\n"
+      "vld1.32 {d14, d15, d16, d17}, [r0:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d19, q6\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovn.s32 d21, q8\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.8 {d18}, [%[destination]]!\n"
+      "vst1.8 {d20}, [r1]!\n"
+
+      "bne 1b\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "cc", "memory");
+}
+
+void qnt_2x8_1(const std::int32_t* source, std::int32_t count,
+               std::int32_t stride, const std::int32_t* offsets,
+               std::uint8_t* destination, std::int32_t destination_stride,
+               std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+               std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "sub %[count], %[count], #1\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d10, d11, d12, d13}, [%[source]:64]!\n"
+      "vld1.32 {d14, d15, d16, d17}, [r0:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d19, q6\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovn.s32 d21, q8\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.8 {d18}, [%[destination]]!\n"
+      "vst1.8 {d20}, [r1]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d10[0]}, [%[source]]\n"
+      "vld1.32 {d14[0]}, [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.8 {d18[0]}, [%[destination]]\n"
+      "vst1.8 {d20[0]}, [r1]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "cc", "memory");
+}
+
+void qnt_2x8_2(const std::int32_t* source, std::int32_t count,
+               std::int32_t stride, const std::int32_t* offsets,
+               std::uint8_t* destination, std::int32_t destination_stride,
+               std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+               std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "sub %[count], %[count], #2\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d10, d11, d12, d13}, [%[source]:64]!\n"
+      "vld1.32 {d14, d15, d16, d17}, [r0:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d19, q6\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovn.s32 d21, q8\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.8 {d18}, [%[destination]]!\n"
+      "vst1.8 {d20}, [r1]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d10}, [%[source]:64]\n"
+      "vld1.32 {d14}, [r0:64]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.16 {d18[0]}, [%[destination]]\n"
+      "vst1.16 {d20[0]}, [r1]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "cc", "memory");
+}
+
+void qnt_2x8_3(const std::int32_t* source, std::int32_t count,
+               std::int32_t stride, const std::int32_t* offsets,
+               std::uint8_t* destination, std::int32_t destination_stride,
+               std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+               std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "sub %[count], %[count], #3\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d10, d11, d12, d13}, [%[source]:64]!\n"
+      "vld1.32 {d14, d15, d16, d17}, [r0:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d19, q6\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovn.s32 d21, q8\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.8 {d18}, [%[destination]]!\n"
+      "vst1.8 {d20}, [r1]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d10}, [%[source]:64]!\n"
+      "vld1.32 {d14}, [r0:64]!\n"
+      "vld1.32 {d11[0]}, [%[source]]\n"
+      "vld1.32 {d15[0]}, [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.16 {d18[0]}, [%[destination]]!\n"
+      "vst1.16 {d20[0]}, [r1]!\n"
+      "vst1.8 {d18[2]}, [%[destination]]\n"
+      "vst1.8 {d20[2]}, [r1]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "cc", "memory");
+}
+
+void qnt_2x8_4(const std::int32_t* source, std::int32_t count,
+               std::int32_t stride, const std::int32_t* offsets,
+               std::uint8_t* destination, std::int32_t destination_stride,
+               std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+               std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "sub %[count], %[count], #4\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d10, d11, d12, d13}, [%[source]:64]!\n"
+      "vld1.32 {d14, d15, d16, d17}, [r0:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d19, q6\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovn.s32 d21, q8\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.8 {d18}, [%[destination]]!\n"
+      "vst1.8 {d20}, [r1]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d10, d11}, [%[source]:64]\n"
+      "vld1.32 {d14, d15}, [r0:64]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.32 {d18[0]}, [%[destination]]\n"
+      "vst1.32 {d20[0]}, [r1]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "cc", "memory");
+}
+
+void qnt_2x8_5(const std::int32_t* source, std::int32_t count,
+               std::int32_t stride, const std::int32_t* offsets,
+               std::uint8_t* destination, std::int32_t destination_stride,
+               std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+               std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "sub %[count], %[count], #5\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d10, d11, d12, d13}, [%[source]:64]!\n"
+      "vld1.32 {d14, d15, d16, d17}, [r0:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d19, q6\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovn.s32 d21, q8\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.8 {d18}, [%[destination]]!\n"
+      "vst1.8 {d20}, [r1]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d10, d11}, [%[source]:64]!\n"
+      "vld1.32 {d14, d15}, [r0:64]!\n"
+      "vld1.32 {d12[0]}, [%[source]]\n"
+      "vld1.32 {d16[0]}, [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d19, q6\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovn.s32 d21, q8\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.32 {d18[0]}, [%[destination]]!\n"
+      "vst1.32 {d20[0]}, [r1]!\n"
+      "vst1.8 {d18[4]}, [%[destination]]\n"
+      "vst1.8 {d20[4]}, [r1]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "cc", "memory");
+}
+
+void qnt_2x8_6(const std::int32_t* source, std::int32_t count,
+               std::int32_t stride, const std::int32_t* offsets,
+               std::uint8_t* destination, std::int32_t destination_stride,
+               std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+               std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "sub %[count], %[count], #6\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d10, d11, d12, d13}, [%[source]:64]!\n"
+      "vld1.32 {d14, d15, d16, d17}, [r0:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d19, q6\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovn.s32 d21, q8\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.8 {d18}, [%[destination]]!\n"
+      "vst1.8 {d20}, [r1]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d10, d11, d12}, [%[source]:64]\n"
+      "vld1.32 {d14, d15, d16}, [r0:64]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d19, q6\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovn.s32 d21, q8\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.32 {d18[0]}, [%[destination]]!\n"
+      "vst1.32 {d20[0]}, [r1]!\n"
+      "vst1.16 {d18[2]}, [%[destination]]\n"
+      "vst1.16 {d20[2]}, [r1]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "cc", "memory");
+}
+
+void qnt_2x8_7(const std::int32_t* source, std::int32_t count,
+               std::int32_t stride, const std::int32_t* offsets,
+               std::uint8_t* destination, std::int32_t destination_stride,
+               std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+               std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "sub %[count], %[count], #7\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d10, d11, d12, d13}, [%[source]:64]!\n"
+      "vld1.32 {d14, d15, d16, d17}, [r0:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d19, q6\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovn.s32 d21, q8\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.8 {d18}, [%[destination]]!\n"
+      "vst1.8 {d20}, [r1]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d10, d11, d12}, [%[source]:64]!\n"
+      "vld1.32 {d14, d15, d16}, [r0:64]!\n"
+      "vld1.32 {d13[0]}, [%[source]]\n"
+      "vld1.32 {d17[0]}, [r0]\n"
+      "vadd.i32 q5, q5, q3\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q4\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vmul.i32 q5, q5, q0\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vadd.i32 q5, q5, q1\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vshl.s32 q5, q5, q2\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vqmovn.s32 d18, q5\n"
+      "vqmovn.s32 d19, q6\n"
+      "vqmovn.s32 d20, q7\n"
+      "vqmovn.s32 d21, q8\n"
+      "vqmovun.s16 d18, q9\n"
+      "vqmovun.s16 d20, q10\n"
+      "vst1.32 {d18[0]}, [%[destination]]!\n"
+      "vst1.32 {d20[0]}, [r1]!\n"
+      "vst1.16 {d18[2]}, [%[destination]]!\n"
+      "vst1.16 {d20[2]}, [r1]!\n"
+      "vst1.8 {d18[6]}, [%[destination]]!\n"
+      "vst1.8 {d20[6]}, [r1]!\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "cc", "memory");
+}
+
+void qnt_3x8(const std::int32_t* source, std::int32_t count,
+             std::int32_t stride, const std::int32_t* offsets,
+             std::uint8_t* destination, std::int32_t destination_stride,
+             std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+             std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d10[], d11[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "add r2, r0, %[stride]\n"
+      "add r3, r1, %[destination_stride]\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d12, d13, d14, d15}, [%[source]:64]!\n"
+      "vld1.32 {d16, d17, d18, d19}, [r0:64]!\n"
+      "vld1.32 {d20, d21, d22, d23}, [r2:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "pld [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q9, q9, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vadd.i32 q11, q11, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q9, q9, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vmul.i32 q11, q11, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q9, q9, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vadd.i32 q11, q11, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q9, q9, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vshl.s32 q11, q11, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d25, q7\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d27, q9\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovn.s32 d29, q11\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.8 {d24}, [%[destination]]!\n"
+      "vst1.8 {d26}, [r1]!\n"
+      "vst1.8 {d28}, [r3]!\n"
+
+      "bne 1b\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "r2", "r3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7",
+        "d8", "d9", "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17",
+        "d18", "d19", "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27",
+        "d28", "d29", "cc", "memory");
+}
+
+void qnt_3x8_1(const std::int32_t* source, std::int32_t count,
+               std::int32_t stride, const std::int32_t* offsets,
+               std::uint8_t* destination, std::int32_t destination_stride,
+               std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+               std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d10[], d11[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "add r2, r0, %[stride]\n"
+      "add r3, r1, %[destination_stride]\n"
+      "sub %[count], %[count], #1\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d12, d13, d14, d15}, [%[source]:64]!\n"
+      "vld1.32 {d16, d17, d18, d19}, [r0:64]!\n"
+      "vld1.32 {d20, d21, d22, d23}, [r2:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "pld [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q9, q9, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vadd.i32 q11, q11, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q9, q9, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vmul.i32 q11, q11, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q9, q9, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vadd.i32 q11, q11, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q9, q9, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vshl.s32 q11, q11, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d25, q7\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d27, q9\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovn.s32 d29, q11\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.8 {d24}, [%[destination]]!\n"
+      "vst1.8 {d26}, [r1]!\n"
+      "vst1.8 {d28}, [r3]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d12[0]}, [%[source]]\n"
+      "vld1.32 {d16[0]}, [r0]\n"
+      "vld1.32 {d20[0]}, [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.8 {d24[0]}, [%[destination]]\n"
+      "vst1.8 {d26[0]}, [r1]\n"
+      "vst1.8 {d28[0]}, [r3]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "r2", "r3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7",
+        "d8", "d9", "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17",
+        "d18", "d19", "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27",
+        "d28", "d29", "cc", "memory");
+}
+
+void qnt_3x8_2(const std::int32_t* source, std::int32_t count,
+               std::int32_t stride, const std::int32_t* offsets,
+               std::uint8_t* destination, std::int32_t destination_stride,
+               std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+               std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d10[], d11[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "add r2, r0, %[stride]\n"
+      "add r3, r1, %[destination_stride]\n"
+      "sub %[count], %[count], #2\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d12, d13, d14, d15}, [%[source]:64]!\n"
+      "vld1.32 {d16, d17, d18, d19}, [r0:64]!\n"
+      "vld1.32 {d20, d21, d22, d23}, [r2:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "pld [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q9, q9, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vadd.i32 q11, q11, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q9, q9, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vmul.i32 q11, q11, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q9, q9, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vadd.i32 q11, q11, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q9, q9, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vshl.s32 q11, q11, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d25, q7\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d27, q9\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovn.s32 d29, q11\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.8 {d24}, [%[destination]]!\n"
+      "vst1.8 {d26}, [r1]!\n"
+      "vst1.8 {d28}, [r3]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d12}, [%[source]:64]\n"
+      "vld1.32 {d16}, [r0:64]\n"
+      "vld1.32 {d20}, [r2:64]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.16 {d24[0]}, [%[destination]]\n"
+      "vst1.16 {d26[0]}, [r1]\n"
+      "vst1.16 {d28[0]}, [r3]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "r2", "r3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7",
+        "d8", "d9", "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17",
+        "d18", "d19", "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27",
+        "d28", "d29", "cc", "memory");
+}
+
+void qnt_3x8_3(const std::int32_t* source, std::int32_t count,
+               std::int32_t stride, const std::int32_t* offsets,
+               std::uint8_t* destination, std::int32_t destination_stride,
+               std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+               std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d10[], d11[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "add r2, r0, %[stride]\n"
+      "add r3, r1, %[destination_stride]\n"
+      "sub %[count], %[count], #3\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d12, d13, d14, d15}, [%[source]:64]!\n"
+      "vld1.32 {d16, d17, d18, d19}, [r0:64]!\n"
+      "vld1.32 {d20, d21, d22, d23}, [r2:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "pld [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q9, q9, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vadd.i32 q11, q11, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q9, q9, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vmul.i32 q11, q11, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q9, q9, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vadd.i32 q11, q11, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q9, q9, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vshl.s32 q11, q11, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d25, q7\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d27, q9\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovn.s32 d29, q11\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.8 {d24}, [%[destination]]!\n"
+      "vst1.8 {d26}, [r1]!\n"
+      "vst1.8 {d28}, [r3]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d12}, [%[source]:64]!\n"
+      "vld1.32 {d16}, [r0:64]!\n"
+      "vld1.32 {d20}, [r2:64]!\n"
+      "vld1.32 {d13[0]}, [%[source]]\n"
+      "vld1.32 {d17[0]}, [r0]\n"
+      "vld1.32 {d21[0]}, [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.16 {d24[0]}, [%[destination]]!\n"
+      "vst1.16 {d26[0]}, [r1]!\n"
+      "vst1.16 {d28[0]}, [r3]!\n"
+      "vst1.8 {d24[2]}, [%[destination]]\n"
+      "vst1.8 {d26[2]}, [r1]\n"
+      "vst1.8 {d28[2]}, [r3]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "r2", "r3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7",
+        "d8", "d9", "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17",
+        "d18", "d19", "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27",
+        "d28", "d29", "cc", "memory");
+}
+
+void qnt_3x8_4(const std::int32_t* source, std::int32_t count,
+               std::int32_t stride, const std::int32_t* offsets,
+               std::uint8_t* destination, std::int32_t destination_stride,
+               std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+               std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d10[], d11[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "add r2, r0, %[stride]\n"
+      "add r3, r1, %[destination_stride]\n"
+      "sub %[count], %[count], #4\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d12, d13, d14, d15}, [%[source]:64]!\n"
+      "vld1.32 {d16, d17, d18, d19}, [r0:64]!\n"
+      "vld1.32 {d20, d21, d22, d23}, [r2:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "pld [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q9, q9, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vadd.i32 q11, q11, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q9, q9, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vmul.i32 q11, q11, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q9, q9, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vadd.i32 q11, q11, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q9, q9, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vshl.s32 q11, q11, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d25, q7\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d27, q9\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovn.s32 d29, q11\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.8 {d24}, [%[destination]]!\n"
+      "vst1.8 {d26}, [r1]!\n"
+      "vst1.8 {d28}, [r3]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d12, d13}, [%[source]:64]\n"
+      "vld1.32 {d16, d17}, [r0:64]\n"
+      "vld1.32 {d20, d21}, [r2:64]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.32 {d24[0]}, [%[destination]]\n"
+      "vst1.32 {d26[0]}, [r1]\n"
+      "vst1.32 {d28[0]}, [r3]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "r2", "r3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7",
+        "d8", "d9", "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17",
+        "d18", "d19", "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27",
+        "d28", "d29", "cc", "memory");
+}
+
+void qnt_3x8_5(const std::int32_t* source, std::int32_t count,
+               std::int32_t stride, const std::int32_t* offsets,
+               std::uint8_t* destination, std::int32_t destination_stride,
+               std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+               std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d10[], d11[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "add r2, r0, %[stride]\n"
+      "add r3, r1, %[destination_stride]\n"
+      "sub %[count], %[count], #5\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d12, d13, d14, d15}, [%[source]:64]!\n"
+      "vld1.32 {d16, d17, d18, d19}, [r0:64]!\n"
+      "vld1.32 {d20, d21, d22, d23}, [r2:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "pld [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q9, q9, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vadd.i32 q11, q11, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q9, q9, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vmul.i32 q11, q11, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q9, q9, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vadd.i32 q11, q11, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q9, q9, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vshl.s32 q11, q11, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d25, q7\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d27, q9\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovn.s32 d29, q11\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.8 {d24}, [%[destination]]!\n"
+      "vst1.8 {d26}, [r1]!\n"
+      "vst1.8 {d28}, [r3]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d12, d13}, [%[source]:64]!\n"
+      "vld1.32 {d16, d17}, [r0:64]!\n"
+      "vld1.32 {d20, d21}, [r2:64]!\n"
+      "vld1.32 {d14[0]}, [%[source]]\n"
+      "vld1.32 {d18[0]}, [r0]\n"
+      "vld1.32 {d22[0]}, [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q9, q9, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vadd.i32 q11, q11, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q9, q9, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vmul.i32 q11, q11, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q9, q9, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vadd.i32 q11, q11, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q9, q9, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vshl.s32 q11, q11, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d25, q7\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d27, q9\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovn.s32 d29, q11\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.32 {d24[0]}, [%[destination]]!\n"
+      "vst1.32 {d26[0]}, [r1]!\n"
+      "vst1.32 {d28[0]}, [r3]!\n"
+      "vst1.8 {d24[4]}, [%[destination]]\n"
+      "vst1.8 {d26[4]}, [r1]\n"
+      "vst1.8 {d28[4]}, [r3]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "r2", "r3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7",
+        "d8", "d9", "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17",
+        "d18", "d19", "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27",
+        "d28", "d29", "cc", "memory");
+}
+
+void qnt_3x8_6(const std::int32_t* source, std::int32_t count,
+               std::int32_t stride, const std::int32_t* offsets,
+               std::uint8_t* destination, std::int32_t destination_stride,
+               std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+               std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d10[], d11[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "add r2, r0, %[stride]\n"
+      "add r3, r1, %[destination_stride]\n"
+      "sub %[count], %[count], #6\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d12, d13, d14, d15}, [%[source]:64]!\n"
+      "vld1.32 {d16, d17, d18, d19}, [r0:64]!\n"
+      "vld1.32 {d20, d21, d22, d23}, [r2:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "pld [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q9, q9, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vadd.i32 q11, q11, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q9, q9, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vmul.i32 q11, q11, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q9, q9, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vadd.i32 q11, q11, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q9, q9, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vshl.s32 q11, q11, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d25, q7\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d27, q9\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovn.s32 d29, q11\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.8 {d24}, [%[destination]]!\n"
+      "vst1.8 {d26}, [r1]!\n"
+      "vst1.8 {d28}, [r3]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d12, d13, d14}, [%[source]:64]\n"
+      "vld1.32 {d16, d17, d18}, [r0:64]\n"
+      "vld1.32 {d20, d21, d22}, [r2:64]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q9, q9, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vadd.i32 q11, q11, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q9, q9, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vmul.i32 q11, q11, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q9, q9, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vadd.i32 q11, q11, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q9, q9, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vshl.s32 q11, q11, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d25, q7\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d27, q9\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovn.s32 d29, q11\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.32 {d24[0]}, [%[destination]]!\n"
+      "vst1.32 {d26[0]}, [r1]!\n"
+      "vst1.32 {d28[0]}, [r3]!\n"
+      "vst1.16 {d24[2]}, [%[destination]]\n"
+      "vst1.16 {d26[2]}, [r1]\n"
+      "vst1.16 {d28[2]}, [r3]\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "r2", "r3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7",
+        "d8", "d9", "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17",
+        "d18", "d19", "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27",
+        "d28", "d29", "cc", "memory");
+}
+
+void qnt_3x8_7(const std::int32_t* source, std::int32_t count,
+               std::int32_t stride, const std::int32_t* offsets,
+               std::uint8_t* destination, std::int32_t destination_stride,
+               std::int32_t multiplicative_offset, std::int32_t rounding_offset,
+               std::int32_t shift) {
+  asm volatile(
+      "vdup.32 q0, %[multiplicative_offset]\n"
+      "vdup.32 q1, %[rounding_offset]\n"
+      "vdup.32 q2, %[shift]\n"
+      "vld1.32 {d6[], d7[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d8[], d9[]}, [%[offsets]:32]!\n"
+      "vld1.32 {d10[], d11[]}, [%[offsets]:32]!\n"
+      "add r0, %[source], %[stride]\n"
+      "add r1, %[destination], %[destination_stride]\n"
+      "add r2, r0, %[stride]\n"
+      "add r3, r1, %[destination_stride]\n"
+      "sub %[count], %[count], #7\n"
+
+      "1:"
+      "subs %[count], %[count], #8\n"
+      "vld1.32 {d12, d13, d14, d15}, [%[source]:64]!\n"
+      "vld1.32 {d16, d17, d18, d19}, [r0:64]!\n"
+      "vld1.32 {d20, d21, d22, d23}, [r2:64]!\n"
+      "pld [%[source]]\n"
+      "pld [r0]\n"
+      "pld [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q9, q9, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vadd.i32 q11, q11, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q9, q9, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vmul.i32 q11, q11, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q9, q9, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vadd.i32 q11, q11, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q9, q9, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vshl.s32 q11, q11, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d25, q7\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d27, q9\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovn.s32 d29, q11\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.8 {d24}, [%[destination]]!\n"
+      "vst1.8 {d26}, [r1]!\n"
+      "vst1.8 {d28}, [r3]!\n"
+
+      "bne 1b\n"
+      "vld1.32 {d12, d13, d14}, [%[source]:64]!\n"
+      "vld1.32 {d16, d17, d18}, [r0:64]!\n"
+      "vld1.32 {d20, d21, d22}, [r2:64]!\n"
+      "vld1.32 {d15[0]}, [%[source]]\n"
+      "vld1.32 {d19[0]}, [r0]\n"
+      "vld1.32 {d23[0]}, [r2]\n"
+      "vadd.i32 q6, q6, q3\n"
+      "vadd.i32 q7, q7, q3\n"
+      "vadd.i32 q8, q8, q4\n"
+      "vadd.i32 q9, q9, q4\n"
+      "vadd.i32 q10, q10, q5\n"
+      "vadd.i32 q11, q11, q5\n"
+      "vmul.i32 q6, q6, q0\n"
+      "vmul.i32 q7, q7, q0\n"
+      "vmul.i32 q8, q8, q0\n"
+      "vmul.i32 q9, q9, q0\n"
+      "vmul.i32 q10, q10, q0\n"
+      "vmul.i32 q11, q11, q0\n"
+      "vadd.i32 q6, q6, q1\n"
+      "vadd.i32 q7, q7, q1\n"
+      "vadd.i32 q8, q8, q1\n"
+      "vadd.i32 q9, q9, q1\n"
+      "vadd.i32 q10, q10, q1\n"
+      "vadd.i32 q11, q11, q1\n"
+      "vshl.s32 q6, q6, q2\n"
+      "vshl.s32 q7, q7, q2\n"
+      "vshl.s32 q8, q8, q2\n"
+      "vshl.s32 q9, q9, q2\n"
+      "vshl.s32 q10, q10, q2\n"
+      "vshl.s32 q11, q11, q2\n"
+      "vqmovn.s32 d24, q6\n"
+      "vqmovn.s32 d25, q7\n"
+      "vqmovn.s32 d26, q8\n"
+      "vqmovn.s32 d27, q9\n"
+      "vqmovn.s32 d28, q10\n"
+      "vqmovn.s32 d29, q11\n"
+      "vqmovun.s16 d24, q12\n"
+      "vqmovun.s16 d26, q13\n"
+      "vqmovun.s16 d28, q14\n"
+      "vst1.32 {d24[0]}, [%[destination]]!\n"
+      "vst1.32 {d26[0]}, [r1]!\n"
+      "vst1.32 {d28[0]}, [r3]!\n"
+      "vst1.16 {d24[2]}, [%[destination]]!\n"
+      "vst1.16 {d26[2]}, [r1]!\n"
+      "vst1.16 {d28[2]}, [r3]!\n"
+      "vst1.8 {d24[6]}, [%[destination]]!\n"
+      "vst1.8 {d26[6]}, [r1]!\n"
+      "vst1.8 {d28[6]}, [r3]!\n"
+      : [count] "+r"(count),
+        [multiplicative_offset] "+r"(multiplicative_offset),
+        [stride] "+r"(stride), [shift] "+r"(shift),
+        [destination] "+r"(destination), [offsets] "+r"(offsets),
+        [source] "+r"(source), [destination_stride] "+r"(destination_stride),
+        [rounding_offset] "+r"(rounding_offset)
+      :
+      : "r0", "r1", "r2", "r3", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7",
+        "d8", "d9", "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17",
+        "d18", "d19", "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27",
+        "d28", "d29", "cc", "memory");
+}
+
+void multi_qnt_1x8_aligned(const std::int32_t* source, std::int32_t count,
+                           std::int32_t stride, const std::int32_t* offsets,
+                           std::uint8_t* destination,
+                           std::int32_t destination_stride,
+                           std::int32_t multiplicative_offset,
+                           std::int32_t rounding_offset, std::int32_t shift) {
+  switch (count % 8) {
+    case 0:
+      qnt_1x8_aligned(source, count, stride, offsets, destination,
+                      destination_stride, multiplicative_offset,
+                      rounding_offset, shift);
+      break;
+    case 1:
+      qnt_1x8_1_aligned(source, count, stride, offsets, destination,
+                        destination_stride, multiplicative_offset,
+                        rounding_offset, shift);
+      break;
+    case 2:
+      qnt_1x8_2_aligned(source, count, stride, offsets, destination,
+                        destination_stride, multiplicative_offset,
+                        rounding_offset, shift);
+      break;
+    case 3:
+      qnt_1x8_3_aligned(source, count, stride, offsets, destination,
+                        destination_stride, multiplicative_offset,
+                        rounding_offset, shift);
+      break;
+    case 4:
+      qnt_1x8_4_aligned(source, count, stride, offsets, destination,
+                        destination_stride, multiplicative_offset,
+                        rounding_offset, shift);
+      break;
+    case 5:
+      qnt_1x8_5_aligned(source, count, stride, offsets, destination,
+                        destination_stride, multiplicative_offset,
+                        rounding_offset, shift);
+      break;
+    case 6:
+      qnt_1x8_6_aligned(source, count, stride, offsets, destination,
+                        destination_stride, multiplicative_offset,
+                        rounding_offset, shift);
+      break;
+    case 7:
+      qnt_1x8_7_aligned(source, count, stride, offsets, destination,
+                        destination_stride, multiplicative_offset,
+                        rounding_offset, shift);
+      break;
+  }
+}
+
+void multi_qnt_2x8_aligned(const std::int32_t* source, std::int32_t count,
+                           std::int32_t stride, const std::int32_t* offsets,
+                           std::uint8_t* destination,
+                           std::int32_t destination_stride,
+                           std::int32_t multiplicative_offset,
+                           std::int32_t rounding_offset, std::int32_t shift) {
+  switch (count % 8) {
+    case 0:
+      qnt_2x8_aligned(source, count, stride, offsets, destination,
+                      destination_stride, multiplicative_offset,
+                      rounding_offset, shift);
+      break;
+    case 1:
+      qnt_2x8_1_aligned(source, count, stride, offsets, destination,
+                        destination_stride, multiplicative_offset,
+                        rounding_offset, shift);
+      break;
+    case 2:
+      qnt_2x8_2_aligned(source, count, stride, offsets, destination,
+                        destination_stride, multiplicative_offset,
+                        rounding_offset, shift);
+      break;
+    case 3:
+      qnt_2x8_3_aligned(source, count, stride, offsets, destination,
+                        destination_stride, multiplicative_offset,
+                        rounding_offset, shift);
+      break;
+    case 4:
+      qnt_2x8_4_aligned(source, count, stride, offsets, destination,
+                        destination_stride, multiplicative_offset,
+                        rounding_offset, shift);
+      break;
+    case 5:
+      qnt_2x8_5_aligned(source, count, stride, offsets, destination,
+                        destination_stride, multiplicative_offset,
+                        rounding_offset, shift);
+      break;
+    case 6:
+      qnt_2x8_6_aligned(source, count, stride, offsets, destination,
+                        destination_stride, multiplicative_offset,
+                        rounding_offset, shift);
+      break;
+    case 7:
+      qnt_2x8_7_aligned(source, count, stride, offsets, destination,
+                        destination_stride, multiplicative_offset,
+                        rounding_offset, shift);
+      break;
+  }
+}
+
+void multi_qnt_3x8_aligned(const std::int32_t* source, std::int32_t count,
+                           std::int32_t stride, const std::int32_t* offsets,
+                           std::uint8_t* destination,
+                           std::int32_t destination_stride,
+                           std::int32_t multiplicative_offset,
+                           std::int32_t rounding_offset, std::int32_t shift) {
+  switch (count % 8) {
+    case 0:
+      qnt_3x8_aligned(source, count, stride, offsets, destination,
+                      destination_stride, multiplicative_offset,
+                      rounding_offset, shift);
+      break;
+    case 1:
+      qnt_3x8_1_aligned(source, count, stride, offsets, destination,
+                        destination_stride, multiplicative_offset,
+                        rounding_offset, shift);
+      break;
+    case 2:
+      qnt_3x8_2_aligned(source, count, stride, offsets, destination,
+                        destination_stride, multiplicative_offset,
+                        rounding_offset, shift);
+      break;
+    case 3:
+      qnt_3x8_3_aligned(source, count, stride, offsets, destination,
+                        destination_stride, multiplicative_offset,
+                        rounding_offset, shift);
+      break;
+    case 4:
+      qnt_3x8_4_aligned(source, count, stride, offsets, destination,
+                        destination_stride, multiplicative_offset,
+                        rounding_offset, shift);
+      break;
+    case 5:
+      qnt_3x8_5_aligned(source, count, stride, offsets, destination,
+                        destination_stride, multiplicative_offset,
+                        rounding_offset, shift);
+      break;
+    case 6:
+      qnt_3x8_6_aligned(source, count, stride, offsets, destination,
+                        destination_stride, multiplicative_offset,
+                        rounding_offset, shift);
+      break;
+    case 7:
+      qnt_3x8_7_aligned(source, count, stride, offsets, destination,
+                        destination_stride, multiplicative_offset,
+                        rounding_offset, shift);
+      break;
+  }
+}
+
+void multi_qnt_1x8(const std::int32_t* source, std::int32_t count,
+                   std::int32_t stride, const std::int32_t* offsets,
+                   std::uint8_t* destination, std::int32_t destination_stride,
+                   std::int32_t multiplicative_offset,
+                   std::int32_t rounding_offset, std::int32_t shift) {
+  switch (count % 8) {
+    case 0:
+      qnt_1x8(source, count, stride, offsets, destination, destination_stride,
+              multiplicative_offset, rounding_offset, shift);
+      break;
+    case 1:
+      qnt_1x8_1(source, count, stride, offsets, destination, destination_stride,
+                multiplicative_offset, rounding_offset, shift);
+      break;
+    case 2:
+      qnt_1x8_2(source, count, stride, offsets, destination, destination_stride,
+                multiplicative_offset, rounding_offset, shift);
+      break;
+    case 3:
+      qnt_1x8_3(source, count, stride, offsets, destination, destination_stride,
+                multiplicative_offset, rounding_offset, shift);
+      break;
+    case 4:
+      qnt_1x8_4(source, count, stride, offsets, destination, destination_stride,
+                multiplicative_offset, rounding_offset, shift);
+      break;
+    case 5:
+      qnt_1x8_5(source, count, stride, offsets, destination, destination_stride,
+                multiplicative_offset, rounding_offset, shift);
+      break;
+    case 6:
+      qnt_1x8_6(source, count, stride, offsets, destination, destination_stride,
+                multiplicative_offset, rounding_offset, shift);
+      break;
+    case 7:
+      qnt_1x8_7(source, count, stride, offsets, destination, destination_stride,
+                multiplicative_offset, rounding_offset, shift);
+      break;
+  }
+}
+
+void multi_qnt_2x8(const std::int32_t* source, std::int32_t count,
+                   std::int32_t stride, const std::int32_t* offsets,
+                   std::uint8_t* destination, std::int32_t destination_stride,
+                   std::int32_t multiplicative_offset,
+                   std::int32_t rounding_offset, std::int32_t shift) {
+  switch (count % 8) {
+    case 0:
+      qnt_2x8(source, count, stride, offsets, destination, destination_stride,
+              multiplicative_offset, rounding_offset, shift);
+      break;
+    case 1:
+      qnt_2x8_1(source, count, stride, offsets, destination, destination_stride,
+                multiplicative_offset, rounding_offset, shift);
+      break;
+    case 2:
+      qnt_2x8_2(source, count, stride, offsets, destination, destination_stride,
+                multiplicative_offset, rounding_offset, shift);
+      break;
+    case 3:
+      qnt_2x8_3(source, count, stride, offsets, destination, destination_stride,
+                multiplicative_offset, rounding_offset, shift);
+      break;
+    case 4:
+      qnt_2x8_4(source, count, stride, offsets, destination, destination_stride,
+                multiplicative_offset, rounding_offset, shift);
+      break;
+    case 5:
+      qnt_2x8_5(source, count, stride, offsets, destination, destination_stride,
+                multiplicative_offset, rounding_offset, shift);
+      break;
+    case 6:
+      qnt_2x8_6(source, count, stride, offsets, destination, destination_stride,
+                multiplicative_offset, rounding_offset, shift);
+      break;
+    case 7:
+      qnt_2x8_7(source, count, stride, offsets, destination, destination_stride,
+                multiplicative_offset, rounding_offset, shift);
+      break;
+  }
+}
+
+void multi_qnt_3x8(const std::int32_t* source, std::int32_t count,
+                   std::int32_t stride, const std::int32_t* offsets,
+                   std::uint8_t* destination, std::int32_t destination_stride,
+                   std::int32_t multiplicative_offset,
+                   std::int32_t rounding_offset, std::int32_t shift) {
+  switch (count % 8) {
+    case 0:
+      qnt_3x8(source, count, stride, offsets, destination, destination_stride,
+              multiplicative_offset, rounding_offset, shift);
+      break;
+    case 1:
+      qnt_3x8_1(source, count, stride, offsets, destination, destination_stride,
+                multiplicative_offset, rounding_offset, shift);
+      break;
+    case 2:
+      qnt_3x8_2(source, count, stride, offsets, destination, destination_stride,
+                multiplicative_offset, rounding_offset, shift);
+      break;
+    case 3:
+      qnt_3x8_3(source, count, stride, offsets, destination, destination_stride,
+                multiplicative_offset, rounding_offset, shift);
+      break;
+    case 4:
+      qnt_3x8_4(source, count, stride, offsets, destination, destination_stride,
+                multiplicative_offset, rounding_offset, shift);
+      break;
+    case 5:
+      qnt_3x8_5(source, count, stride, offsets, destination, destination_stride,
+                multiplicative_offset, rounding_offset, shift);
+      break;
+    case 6:
+      qnt_3x8_6(source, count, stride, offsets, destination, destination_stride,
+                multiplicative_offset, rounding_offset, shift);
+      break;
+    case 7:
+      qnt_3x8_7(source, count, stride, offsets, destination, destination_stride,
+                multiplicative_offset, rounding_offset, shift);
+      break;
+  }
+}
+
+void gemm_0_0_0_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_0_1_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_1_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_1_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_0_2_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_2_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_2_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_0_3_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_3_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_3_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_0_4_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_4_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_4_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_0_5_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_5_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_5_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_0_6_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_6_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_6_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_0_7_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_7_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_7_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_1_0_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_1_1_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_1_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_1_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_1_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_1_2_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_2_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_2_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_2_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_1_3_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_3_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_3_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_3_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_1_4_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_4_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_4_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_4_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_1_5_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_5_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_5_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_5_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_1_6_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_6_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_6_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_6_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_1_7_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_7_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_7_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_7_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_2_0_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_2_1_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_1_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_1_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_1_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_2_2_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_2_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_2_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_2_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_2_3_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_3_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_3_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_3_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_2_4_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_4_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_4_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_4_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_2_5_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_5_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_5_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_5_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_2_6_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_6_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_6_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_6_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_2_7_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_7_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_7_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_7_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_1_0_0_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_0_1_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_1_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_1_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_1_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_0_2_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_2_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_2_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_2_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_0_3_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_3_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_3_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_3_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_0_4_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_4_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_4_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_4_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_0_5_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_5_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_5_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_5_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_0_6_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_6_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_6_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_6_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_0_7_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_7_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_7_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_7_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_1_0_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_1_1_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_1_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_1_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_1_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_1_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_1_2_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_2_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_2_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_2_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_2_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_1_3_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_3_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_3_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_3_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_3_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_1_4_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_4_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_4_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_4_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_4_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_1_5_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_5_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_5_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_5_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_5_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_1_6_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_6_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_6_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_6_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_6_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_1_7_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_7_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_7_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_7_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_7_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_2_0_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_2_1_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_1_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_1_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_1_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_1_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_2_2_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_2_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_2_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_2_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_2_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_2_3_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_3_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_3_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_3_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_3_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_2_4_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_4_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_4_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_4_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_4_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_2_5_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_5_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_5_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_5_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_5_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_2_6_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_6_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_6_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_6_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_6_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_1_2_7_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_7_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_7_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_7_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_7_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_1_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_0_0_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_0_1_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_1_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_1_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_1_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_0_2_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_2_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_2_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_2_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_0_3_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_3_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_3_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_3_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_0_4_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_4_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_4_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_4_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_0_5_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_5_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_5_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_5_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_0_6_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_6_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_6_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_6_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_0_7_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_7_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_7_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_7_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_1_0_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_1_1_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_1_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_1_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_1_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_1_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_1_2_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_2_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_2_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_2_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_2_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_1_3_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_3_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_3_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_3_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_3_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_1_4_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_4_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_4_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_4_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_4_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_1_5_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_5_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_5_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_5_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_5_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_1_6_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_6_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_6_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_6_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_6_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_1_7_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_7_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_7_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_7_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_7_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_2_0_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_2_1_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_1_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_1_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_1_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_1_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_2_2_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_2_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_2_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_2_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_2_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_2_3_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_3_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_3_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_3_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_3_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_2_4_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_4_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_4_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_4_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_4_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_2_5_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_5_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_5_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_5_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_5_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_2_6_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_6_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_6_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_6_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_6_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_2_2_7_aligned(std::uint8_t* scratch, const std::uint8_t* lhs,
+                        const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                        std::int32_t k, std::int32_t lhs_offset,
+                        std::int32_t rhs_offset, std::int32_t result_offset,
+                        std::int32_t multiplicative_offset, std::int32_t shift,
+                        std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_7_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_7_aligned(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_7_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8_aligned(temp_result, m, temp_result_stride,
+                          zipped_lhs_3_offsets, result_chunk, m,
+                          multiplicative_offset, rounding_offset, -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_7_aligned(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8_aligned(temp_result, m, temp_result_stride,
+                        zipped_lhs_2_offsets, result_chunk, m,
+                        multiplicative_offset, rounding_offset, -shift);
+}
+
+void gemm_0_0_0(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_0_1(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_1(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_1(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_0_2(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_2(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_2(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_0_3(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_3(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_3(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_0_4(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_4(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_4(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_0_5(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_5(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_5(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_0_6(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_6(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_6(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_0_7(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_7(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_7(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_1_0(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_1_1(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_1(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_1(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_1(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_1_2(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_2(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_2(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_2(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_1_3(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_3(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_3(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_3(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_1_4(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_4(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_4(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_4(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_1_5(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_5(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_5(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_5(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_1_6(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_6(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_6(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_6(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_1_7(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_7(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_7(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_7(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_2_0(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_2_1(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_1(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_1(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_1(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_2_2(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_2(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_2(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_2(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_2_3(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_3(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_3(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_3(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_2_4(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_4(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_4(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_4(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_2_5(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_5(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_5(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_5(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_2_6(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_6(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_6(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_6(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_0_2_7(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_7(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_7(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_7(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+}
+
+void gemm_1_0_0(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_0_1(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_1(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_1(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_1(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_0_2(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_2(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_2(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_2(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_0_3(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_3(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_3(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_3(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_0_4(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_4(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_4(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_4(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_0_5(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_5(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_5(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_5(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_0_6(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_6(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_6(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_6(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_0_7(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_7(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_7(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_7(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_1_0(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_1_1(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_1(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_1(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_1(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_1(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_1_2(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_2(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_2(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_2(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_2(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_1_3(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_3(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_3(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_3(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_3(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_1_4(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_4(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_4(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_4(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_4(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_1_5(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_5(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_5(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_5(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_5(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_1_6(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_6(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_6(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_6(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_6(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_1_7(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_7(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_7(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_7(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_7(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_2_0(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_2_1(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_1(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_1(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_1(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_1(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_2_2(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_2(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_2(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_2(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_2(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_2_3(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_3(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_3(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_3(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_3(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_2_4(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_4(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_4(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_4(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_4(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_2_5(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_5(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_5(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_5(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_5(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_2_6(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_6(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_6(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_6(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_6(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_1_2_7(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_1_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 1);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_7(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_7(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_7(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_1x8_7(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_1x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_1x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_1x8(temp_result, m, temp_result_stride, zipped_lhs_1_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_0_0(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_0_1(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_1(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_1(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_1(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_0_2(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_2(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_2(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_2(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_0_3(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_3(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_3(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_3(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_0_4(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_4(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_4(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_4(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_0_5(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_5(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_5(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_5(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_0_6(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_6(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_6(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_6(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_0_7(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_7(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_7(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_7(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_1_0(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_1_1(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_1(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_1(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_1(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_1(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_1_2(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_2(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_2(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_2(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_2(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_1_3(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_3(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_3(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_3(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_3(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_1_4(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_4(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_4(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_4(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_4(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_1_5(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_5(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_5(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_5(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_5(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_1_6(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_6(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_6(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_6(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_6(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_1_7(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_7(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_1x8_7(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_7(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_7(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_1x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_2_0(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_2_1(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_1(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_1(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_1(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_1(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_2_2(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_2(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_2(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_2(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_2(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_2_3(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_3(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_3(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_3(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_3(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_2_4(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_4(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_4(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_4(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_4(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_2_5(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_5(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_5(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_5(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_5(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_2_6(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_6(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_6(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_6(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_6(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+void gemm_2_2_7(std::uint8_t* scratch, const std::uint8_t* lhs,
+                const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+                std::int32_t k, std::int32_t lhs_offset,
+                std::int32_t rhs_offset, std::int32_t result_offset,
+                std::int32_t multiplicative_offset, std::int32_t shift,
+                std::uint8_t* result) {
+  const std::int32_t row_chunks = n / 3;
+  const std::int32_t col_chunks = m / 3;
+  const std::int32_t padded_k = ((k + 7) / 8) * 8;
+
+  const std::int32_t chunk_size = k * 3;
+  const std::int32_t zipped_chunk_size = (padded_k + 16) * 3;
+  const std::int32_t zipped_rhs_size = (padded_k + 16) * m;
+  const std::int32_t temp_result_stride = ((m * 4 + 7) / 8) * 8;
+  const std::int32_t temp_result_size = 3 * temp_result_stride;
+  const std::int32_t rounding_offset = (1 << (shift - 1));
+  const std::int32_t result_chunk_size = m * 3;
+
+  std::uint8_t* zipped_lhs = scratch;
+  std::int32_t* zipped_lhs_3_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 3);
+  std::int32_t* zipped_lhs_2_offsets =
+      reinterpret_cast<std::int32_t*>(zipped_lhs + padded_k * 2);
+  std::uint8_t* zipped_rhs = scratch + zipped_chunk_size;
+  std::int32_t* temp_result = reinterpret_cast<std::int32_t*>(
+      scratch + zipped_chunk_size + zipped_rhs_size);
+
+  const std::uint8_t* lhs_chunk = lhs;
+  const std::uint8_t* rhs_chunk = rhs;
+  std::uint8_t* zipped_rhs_chunk = zipped_rhs;
+  std::int32_t* temp_result_chunk = temp_result;
+  std::uint8_t* result_chunk = result;
+
+  const std::int32_t const_offset = lhs_offset * rhs_offset * k + result_offset;
+  for (int i = 0; i < col_chunks; ++i) {
+    zip_3x8_7(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+    rhs_chunk += chunk_size;
+    zipped_rhs_chunk += zipped_chunk_size;
+  }
+  zip_2x8_7(rhs_chunk, k, k, zipped_rhs_chunk, lhs_offset, 0);
+
+  for (int i = 0; i < row_chunks; ++i) {
+    zip_3x8_7(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+    zipped_rhs_chunk = zipped_rhs;
+    temp_result_chunk = temp_result;
+    for (int j = 0; j < col_chunks; ++j) {
+      mul_3x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                         temp_result_chunk, temp_result_stride);
+      zipped_rhs_chunk += zipped_chunk_size;
+      temp_result_chunk += 3;
+    }
+    mul_3x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    multi_qnt_3x8(temp_result, m, temp_result_stride, zipped_lhs_3_offsets,
+                  result_chunk, m, multiplicative_offset, rounding_offset,
+                  -shift);
+    lhs_chunk += chunk_size;
+    result_chunk += result_chunk_size;
+  }
+
+  zip_2x8_7(lhs_chunk, k, k, zipped_lhs, rhs_offset, const_offset);
+  zipped_rhs_chunk = zipped_rhs;
+  temp_result_chunk = temp_result;
+  for (int j = 0; j < col_chunks; ++j) {
+    mul_2x8_3x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k,
+                       temp_result_chunk, temp_result_stride);
+    zipped_rhs_chunk += zipped_chunk_size;
+    temp_result_chunk += 3;
+  }
+  mul_2x8_2x8_rhsadd(zipped_lhs, zipped_rhs_chunk, padded_k, temp_result_chunk,
+                     temp_result_stride);
+  multi_qnt_2x8(temp_result, m, temp_result_stride, zipped_lhs_2_offsets,
+                result_chunk, m, multiplicative_offset, rounding_offset,
+                -shift);
+}
+
+}  // namespace internal
+
+void gemm(std::uint8_t* scratch, const std::uint8_t* lhs,
+          const std::uint8_t* rhs, std::int32_t n, std::int32_t m,
+          std::int32_t k, std::int32_t lhs_offset, std::int32_t rhs_offset,
+          std::int32_t result_offset, std::int32_t multiplicative_offset,
+          std::int32_t shift, std::uint8_t* result) {
+  const bool lhs_aligned = ((reinterpret_cast<std::uintptr_t>(lhs) % 8) == 0);
+  const bool rhs_aligned = ((reinterpret_cast<std::uintptr_t>(rhs) % 8) == 0);
+  const bool result_aligned =
+      ((reinterpret_cast<std::uintptr_t>(result) % 8) == 0);
+  const bool m_aligned = ((m % 8) == 0);
+  const bool k_aligned = ((k % 8) == 0);
+  const bool aligned =
+      lhs_aligned && rhs_aligned && result_aligned && m_aligned && k_aligned;
+  if (aligned) {
+    switch (n % 3) {
+      case 0:
+        switch (m % 3) {
+          case 0:
+            switch (k % 8) {
+              case 0:
+                internal::gemm_0_0_0_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 1:
+                internal::gemm_0_0_1_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 2:
+                internal::gemm_0_0_2_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 3:
+                internal::gemm_0_0_3_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 4:
+                internal::gemm_0_0_4_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 5:
+                internal::gemm_0_0_5_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 6:
+                internal::gemm_0_0_6_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 7:
+                internal::gemm_0_0_7_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+            }
+            break;
+          case 1:
+            switch (k % 8) {
+              case 0:
+                internal::gemm_0_1_0_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 1:
+                internal::gemm_0_1_1_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 2:
+                internal::gemm_0_1_2_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 3:
+                internal::gemm_0_1_3_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 4:
+                internal::gemm_0_1_4_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 5:
+                internal::gemm_0_1_5_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 6:
+                internal::gemm_0_1_6_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 7:
+                internal::gemm_0_1_7_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+            }
+            break;
+          case 2:
+            switch (k % 8) {
+              case 0:
+                internal::gemm_0_2_0_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 1:
+                internal::gemm_0_2_1_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 2:
+                internal::gemm_0_2_2_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 3:
+                internal::gemm_0_2_3_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 4:
+                internal::gemm_0_2_4_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 5:
+                internal::gemm_0_2_5_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 6:
+                internal::gemm_0_2_6_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 7:
+                internal::gemm_0_2_7_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+            }
+            break;
+        }
+        break;
+      case 1:
+        switch (m % 3) {
+          case 0:
+            switch (k % 8) {
+              case 0:
+                internal::gemm_1_0_0_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 1:
+                internal::gemm_1_0_1_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 2:
+                internal::gemm_1_0_2_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 3:
+                internal::gemm_1_0_3_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 4:
+                internal::gemm_1_0_4_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 5:
+                internal::gemm_1_0_5_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 6:
+                internal::gemm_1_0_6_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 7:
+                internal::gemm_1_0_7_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+            }
+            break;
+          case 1:
+            switch (k % 8) {
+              case 0:
+                internal::gemm_1_1_0_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 1:
+                internal::gemm_1_1_1_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 2:
+                internal::gemm_1_1_2_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 3:
+                internal::gemm_1_1_3_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 4:
+                internal::gemm_1_1_4_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 5:
+                internal::gemm_1_1_5_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 6:
+                internal::gemm_1_1_6_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 7:
+                internal::gemm_1_1_7_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+            }
+            break;
+          case 2:
+            switch (k % 8) {
+              case 0:
+                internal::gemm_1_2_0_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 1:
+                internal::gemm_1_2_1_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 2:
+                internal::gemm_1_2_2_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 3:
+                internal::gemm_1_2_3_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 4:
+                internal::gemm_1_2_4_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 5:
+                internal::gemm_1_2_5_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 6:
+                internal::gemm_1_2_6_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 7:
+                internal::gemm_1_2_7_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+            }
+            break;
+        }
+        break;
+      case 2:
+        switch (m % 3) {
+          case 0:
+            switch (k % 8) {
+              case 0:
+                internal::gemm_2_0_0_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 1:
+                internal::gemm_2_0_1_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 2:
+                internal::gemm_2_0_2_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 3:
+                internal::gemm_2_0_3_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 4:
+                internal::gemm_2_0_4_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 5:
+                internal::gemm_2_0_5_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 6:
+                internal::gemm_2_0_6_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 7:
+                internal::gemm_2_0_7_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+            }
+            break;
+          case 1:
+            switch (k % 8) {
+              case 0:
+                internal::gemm_2_1_0_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 1:
+                internal::gemm_2_1_1_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 2:
+                internal::gemm_2_1_2_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 3:
+                internal::gemm_2_1_3_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 4:
+                internal::gemm_2_1_4_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 5:
+                internal::gemm_2_1_5_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 6:
+                internal::gemm_2_1_6_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 7:
+                internal::gemm_2_1_7_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+            }
+            break;
+          case 2:
+            switch (k % 8) {
+              case 0:
+                internal::gemm_2_2_0_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 1:
+                internal::gemm_2_2_1_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 2:
+                internal::gemm_2_2_2_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 3:
+                internal::gemm_2_2_3_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 4:
+                internal::gemm_2_2_4_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 5:
+                internal::gemm_2_2_5_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 6:
+                internal::gemm_2_2_6_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+              case 7:
+                internal::gemm_2_2_7_aligned(
+                    scratch, lhs, rhs, n, m, k, lhs_offset, rhs_offset,
+                    result_offset, multiplicative_offset, shift, result);
+                break;
+            }
+            break;
+        }
+        break;
+    }
+  } else {
+    switch (n % 3) {
+      case 0:
+        switch (m % 3) {
+          case 0:
+            switch (k % 8) {
+              case 0:
+                internal::gemm_0_0_0(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 1:
+                internal::gemm_0_0_1(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 2:
+                internal::gemm_0_0_2(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 3:
+                internal::gemm_0_0_3(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 4:
+                internal::gemm_0_0_4(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 5:
+                internal::gemm_0_0_5(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 6:
+                internal::gemm_0_0_6(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 7:
+                internal::gemm_0_0_7(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+            }
+            break;
+          case 1:
+            switch (k % 8) {
+              case 0:
+                internal::gemm_0_1_0(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 1:
+                internal::gemm_0_1_1(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 2:
+                internal::gemm_0_1_2(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 3:
+                internal::gemm_0_1_3(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 4:
+                internal::gemm_0_1_4(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 5:
+                internal::gemm_0_1_5(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 6:
+                internal::gemm_0_1_6(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 7:
+                internal::gemm_0_1_7(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+            }
+            break;
+          case 2:
+            switch (k % 8) {
+              case 0:
+                internal::gemm_0_2_0(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 1:
+                internal::gemm_0_2_1(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 2:
+                internal::gemm_0_2_2(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 3:
+                internal::gemm_0_2_3(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 4:
+                internal::gemm_0_2_4(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 5:
+                internal::gemm_0_2_5(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 6:
+                internal::gemm_0_2_6(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 7:
+                internal::gemm_0_2_7(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+            }
+            break;
+        }
+        break;
+      case 1:
+        switch (m % 3) {
+          case 0:
+            switch (k % 8) {
+              case 0:
+                internal::gemm_1_0_0(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 1:
+                internal::gemm_1_0_1(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 2:
+                internal::gemm_1_0_2(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 3:
+                internal::gemm_1_0_3(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 4:
+                internal::gemm_1_0_4(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 5:
+                internal::gemm_1_0_5(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 6:
+                internal::gemm_1_0_6(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 7:
+                internal::gemm_1_0_7(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+            }
+            break;
+          case 1:
+            switch (k % 8) {
+              case 0:
+                internal::gemm_1_1_0(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 1:
+                internal::gemm_1_1_1(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 2:
+                internal::gemm_1_1_2(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 3:
+                internal::gemm_1_1_3(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 4:
+                internal::gemm_1_1_4(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 5:
+                internal::gemm_1_1_5(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 6:
+                internal::gemm_1_1_6(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 7:
+                internal::gemm_1_1_7(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+            }
+            break;
+          case 2:
+            switch (k % 8) {
+              case 0:
+                internal::gemm_1_2_0(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 1:
+                internal::gemm_1_2_1(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 2:
+                internal::gemm_1_2_2(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 3:
+                internal::gemm_1_2_3(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 4:
+                internal::gemm_1_2_4(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 5:
+                internal::gemm_1_2_5(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 6:
+                internal::gemm_1_2_6(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 7:
+                internal::gemm_1_2_7(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+            }
+            break;
+        }
+        break;
+      case 2:
+        switch (m % 3) {
+          case 0:
+            switch (k % 8) {
+              case 0:
+                internal::gemm_2_0_0(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 1:
+                internal::gemm_2_0_1(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 2:
+                internal::gemm_2_0_2(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 3:
+                internal::gemm_2_0_3(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 4:
+                internal::gemm_2_0_4(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 5:
+                internal::gemm_2_0_5(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 6:
+                internal::gemm_2_0_6(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 7:
+                internal::gemm_2_0_7(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+            }
+            break;
+          case 1:
+            switch (k % 8) {
+              case 0:
+                internal::gemm_2_1_0(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 1:
+                internal::gemm_2_1_1(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 2:
+                internal::gemm_2_1_2(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 3:
+                internal::gemm_2_1_3(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 4:
+                internal::gemm_2_1_4(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 5:
+                internal::gemm_2_1_5(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 6:
+                internal::gemm_2_1_6(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 7:
+                internal::gemm_2_1_7(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+            }
+            break;
+          case 2:
+            switch (k % 8) {
+              case 0:
+                internal::gemm_2_2_0(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 1:
+                internal::gemm_2_2_1(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 2:
+                internal::gemm_2_2_2(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 3:
+                internal::gemm_2_2_3(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 4:
+                internal::gemm_2_2_4(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 5:
+                internal::gemm_2_2_5(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 6:
+                internal::gemm_2_2_6(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+              case 7:
+                internal::gemm_2_2_7(scratch, lhs, rhs, n, m, k, lhs_offset,
+                                     rhs_offset, result_offset,
+                                     multiplicative_offset, shift, result);
+                break;
+            }
+            break;
+        }
+        break;
+    }
+  }
+}
+
+}  // namespace meta
+}  // namespace gemmlowp
+
+#else
+#warning "Meta gemm fast-path requires GEMMLOWP_NEON_32!"
+#endif
+
+#endif  // GEMMLOWP_META_SINGLE_THREAD_GEMM_H_


### PR DESCRIPTION
Hi,
This bulky change adds new ARM/NEON codepath. In our tests it has shown to improve 8bit gemm performance up to 35% in some cases. This codepath is disabled by default. Please take a look at meta/README.txt for some details. 