### PR TITLE
Don't use posix_memalign when building for API 16 / x86 

### DIFF
--- a/internal/allocator.h
+++ b/internal/allocator.h
@@ -47,6 +47,13 @@
 #include <malloc.h>
 #define GEMMLOWP_USE_MEMALIGN
 #endif
+// posix_memalign is missing on some 4.1 x86 devices
+#if __ANDROID_API__ == 16
+#if __i386__
+#include <malloc.h>
+#define GEMMLOWP_USE_MEMALIGN
+#endif
+#endif
 #endif
 
 namespace gemmlowp {

--- a/internal/allocator.h
+++ b/internal/allocator.h
@@ -49,7 +49,7 @@
 #endif
 // posix_memalign is missing on some 4.1 x86 devices
 #if __ANDROID_API__ == 16
-#if __i386__
+#ifdef GEMMLOWP_X86_32
 #include <malloc.h>
 #define GEMMLOWP_USE_MEMALIGN
 #endif


### PR DESCRIPTION
This function is missing on some such devices. See [android bug 28834](https://code.google.com/p/android/issues/detail?id=28834)