### PR TITLE
Include <array> in test.cc

### DIFF
--- a/test/test.cc
+++ b/test/test.cc
@@ -15,6 +15,7 @@
 #include "test.h"
 
 #include <unistd.h>
+#include <array>
 #include <cstdint>
 #include <cstdlib>
 #include <ctime>


### PR DESCRIPTION
This PR addresses a problem where `bazel build gemmlowp:all` fails on OS X because `array` is missing from test/test.cc. The error produced is:

```
ERROR: /Users/cfougner/code/gemmlp/gemmlowp/BUILD:116:1: C++ compilation of rule '//gemmlowp:test' failed: cc_wrapper.sh failed: error executing command external/local_config_cc/cc_wrapper.sh -U_FORTIFY_SOURCE '-D_FORTIFY_SOURCE=1' -fstack-protector -Wall -Wthread-safety -Wself-assign -fcolor-diagnostics -fno-omit-frame-pointer '-std=c++0x' -iquote . ... (remaining 23 argument(s) skipped): com.google.devtools.build.lib.shell.BadExitStatusException: Process exited with status 1.
gemmlowp/test/test.cc:1025:32: error: implicit instantiation of undefined template 'std::__1::array<int, 4>'
...
```
