### PR TITLE
Move pre-multiplication for rank one update from packing to unpacking.

### DIFF
--- a/doc/low-precision.txt
+++ b/doc/low-precision.txt
@@ -59,15 +59,15 @@ The rationale for these parameters is as follows:
     case. One may at first glance worry that these offsets would incur
     substantial overhead to the GEMM computation, but that is actually not the
     case thanks to a trick described below (see "Efficient handling of
-    offsets as rank-one updates").
+    offsets").
   - The result_mult_int and result_shift parameters allow approximating
     arbitrarily closely any real multiplier, as a fraction of the form given
     in (1) above, without using floating-point arithmetic and without using
     a division instruction (only a right shift).
 
 
-Efficient handling of offsets as rank-one updates
-=================================================
+Efficient handling of offsets
+=============================
 
 At first glance it may seem like the above-described quantized computation
 scheme requires adding the lhs_offset and rhs_offset to each of the lhs and
@@ -116,15 +116,15 @@ with 1's, P * rhs has all its rows equal to each other, and equal to the
 row-vector of sums of all the entries in each column of rhs.
 
 Thus, we can compute the second term, lhs_offset * P * rhs, by summing
-each column of rhs, and multiplying these sums by lhs_offset. This produces
-a single row-vector, and in order to add the second term, we simply need
-to add this row-vector to each row of the result. This is just a rank one
-update of the result (equivalently, the second term is a rank one matrix),
-and we can efficiently store it as a single vector.
+each column of rhs. This produces a single row-vector, and in order to add the
+second term, we simply need to add this row-vector (multiplied by lhs_offset)
+to each row of the result. This is just a rank one update of the result
+(equivalently, the second term is a rank one matrix), and we can efficiently
+store it as a single vector.
 
 The third term, lhs * rhs_offset * Q, is entirely similar to the second one,
-and can be similarly computed by summing each row of lhs, and multiplying
-these sums by rhs_offset, storing this in a single column-vector.
+and can be similarly computed by summing each row of lhs, storing this in a
+single column-vector, and later multiplying these sums by rhs_offset.
 
 The fourth term is a single constant, repeated into all the entries of the
 matrix. The matrix P * Q is filled with the single constant value 'depth'
@@ -140,26 +140,17 @@ Implementation of this technique in gemmlowp
 
 In gemmlowp, at the packing stage (where we traverse blocks of the lhs and rhs
 to prepare them for efficient repeated traversal by the kernel), we compute
-the sum of each row of the lhs block and the sum of each columns of the rhs
-block, and multiply these values by the rhs_offset and lhs_offset,
-respectively.
+the sum of each row of the lhs block and the sum of each column of the rhs
+block.
 
-See in internal/pack.h, in the PackedSideBlock class, the following members:
+See in internal/pack.h, in the PackedSideBlock class, the following member:
 
-  // Handle on the additional buffer backing the rank-one-update vector
+  // Handle on the additional buffer backing the vector of sums of slices
   // associated with this block. Owned.
-  Allocator::Handle rank_one_update_handle_;
+  Allocator::Handle sums_of_each_slice_handle_;
 
-  // The constant multiplier of the rank one update vector.
-  std::int32_t rank_one_update_multiplier_;
-
-Here, rank_one_update_multiplier_ is the offset to be multiplied with. It is
-rhs_offset for lhs blocks, and lhs_offet for rhs blocks.
-
-rank_one_update_handle_ is the handle to the buffer allocated to store
-the vector describing the rank one update, i.e. the vector of sums of
-rows of lhs or of sums of columns of rhs, multiplied by
-rank_one_update_multiplier_.
+sums_of_each_slice_handle_ is the handle to the buffer allocated to store
+the vector containing sums of rows of lhs, or of sums of columns of rhs.
 
 After these rank one updates have been computed at the packing stage, they are
 ignored at the compute kernel stage, since that stage is only concerned

--- a/doc/packing.txt
+++ b/doc/packing.txt
@@ -15,7 +15,7 @@ packed format requirements that the kernels expect, and that forms
 basically the contract that the packing stage must honor.
 
 Some parts below also assume familiarity with doc/low-precision.txt
-as the packing stage also has to compute the rank-one-update vectors
+as the packing stage also has to compute the vectors of sums or columns as
 described there.
 
 
@@ -180,8 +180,8 @@ Besides storing matrix entries in a suitable order, the packing stages also has
 two other things to do.
 
 First, packing has to compute the vectors of sums of entries along the depth
-dimension, which we call the "rank-one-update" vectors. If this is any mysterious,
-read doc/low-precision.txt. These will only be used at the unpacking stage.
+dimension. If this is any mysterious, read doc/low-precision.txt. These will
+only be used at the unpacking stage.
 
 Second, if the BitDepthSetting requires less than 8 bit of precision, then at
 the packing stage we have to requantize inputs accordingly.
@@ -204,4 +204,3 @@ in which case a given path is to be used in place of the generic packing code.
 It is entirely possible to set the value of kRegisterSize differently based on
 the CPU architecture (for example, 32 on x86 with AVX) as long as all the
 specialized packing paths used on that CPU architecture are consistent with it.
-

--- a/internal/multi_thread_gemm.h
+++ b/internal/multi_thread_gemm.h
@@ -391,7 +391,7 @@ struct GemmWithPackedRhsTask : Task {
     BlockParams block_params;
     block_params.Init<KernelFormat>(rows, cols, depth, 1);
 
-    PackedLhs packed_lhs(Side::Lhs, local_allocator, block_params, rhs_offset);
+    PackedLhs packed_lhs(Side::Lhs, local_allocator, block_params);
 
     PackedResult packed_result(local_allocator, block_params);
 
@@ -409,9 +409,9 @@ struct GemmWithPackedRhsTask : Task {
 
         auto result_block = result.block(r, c, rs, cs);
         UnpackResult<BitDepthParams>(&result_block, packed_result, depth,
-                                     packed_lhs.rank_one_update(),
-                                     packed_rhs.rank_one_update(), lhs_offset,
-                                     rhs_offset, output_pipeline);
+                                     packed_lhs.sums_of_each_slice(),
+                                     packed_rhs.sums_of_each_slice(),
+                                     lhs_offset, rhs_offset, output_pipeline);
       }
     }
 
