### PR TITLE
Partial cleanup of build file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *binary*
 /.idea/
 CMakeLists.txt
+/bazel-*


### PR DESCRIPTION
I noticed this library was causing warnings to show up in the TensorFlow build. They brought me displeasure. So here's a pull request making them go away. I also pruned some of the complexity of these definitions. I'm not sure if this is the optimal way to use the C++ rules. But I will guarantee you that what you see in this PR is equivalent to what you had before.