### PR TITLE
Fix per channel quantization with multithreading.

### DIFF
--- a/internal/iterator.h
+++ b/internal/iterator.h
@@ -34,8 +34,9 @@ template <typename tScalar, VectorShape tShape>
 class ConstIterator<VectorMap<tScalar, tShape>> {
  public:
   typedef tScalar Scalar;
-  ConstIterator(const VectorMap<tScalar, tShape>& vector_map)
-      : pointer_(vector_map.data()) {}
+  ConstIterator(const VectorMap<tScalar, tShape>& vector_map,
+                const int start_offset)
+      : pointer_(vector_map.data() + start_offset) {}
   const Scalar operator*() const { return *pointer_; }
   const Scalar* get() const { return pointer_; }
   ConstIterator& operator+=(int inc) { pointer_ += inc; return *this; }
@@ -45,8 +46,9 @@ class ConstIterator<VectorMap<tScalar, tShape>> {
 
 template <typename tScalar, VectorShape tShape>
 ConstIterator<VectorMap<tScalar, tShape>> const_iterator(
-    const VectorMap<tScalar, tShape>& vector_map) {
-  return ConstIterator<VectorMap<tScalar, tShape>>(vector_map);
+    const VectorMap<tScalar, tShape>& vector_map,
+    const int start_offset) {
+  return ConstIterator<VectorMap<tScalar, tShape>>(vector_map, start_offset);
 }
 
 template <typename tScalar, VectorShape tShape> class VectorDup;
@@ -66,7 +68,8 @@ class ConstIterator<VectorDup<tScalar, tShape>> {
 
 template <typename tScalar, VectorShape tShape>
 ConstIterator<VectorDup<tScalar, tShape>> const_iterator(
-    const VectorDup<tScalar, tShape>& vector_map) {
+    const VectorDup<tScalar, tShape>& vector_map,
+    const int start_offset) {
   return ConstIterator<VectorDup<tScalar, tShape>>(vector_map);
 }
 

--- a/internal/single_thread_gemm.h
+++ b/internal/single_thread_gemm.h
@@ -100,8 +100,8 @@ void SingleThreadGemm(SingleThreadGemmContext* context,
 
       Compute(kernel, block_params, &packed_result, packed_lhs, packed_rhs);
 
-      auto result_block = result->block(r, c, rs, cs);
-      UnpackResult<BitDepthParams>(&result_block, packed_result, depth,
+      UnpackResult<BitDepthParams>(result, MatrixBlockBounds(r, c, rs, cs),
+                                   packed_result, depth,
                                    packed_lhs.sums_of_each_slice(),
                                    packed_rhs.sums_of_each_slice(),
                                    lhs_offset, rhs_offset, output_pipeline);

--- a/internal/unpack.h
+++ b/internal/unpack.h
@@ -87,15 +87,31 @@ std::int32_t RoundingMultiplyByConstantFraction(std::int32_t x) {
   return x * int_quotient + remaining_product;
 }
 
+struct MatrixBlockBounds {
+  int start_row;
+  int start_col;
+  int rows;
+  int cols;
+
+  MatrixBlockBounds(int start_row_, int start_col_, int rows_, int cols_)
+      : start_row(start_row_), start_col(start_col_), rows(rows_), cols(cols_) {
+  }
+};
+
 template <typename BitDepthParams, typename ResultBlockType,
           typename PackedResultType, typename LhsOffset, typename RhsOffset,
           typename OutputPipelineType>
 struct UnpackResultImplGeneric {
-  static void Unpack(ResultBlockType* dst, const PackedResultType& src,
-                     int depth, const std::int32_t* lhs_sums_of_each_slice,
+  static void Unpack(ResultBlockType* dst, const MatrixBlockBounds& dst_block,
+                     const PackedResultType& src, int depth,
+                     const std::int32_t* lhs_sums_of_each_slice,
                      const std::int32_t* rhs_sums_of_each_slice,
                      const LhsOffset& lhs_offset, const RhsOffset& rhs_offset,
                      const OutputPipelineType& output_pipeline) {
+    assert(dst_block.start_row >= 0);
+    assert(dst_block.start_row + dst_block.rows <= dst->rows());
+    assert(dst_block.start_col >= 0);
+    assert(dst_block.start_col + dst_block.cols <= dst->cols());
     auto src_map = src.Map();
     // No top-level blocking in the depth dimension at the moment.
     // Too much loss of precision.
@@ -105,8 +121,10 @@ struct UnpackResultImplGeneric {
     const std::int32_t kRhsMax = (1 << kRhsBits) - 1;
     OutputPipelineExecutor<OutputPipelineType, FragmentInt32x1x1>
         output_pipeline_executor(output_pipeline);
-    for (int c = 0; c < dst->cols(); c++) {
-      for (int r = 0; r < dst->rows(); r++) {
+    for (int c = 0; c < dst_block.cols; c++) {
+      int c_dst = c + dst_block.start_col;
+      for (int r = 0; r < dst_block.rows; r++) {
+        int r_dst = r + dst_block.start_row;
         // To understand this code, read
         //   doc/low-precision.txt
         //   doc/less-than-8-bit.txt
@@ -114,8 +132,8 @@ struct UnpackResultImplGeneric {
         // In case of requantization, we first need to scale them back
         // to the original scale, using RoundingMultiplyByConstantFraction.
         std::int32_t raw_xx = src_map(r, c);
-        std::int32_t raw_x1 = lhs_sums_of_each_slice[r] * rhs_offset(c);
-        std::int32_t raw_1x = rhs_sums_of_each_slice[c] * lhs_offset(r);
+        std::int32_t raw_x1 = lhs_sums_of_each_slice[r] * rhs_offset(c_dst);
+        std::int32_t raw_1x = rhs_sums_of_each_slice[c] * lhs_offset(r_dst);
         std::int32_t term_xx =
             RoundingMultiplyByConstantFraction<255 * 255, kLhsMax * kRhsMax>(
                 raw_xx);
@@ -127,7 +145,7 @@ struct UnpackResultImplGeneric {
         // Sum the 4 terms.
         FragmentInt32x1x1 sum = term_xx + term_x1 + term_1x + term_11;
 
-        output_pipeline_executor.Execute(sum, dst, r, c);
+        output_pipeline_executor.Execute(sum, dst, r_dst, c_dst);
       }
     }
   }
@@ -143,7 +161,8 @@ struct UnpackResultImpl
 template <typename BitDepthParams, typename ResultBlockType,
           typename PackedResultType, typename LhsOffset, typename RhsOffset,
           typename OutputPipelineType>
-void UnpackResult(ResultBlockType* dst, const PackedResultType& src, int depth,
+void UnpackResult(ResultBlockType* dst, const MatrixBlockBounds& dst_block,
+                  const PackedResultType& src, int depth,
                   const std::int32_t* lhs_sums_of_each_slice,
                   const std::int32_t* rhs_sums_of_each_slice,
                   const LhsOffset& lhs_offset, const RhsOffset& rhs_offset,
@@ -151,8 +170,8 @@ void UnpackResult(ResultBlockType* dst, const PackedResultType& src, int depth,
   ScopedProfilingLabel label("unpack");
   UnpackResultImpl<BitDepthParams, ResultBlockType, PackedResultType,
                    LhsOffset, RhsOffset, OutputPipelineType>::Unpack(
-      dst, src, depth, lhs_sums_of_each_slice, rhs_sums_of_each_slice,
-      lhs_offset, rhs_offset, output_pipeline);
+      dst, dst_block, src, depth, lhs_sums_of_each_slice,
+      rhs_sums_of_each_slice, lhs_offset, rhs_offset, output_pipeline);
 }
 
 }  // namespace gemmlowp


### PR DESCRIPTION
* Add a test that triggers multi-threaded implementation.
* Make sure offset indices account for matrix subblocks being processed.