### PR TITLE
Remove check for start_row divisible by 16 in Gemmlowp NEON unpack code.

### DIFF
--- a/internal/unpack_neon.h
+++ b/internal/unpack_neon.h
@@ -81,7 +81,6 @@ struct UnpackResultImpl<BitDepthParams,
                      const OutputPipelineType& output_pipeline) {
     ScopedProfilingLabel label("optimized path (NEON)");
     assert(dst_block.start_row >= 0);
-    assert(dst_block.start_row % 16 == 0);
     assert(dst_block.start_row + dst_block.rows <= dst->rows());
     assert(dst_block.start_col >= 0);
     assert(dst_block.start_col + dst_block.cols <= dst->cols());


### PR DESCRIPTION
There are no alignment requirements on inputs imposed by NEON unpacking code.