@@ -575,7 +575,7 @@ void MultiThreadGemm(MultiThreadGemmContext* context, const KernelBase& kernel,
   block_params.Init<KernelFormat>(rows, cols, depth, workers_count);
 
   PackedSideBlock<typename KernelFormat::Rhs> packed_rhs(
-      Side::Rhs, allocator, block_params, lhs_offset);
+      Side::Rhs, allocator, block_params);
   allocator->Commit();
 
   // We loop over large blocks of the RHS.

--- a/internal/pack.h
+++ b/internal/pack.h
@@ -50,15 +50,13 @@ class PackedSideBlock {
   typedef tKernelSideFormat KernelSideFormat;
 
   PackedSideBlock(Side side, Allocator* allocator,
-                  const BlockParams& block_params,
-                  int rank_one_update_multiplier)
+                  const BlockParams& block_params)
       : allocator_(allocator),
-        rank_one_update_multiplier_(rank_one_update_multiplier),
         pos_(0) {
     GetSideBlockParams(side, &params_, block_params);
     data_handle_ =
         allocator_->Reserve<std::uint8_t>(params_.l2_width * params_.l2_depth);
-    rank_one_update_handle_ =
+    sums_of_each_slice_handle_ =
         allocator_->Reserve<std::int32_t>(params_.l2_width);
   }
 
@@ -84,16 +82,13 @@ class PackedSideBlock {
     return allocator_->GetPointer<std::uint8_t>(data_handle_) + pos_;
   }
 
