### PR TITLE
Allow gemmlowp to be depended on as a dep on Android.

### DIFF
--- a/flags.bzl
+++ b/flags.bzl
@@ -1,3 +1,17 @@
-LIB_LINKOPTS = ["-lpthread"]
+config_setting(
+    name = "android",
+    values = {
+        "crosstool_top": "//external:android/crosstool",
+    },
+)
 
-BIN_LINKOPTS = ["-lpthread"]
+# Android builds do not need to link in a separate pthread library.
+LIB_LINKOPTS = select({
+    ":android": [],
+    "//conditions:default": ["-lpthread"],
+})
+
+BIN_LINKOPTS = select({
+    ":android": [],
+    "//conditions:default": ["-lpthread"],
+})


### PR DESCRIPTION
Android builds will break if -lpthread is specified, so selectively unset it if building under that config.