-  std::int32_t* rank_one_update() {
-    return allocator_->GetPointer<std::int32_t>(rank_one_update_handle_);
+  std::int32_t* sums_of_each_slice() {
+    return allocator_->GetPointer<std::int32_t>(sums_of_each_slice_handle_);
   }
 
-  const std::int32_t* rank_one_update() const {
-    return allocator_->GetPointer<const std::int32_t>(rank_one_update_handle_);
-  }
-
-  std::int32_t rank_one_update_multiplier() const {
-    return rank_one_update_multiplier_;
+  const std::int32_t* sums_of_each_slice() const {
+    return allocator_->GetPointer<const std::int32_t>(
+        sums_of_each_slice_handle_);
   }
 
   const SideBlockParams& params() const { return params_; }
@@ -112,12 +107,9 @@ class PackedSideBlock {
   // Handle on the buffer backing this packed block. Owned.
   Allocator::Handle data_handle_;
 
-  // Handle on the additional buffer backing the rank-one-update vector
+  // Handle on the additional buffer backing the vector of sums of slices
   // associated with this block. Owned.
-  Allocator::Handle rank_one_update_handle_;
-
-  // The constant multiplier of the rank one update vector.
-  std::int32_t rank_one_update_multiplier_;
+  Allocator::Handle sums_of_each_slice_handle_;
 
   // pos_ is the current position in the buffer, which we access
   // sequentially, like a file.
@@ -360,8 +352,8 @@ class PackingRegisterBlockBase {
          cell_start_depth += kCellDepth) {
       for (int cell_start_width = 0; cell_start_width < kKernelWidth;
            cell_start_width += kCellWidth) {
-        std::int32_t* cell_rank_one_update_ptr =
-            dst->rank_one_update() + start_width + cell_start_width;
+        std::int32_t* cell_sums_of_each_slice_ptr =
+            dst->sums_of_each_slice() + start_width + cell_start_width;
         const SideMap<const std::uint8_t, kSrcOrder> src_cell_map(
             complete_src_.block(cell_start_width, cell_start_depth, kCellWidth,
                                 kCellDepth));
@@ -374,8 +366,7 @@ class PackingRegisterBlockBase {
             dst_ptr[OffsetIntoCell<CellFormat>(w, d)] = requantized;
             sum += requantized;
           }
-          cell_rank_one_update_ptr[w] +=
-              sum * dst->rank_one_update_multiplier();
+          cell_sums_of_each_slice_ptr[w] += sum;
         }
         dst_ptr += kCellSize;
       }
@@ -417,7 +408,7 @@ class PackSideBlockImpl {
 
   // The public entry point to pack a block.
   void PackL2() {
-    memset(packed_side_block_->rank_one_update(), 0,
+    memset(packed_side_block_->sums_of_each_slice(), 0,
            sizeof(std::int32_t) * packed_side_block_->params().l2_width);
     for (int d = 0; d < src_map_.depth();
          d += packed_side_block_->params().l1_depth) {

--- a/internal/pack_neon.h
+++ b/internal/pack_neon.h
@@ -247,18 +247,17 @@ class PackingRegisterBlock<
                       vget_high_u16(sums_of_2_cells[cell][i])));
       }
     }
-    // Update the rank_one_update vector
+    // Update the sums_of_each_slice vector
     for (int cell = 0; cell < kCells; cell++) {
       int32x4_t s01 =
           vaddq_s32(sums_of_4_cells[cell][0], sums_of_4_cells[cell][1]);
       int32x4_t s23 =
           vaddq_s32(sums_of_4_cells[cell][2], sums_of_4_cells[cell][3]);
       int32x4_t s = vaddq_s32(s01, s23);
-      int32x4_t u = vmulq_n_s32(s, dst->rank_one_update_multiplier());
-      std::int32_t* rank_one_update_ptr =
-          dst->rank_one_update() + start_width + 4 * cell;
-      vst1q_s32(rank_one_update_ptr,
-                vaddq_s32(u, vld1q_s32(rank_one_update_ptr)));
+      std::int32_t* sums_of_each_slice_ptr =
+          dst->sums_of_each_slice() + start_width + 4 * cell;
+      vst1q_s32(sums_of_each_slice_ptr,
+                vaddq_s32(s, vld1q_s32(sums_of_each_slice_ptr)));
     }
     dst->seek_forward_n_cells(kCells * kRegisterSize / kCellDepth);
   }
@@ -374,14 +373,13 @@ class PackingRegisterBlock<
       sums_of_16[cell] = vadd_u16(vget_low_u16(sums_of_8[cell]),
                                   vget_high_u16(sums_of_8[cell]));
     }
-    // Update the rank_one_update vector
+    // Update the sums_of_each_slice vector
     for (int cell = 0; cell < kCells; cell++) {
       int32x4_t s = vreinterpretq_s32_u32(vmovl_u16(sums_of_16[cell]));
-      int32x4_t u = vmulq_n_s32(s, dst->rank_one_update_multiplier());
-      std::int32_t* rank_one_update_ptr =
-          dst->rank_one_update() + start_width + 4 * cell;
-      vst1q_s32(rank_one_update_ptr,
-                vaddq_s32(u, vld1q_s32(rank_one_update_ptr)));
+      std::int32_t* sums_of_each_slice_ptr =
+          dst->sums_of_each_slice() + start_width + 4 * cell;
+      vst1q_s32(sums_of_each_slice_ptr,
+                vaddq_s32(s, vld1q_s32(sums_of_each_slice_ptr)));
     }
     dst->seek_forward_n_cells(kCells * kRegisterSize / kCellDepth);
   }

--- a/internal/single_thread_gemm.h
+++ b/internal/single_thread_gemm.h
@@ -66,9 +66,9 @@ void SingleThreadGemm(SingleThreadGemmContext* context,
   block_params.Init<KernelFormat>(rows, cols, depth, 1);
 
   PackedSideBlock<typename KernelFormat::Lhs> packed_lhs(
-      Side::Lhs, allocator, block_params, rhs_offset);
+      Side::Lhs, allocator, block_params);
   PackedSideBlock<typename KernelFormat::Rhs> packed_rhs(
-      Side::Rhs, allocator, block_params, lhs_offset);
+      Side::Rhs, allocator, block_params);
 
   PackedResult packed_result(allocator, block_params);
 
@@ -96,8 +96,8 @@ void SingleThreadGemm(SingleThreadGemmContext* context,
 
       auto result_block = result->block(r, c, rs, cs);
       UnpackResult<BitDepthParams>(&result_block, packed_result, depth,
-                                   packed_lhs.rank_one_update(),
-                                   packed_rhs.rank_one_update(), lhs_offset,
+                                   packed_lhs.sums_of_each_slice(),
+                                   packed_rhs.sums_of_each_slice(), lhs_offset,
                                    rhs_offset, output_pipeline);
     }
   }


### PR DESCRIPTION
Also rename PackedSideBlock::rank_one_update -> sums_of_each_slice.
This is in preparation for adding code to support different quantization
ranges per RHS row or LHS column.  Pre-multiplication will then stop working