### PR TITLE
MetaGemm - 1D transformation framework

### DIFF
--- a/meta/base.h
+++ b/meta/base.h
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gemmlowp Authors. All Rights Reserved.
+// Copyright 2016 The Gemmlowp Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,11 +24,11 @@ namespace gemmlowp {
 namespace meta {
 
 template <int align>
-int AlignTo(int value) {
+inline int AlignTo(int value) {
   return ((value + align - 1) / align) * align;
 }
 
-int AlignTo(int align, int value) {
+inline int AlignTo(int align, int value) {
   return ((value + align - 1) / align) * align;
 }
 
@@ -104,6 +104,39 @@ class MulKernel {
   static void Multiply(const InType* lhs, const InType* rhs,
                        const FusedKernelParams<Kernel, OutputStream>& params,
                        OutType* result);
+};
+
+template <typename InType_, typename OutType_, typename Kernel_>
+struct Transform1DParams {
+  typedef InType_ InType;
+  typedef OutType_ OutType;
+  typedef Kernel_ Kernel;
+
+  const InType* input;
+  OutType* output;
+  uint8_t* scratch;
+
+  Kernel kernel;
+};
+
+template <typename InType, typename OutType, typename Kernel, int kernel_size,
+          int leftovers>
+class Transform1DKernel {
+ public:
+  static void Transform(const InType* input, const Kernel& params,
+                        OutType* output);
+};
+
+template <typename InType, typename OutType, typename Transform>
+class Transform1DUtil {
+ public:
+  static int EstimateComputeCost(const Transform& params);
+
+  static const InType* OffsetInput(const Transform& params, const InType* input,
+                                   int offset);
+
+  static OutType* OffsetOutput(const Transform& params, OutType* output,
+                               int offset);
 };
 
 }  // namespace meta

--- a/meta/generators/cc_emitter.py
+++ b/meta/generators/cc_emitter.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """CC code emitter.
 
 Used by generators to programatically prepare C++ code. Contains some simple

--- a/meta/generators/metagemm_generate_headers.sh
+++ b/meta/generators/metagemm_generate_headers.sh
@@ -3,5 +3,6 @@ python streams_arm_32.py > ../streams_arm_32.h
 python streams_arm_64.py > ../streams_arm_64.h
 python quantized_mul_kernels_arm_32.py > ../quantized_mul_kernels_arm_32.h
 python quantized_mul_kernels_arm_64.py > ../quantized_mul_kernels_arm_64.h
-
+python transform_kernels_arm_32.py > ../transform_kernels_arm_32.h
+python transform_kernels_arm_64.py > ../transform_kernels_arm_64.h
 

--- a/meta/generators/quantized_mul_kernels_arm_32.py
+++ b/meta/generators/quantized_mul_kernels_arm_32.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Generates the arm32 headers used by the gemm/gemv lib."""
 
 import cc_emitter
@@ -33,7 +32,8 @@ def Main():
   shapes = [(1, 1), (1, 2), (1, 3), (1, 4), (1, 5), (1, 6), (1, 7), (1, 8),
             (2, 1), (2, 2), (2, 3), (2, 4), (3, 1), (3, 2), (3, 3)]
 
-  quantized_mul_kernels_common.GenerateKernels(cc, neon_emitter.NeonEmitter(),
+  quantized_mul_kernels_common.GenerateKernels(cc,
+                                               neon_emitter.NeonEmitter(),
                                                shapes)
 
   cc.EmitNamespaceEnd()

--- a/meta/generators/quantized_mul_kernels_common.py
+++ b/meta/generators/quantized_mul_kernels_common.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """."""
 
 import common
@@ -19,8 +18,10 @@ import common
 
 def _ReadParams(emitter, registers, input_address, elements, min_register):
   registers_count = (elements + 3) / 4
-  registers = [registers.QuadRegister(min_register)
-               for unused_i in range(registers_count)]
+  registers = [
+      registers.QuadRegister(min_register)
+      for unused_i in range(registers_count)
+  ]
   emitter.EmitVLoadAE(registers_count * 4, 32, registers, input_address, 64)
   return registers
 
@@ -426,8 +427,9 @@ def _GenerateNxMLoadMultiplyAggregate(emitter, registers, kernel_m, kernel_n,
   emitter.EmitPldOffset(lhs, emitter.ImmediateConstant(64))
   emitter.EmitPldOffset(rhs, emitter.ImmediateConstant(64))
 
-  results = [registers.QuadRegister()
-             for unused_i in range(kernel_m * kernel_n)]
+  results = [
+      registers.QuadRegister() for unused_i in range(kernel_m * kernel_n)
+  ]
 
   for row in range(kernel_m):
     for col in range(kernel_n):

--- a/meta/generators/streams_arm_32.py
+++ b/meta/generators/streams_arm_32.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Generates the arm32 headers used by the gemm/gemv lib."""
 
 import cc_emitter

--- a/meta/generators/streams_arm_64.py
+++ b/meta/generators/streams_arm_64.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Generates the arm32 headers used by the gemm/gemv lib."""
 
 import cc_emitter

--- a/meta/generators/streams_common.py
+++ b/meta/generators/streams_common.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """."""
 
 import common
@@ -87,8 +86,8 @@ def _GenerateAggregatorReduction(emitter, registers, aggregators,
   emitter.EmitComment('Aggregator Reduction.')
 
   multiplier = registers.DoubleRegister()
-  emitter.EmitVMov('32', emitter.Lane(32, multiplier, 0),
-                   multiplicative_sum_offset)
+  emitter.EmitVMov('32',
+                   emitter.Lane(32, multiplier, 0), multiplicative_sum_offset)
 
   offset = registers.QuadRegister()
   emitter.EmitVDup('32', offset, additive_sum_offset)

--- a/meta/generators/transform_kernels_arm_32.py
+++ b/meta/generators/transform_kernels_arm_32.py
@@ -15,32 +15,29 @@
 
 import cc_emitter
 import common
-import neon_emitter_64
-import quantized_mul_kernels_common
+import neon_emitter
+import transform_kernels_common
 
 
 def Main():
   """."""
   cc = cc_emitter.CCEmitter()
-  common.GenerateHeader(cc, 'gemmlowp_meta_quantized_mul_kernels_arm_64',
-                        'GEMMLOWP_NEON_64')
+  common.GenerateHeader(cc, 'gemmlowp_meta_transform_kernels_arm_32',
+                        'GEMMLOWP_NEON_32')
 
   cc.EmitNamespaceBegin('gemmlowp')
   cc.EmitNamespaceBegin('meta')
   cc.EmitNewline()
 
-  shapes = [(1, 1), (1, 2), (1, 3), (1, 4), (1, 5), (1, 6), (1, 7), (1, 8),
-            (2, 1), (2, 2), (2, 3), (2, 4), (3, 1), (3, 2), (3, 3)]
-
-  quantized_mul_kernels_common.GenerateKernels(cc,
-                                               neon_emitter_64.NeonEmitter64(),
-                                               shapes)
+  transform_kernels_common.GenerateKernels(cc,
+                                           neon_emitter.NeonEmitter(),
+                                           [(16, x) for x in range(16)])
 
   cc.EmitNamespaceEnd()
   cc.EmitNamespaceEnd()
   cc.EmitNewline()
 
-  common.GenerateFooter(cc, 'Meta gemm for arm64 requires: GEMMLOWP_NEON_64!')
+  common.GenerateFooter(cc, 'Meta gemm for arm32 requires: GEMMLOWP_NEON_32!')
 
 
 if __name__ == '__main__':

--- a/meta/generators/transform_kernels_arm_64.py
+++ b/meta/generators/transform_kernels_arm_64.py
@@ -16,25 +16,22 @@
 import cc_emitter
 import common
 import neon_emitter_64
-import quantized_mul_kernels_common
+import transform_kernels_common
 
 
 def Main():
   """."""
   cc = cc_emitter.CCEmitter()
-  common.GenerateHeader(cc, 'gemmlowp_meta_quantized_mul_kernels_arm_64',
+  common.GenerateHeader(cc, 'gemmlowp_meta_transform_kernels_arm_64',
                         'GEMMLOWP_NEON_64')
 
   cc.EmitNamespaceBegin('gemmlowp')
   cc.EmitNamespaceBegin('meta')
   cc.EmitNewline()
 
-  shapes = [(1, 1), (1, 2), (1, 3), (1, 4), (1, 5), (1, 6), (1, 7), (1, 8),
-            (2, 1), (2, 2), (2, 3), (2, 4), (3, 1), (3, 2), (3, 3)]
-
-  quantized_mul_kernels_common.GenerateKernels(cc,
-                                               neon_emitter_64.NeonEmitter64(),
-                                               shapes)
+  transform_kernels_common.GenerateKernels(cc,
+                                           neon_emitter_64.NeonEmitter64(),
+                                           [(16, x) for x in range(16)])
 
   cc.EmitNamespaceEnd()
   cc.EmitNamespaceEnd()

--- a/meta/generators/transform_kernels_common.py
+++ b/meta/generators/transform_kernels_common.py
@@ -1,0 +1,590 @@
+# Copyright 2016 The Gemmlowp Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""."""
+
+import common
+
+
+def _DuplicateGeneralRegister(size, emitter, registers, value, min_register):
+  register = registers.QuadRegister(min_register)
+  emitter.EmitVDup(size, register, value)
+  return register
+
+
+def _DuplicateGeneralMemoryRegister(size, emitter, registers, value,
+                                    min_register):
+  register = registers.QuadRegister(min_register)
+  general = registers.GeneralRegister()
+  emitter.EmitLdr(general, value)
+  emitter.EmitVDup(size, register, general)
+  registers.FreeRegister(general)
+  return register
+
+
+class MinMaxTransformation(object):
+  """."""
+
+  def Check(self, in_type, out_type, kernel_size, leftovers):
+    assert in_type is 'uint8_t'
+    assert out_type is 'uint8_t'
+    assert kernel_size is 16
+    assert leftovers < 16
+
+  def Prepare(self, emitter, registers, unused_kernel_size):
+    emitter.EmitNewline()
+    emitter.EmitComment('MinMax::Prepare')
+
+    self.min = _DuplicateGeneralRegister(8, emitter, registers,
+                                         registers.MapParameter('min',
+                                                                'params.min'),
+                                         4)
+    self.max = _DuplicateGeneralRegister(8, emitter, registers,
+                                         registers.MapParameter('max',
+                                                                'params.max'),
+                                         4)
+
+  def Transform(self, emitter, registers, input_address, elements,
+                output_address):
+    """Generate the MinMax transform inner loop code."""
+    emitter.EmitNewline()
+    emitter.EmitComment('MinMax::Transform')
+    register_count = (elements + 15) / 16
+    load = [registers.QuadRegister() for unused_i in range(register_count)]
+    emitter.EmitVLoadAE(8, elements, load, input_address, None)
+    emitter.EmitPldOffset(input_address, emitter.ImmediateConstant(16))
+
+    for register in load:
+      emitter.EmitVMax('u8', register, register, self.min)
+
+    for register in load:
+      emitter.EmitVMin('u8', register, register, self.max)
+
+    emitter.EmitNewline()
+    emitter.EmitVStoreAE(8, elements, load, output_address, None)
+    emitter.EmitPld(output_address)
+    registers.FreeRegisters(load)
+
+
+class DequantizeTransformation(object):
+  """."""
+
+  def Check(self, in_type, out_type, kernel_size, leftovers):
+    assert in_type is 'uint8_t'
+    assert out_type is 'float'
+    assert kernel_size is 16
+    assert leftovers < 16
+
+  def Prepare(self, emitter, registers, unused_kernel_size):
+    """Duplicate quantization offsets to vector registers."""
+    emitter.EmitNewline()
+    emitter.EmitComment('Dequantize::Prepare')
+
+    self.range_min = _DuplicateGeneralRegister(
+        32, emitter, registers,
+        registers.MapParameter('range_min', 'params.range_min'), 4)
+    self.range_offset = _DuplicateGeneralRegister(
+        32, emitter, registers,
+        registers.MapParameter('range_offset', 'params.range_offset'), 4)
+    self.range_scale = _DuplicateGeneralRegister(
+        32, emitter, registers,
+        registers.MapParameter('range_scale', 'params.range_scale'), 4)
+
+  def Transform(self, emitter, registers, input_address, elements,
+                output_address):
+    """Emit the dequantization inner loop."""
+    emitter.EmitNewline()
+    emitter.EmitComment('Dequantize::Transform')
+    register_count = (elements + 3) / 4
+    load = [registers.QuadRegister() for unused_i in range(register_count)]
+    emitter.EmitVLoadAE(8, elements, load, input_address, None)
+    emitter.EmitPldOffset(input_address, emitter.ImmediateConstant(32))
+
+    if len(load) is 1:
+      emitter.EmitVMovl('u8', load[0], load[0])
+      emitter.EmitVMovl('s16', load[0], load[0])
+    elif len(load) is 2:
+      emitter.EmitVMovl('u8', load[0], load[0])
+      emitter.EmitVMovl2('s16', load[0], load[1], load[0])
+    elif len(load) is 3:
+      emitter.EmitVMovl2('u8', load[0], load[1], load[0])
+      emitter.EmitVMovl('s16', load[2], load[1])
+      emitter.EmitVMovl2('s16', load[0], load[1], load[0])
+    elif len(load) is 4:
+      emitter.EmitVMovl2('u8', load[0], load[1], load[0])
+      emitter.EmitVMovl2('s16', load[2], load[3], load[1])
+      emitter.EmitVMovl2('s16', load[0], load[1], load[0])
+    else:
+      assert False
+
+    for register in load:
+      emitter.EmitVCvt('f32', 's32', register, register)
+
+    for register in load:
+      emitter.EmitVSub('f32', register, register, self.range_offset)
+
+    for register in load:
+      emitter.EmitVMul('f32', register, register, self.range_scale)
+
+    for register in load:
+      emitter.EmitVAdd('f32', register, register, self.range_min)
+
+    emitter.EmitNewline()
+    emitter.EmitVStoreAE(32, elements, load, output_address, None)
+    emitter.EmitPld(output_address)
+    registers.FreeRegisters(load)
+
+
+class QuantizeTransformation(object):
+  """."""
+
+  def Check(self, in_type, out_type, kernel_size, leftovers):
+    assert in_type is 'float'
+    assert out_type is 'uint8_t'
+    assert kernel_size is 16
+    assert leftovers < 16
+
+  def Prepare(self, emitter, registers, unused_kernel_size):
+    """Duplicate quantization offsets to vector registers."""
+    emitter.EmitNewline()
+    emitter.EmitComment('Quantize::Prepare')
+
+    self.range_min = _DuplicateGeneralRegister(
+        32, emitter, registers,
+        registers.MapParameter('range_min', 'params.range_min'), 4)
+    self.range_offset = _DuplicateGeneralRegister(
+        32, emitter, registers,
+        registers.MapParameter('range_offset', 'params.range_offset'), 4)
+    self.range_scale = _DuplicateGeneralRegister(
+        32, emitter, registers,
+        registers.MapParameter('range_scale', 'params.range_scale'), 4)
+
+  def Transform(self, emitter, registers, input_address, elements,
+                output_address):
+    """Emit quantization inner loop code."""
+    emitter.EmitNewline()
+    emitter.EmitComment('Quantize::Transform')
+    register_count = (elements + 3) / 4
+    load = [registers.QuadRegister() for unused_i in range(register_count)]
+    emitter.EmitVLoadAE(32, elements, load, input_address, None)
+    emitter.EmitPldOffset(input_address, emitter.ImmediateConstant(64))
+
+    for register in load:
+      emitter.EmitVSub('f32', register, register, self.range_min)
+
+    for register in load:
+      emitter.EmitVMul('f32', register, register, self.range_scale)
+
+    for register in load:
+      emitter.EmitVAdd('f32', register, register, self.range_offset)
+
+    for register in load:
+      emitter.EmitVCvt('s32', 'f32', register, register)
+
+    if len(load) is 1:
+      emitter.EmitVQmovn('s32', load[0], load[0])
+      emitter.EmitVQmovun('s16', load[0], load[0])
+    elif len(load) is 2:
+      emitter.EmitVQmovn2('s32', load[0], load[0], load[1])
+      emitter.EmitVQmovun('s16', load[0], load[0])
+    elif len(load) is 3:
+      emitter.EmitVQmovn2('s32', load[0], load[0], load[1])
+      emitter.EmitVQmovn('s32', load[2], load[2])
+      emitter.EmitVQmovun2('s16', load[0], load[0], load[2])
+    elif len(load) is 4:
+      emitter.EmitVQmovn2('s32', load[0], load[0], load[1])
+      emitter.EmitVQmovn2('s32', load[2], load[2], load[3])
+      emitter.EmitVQmovun2('s16', load[0], load[0], load[2])
+    else:
+      assert False
+
+    emitter.EmitNewline()
+    emitter.EmitVStoreAE(8, elements, load, output_address, None)
+    emitter.EmitPld(output_address)
+    registers.FreeRegisters(load)
+
+
+class RequantizeTransformation(object):
+  """."""
+
+  def Check(self, in_type, out_type, kernel_size, leftovers):
+    assert in_type is 'int32_t'
+    assert out_type is 'uint8_t'
+    assert kernel_size is 16
+    assert leftovers < 16
+
+  def Prepare(self, emitter, registers, unused_kernel_size):
+    """Duplicate quantization parameters to vector registers."""
+    emitter.EmitNewline()
+    emitter.EmitComment('Requantize::Prepare')
+
+    self.range_min_delta = _DuplicateGeneralRegister(
+        32, emitter, registers,
+        registers.MapParameter('input_range_min', 'params.input_range_min'), 4)
+    self.output_range_min = _DuplicateGeneralRegister(
+        32, emitter, registers,
+        registers.MapParameter('output_range_min', 'params.output_range_min'),
+        4)
+    self.input_range_offset = _DuplicateGeneralRegister(
+        32, emitter, registers,
+        registers.MapParameter('input_range_offset',
+                               'params.input_range_offset'), 4)
+    self.input_range_scale = _DuplicateGeneralRegister(
+        32, emitter, registers,
+        registers.MapParameter('input_range_scale', 'params.input_range_scale'),
+        4)
+    self.one_over_output_range_scale = _DuplicateGeneralRegister(
+        32, emitter, registers,
+        registers.MapParameter('one_over_output_range_scale',
+                               'params.one_over_output_range_scale'), 4)
+    emitter.EmitVSub('f32', self.range_min_delta, self.range_min_delta,
+                     self.output_range_min)
+
+  def Transform(self, emitter, registers, input_address, elements,
+                output_address):
+    """Emit requantization inner loop code."""
+    emitter.EmitNewline()
+    emitter.EmitComment('Requantize::Transform')
+    register_count = (elements + 3) / 4
+    load = [registers.QuadRegister() for unused_i in range(register_count)]
+    emitter.EmitVLoadAE(32, elements, load, input_address, None)
+    emitter.EmitPldOffset(input_address, emitter.ImmediateConstant(64))
+
+    for register in load:
+      emitter.EmitVCvt('f32', 's32', register, register)
+
+    for register in load:
+      emitter.EmitVSub('f32', register, register, self.input_range_offset)
+
+    for register in load:
+      emitter.EmitVMul('f32', register, register, self.input_range_scale)
+
+    for register in load:
+      emitter.EmitVAdd('f32', register, register, self.range_min_delta)
+
+    for register in load:
+      emitter.EmitVMul('f32', register, register,
+                       self.one_over_output_range_scale)
+
+    for register in load:
+      emitter.EmitVCvt('s32', 'f32', register, register)
+
+    if len(load) is 1:
+      emitter.EmitVQmovn('s32', load[0], load[0])
+      emitter.EmitVQmovun('s16', load[0], load[0])
+    elif len(load) is 2:
+      emitter.EmitVQmovn2('s32', load[0], load[0], load[1])
+      emitter.EmitVQmovun('s16', load[0], load[0])
+    elif len(load) is 3:
+      emitter.EmitVQmovn2('s32', load[0], load[0], load[1])
+      emitter.EmitVQmovn('s32', load[2], load[2])
+      emitter.EmitVQmovun2('s16', load[0], load[0], load[2])
+    elif len(load) is 4:
+      emitter.EmitVQmovn2('s32', load[0], load[0], load[1])
+      emitter.EmitVQmovn2('s32', load[2], load[2], load[3])
+      emitter.EmitVQmovun2('s16', load[0], load[0], load[2])
+    else:
+      assert False
+
+    emitter.EmitNewline()
+    emitter.EmitVStoreAE(8, elements, load, output_address, None)
+    emitter.EmitPld(output_address)
+    registers.FreeRegisters(load)
+
+
+class BaseTransform(common.Transform1DKernelGenerator):
+  """."""
+
+  def __init__(self, cc_emitter, kernel_name, asm_emitter, transformation):
+    common.Transform1DKernelGenerator.__init__(self, cc_emitter, kernel_name)
+    self.asm_emitter = asm_emitter
+    self.transformation = transformation
+
+  def EmitTransform(self, in_type, out_type, kernel_size, leftovers):
+    """."""
+    self.transformation.Check(in_type, out_type, kernel_size, leftovers)
+
+    registers = self.asm_emitter.CreateRegisters()
+
+    self.emitter.EmitDeclare('int', 'params_count_copy', 'params.count')
+
+    self.asm_emitter.PushIndent(self.emitter.indent)
+    self.asm_emitter.EmitAsmBegin()
+
+    count = registers.MapOutputParameter('count', 'params_count_copy')
+    input_address = registers.MapOutputParameter('input')
+    output_address = registers.MapOutputParameter('output')
+
+    self.transformation.Prepare(self.asm_emitter, registers, kernel_size)
+
+    if leftovers:
+      self.asm_emitter.EmitNewline()
+      self.asm_emitter.EmitComment('Reduce count by leftovers.')
+      self.asm_emitter.EmitSubs(count, count,
+                                self.asm_emitter.ImmediateConstant(leftovers))
+      self.asm_emitter.EmitBeqFront(2)
+
+    self.asm_emitter.EmitNewline()
+    self.asm_emitter.EmitNumericalLabel(1)
+    self.asm_emitter.EmitSubs(count, count,
+                              self.asm_emitter.ImmediateConstant(kernel_size))
+
+    self.transformation.Transform(self.asm_emitter, registers, input_address,
+                                  kernel_size, output_address)
+
+    self.asm_emitter.EmitNewline()
+    self.asm_emitter.EmitBneBack(1)
+
+    if leftovers:
+      self.asm_emitter.EmitNumericalLabel(2)
+      self.asm_emitter.EmitNewline()
+      self.asm_emitter.EmitComment('Handle leftovers.')
+      self.transformation.Transform(self.asm_emitter, registers, input_address,
+                                    leftovers, output_address)
+
+    self.asm_emitter.EmitAsmEnd(registers)
+    self.asm_emitter.PopIndent(len(self.emitter.indent))
+
+
+class Requantize(BaseTransform):
+  """."""
+
+  def __init__(self, cc_emitter, asm_emitter):
+    BaseTransform.__init__(self, cc_emitter, 'Requantize', asm_emitter,
+                           RequantizeTransformation())
+
+
+class Quantize(BaseTransform):
+  """."""
+
+  def __init__(self, cc_emitter, asm_emitter):
+    BaseTransform.__init__(self, cc_emitter, 'Quantize', asm_emitter,
+                           QuantizeTransformation())
+
+
+class Dequantize(BaseTransform):
+  """."""
+
+  def __init__(self, cc_emitter, asm_emitter):
+    BaseTransform.__init__(self, cc_emitter, 'Dequantize', asm_emitter,
+                           DequantizeTransformation())
+
+
+class MinMax(BaseTransform):
+  """."""
+
+  def __init__(self, numerical_type, cc_emitter, asm_emitter):
+    BaseTransform.__init__(self, cc_emitter, 'MinMax<%s>' % numerical_type,
+                           asm_emitter, MinMaxTransformation())
+
+
+class BiasAdd(common.Transform1DKernelGenerator):
+  """."""
+
+  def __init__(self, bias_type, cc_emitter, asm_emitter):
+    common.Transform1DKernelGenerator.__init__(self, cc_emitter,
+                                               'BiasAdd<%s>' % bias_type)
+    self.asm_emitter = asm_emitter
+
+  def EmitTransform(self, in_type, out_type, kernel_size, leftovers):
+    """."""
+    assert in_type is 'uint8_t'
+    assert out_type is 'int32_t'
+    assert kernel_size is 16
+    assert leftovers < 16
+
+    registers = self.asm_emitter.CreateRegisters()
+
+    self.emitter.EmitDeclare('int', 'params_rows_copy', 'params.rows')
+
+    self.asm_emitter.PushIndent(self.emitter.indent)
+    self.asm_emitter.EmitAsmBegin()
+
+    self._Prepare(self.asm_emitter, registers)
+
+    rows = registers.MapParameter('rows', 'params_rows_copy')
+
+    self.asm_emitter.EmitNumericalLabel(1)
+
+    self._ProcessRow(self.asm_emitter, registers, kernel_size, leftovers)
+
+    self.asm_emitter.EmitSubs(rows, rows, self.asm_emitter.ImmediateConstant(1))
+    self.asm_emitter.EmitBneBack(1)
+
+    self.asm_emitter.EmitAsmEnd(registers)
+    self.asm_emitter.PopIndent(len(self.emitter.indent))
+
+  def _Prepare(self, emitter, registers):
+    self.input_range_min = _DuplicateGeneralMemoryRegister(
+        32, emitter, registers,
+        registers.MapMemoryParameter('input_range_min',
+                                     'params.input_range_min'), 8)
+    self.input_range_scale = _DuplicateGeneralMemoryRegister(
+        32, emitter, registers,
+        registers.MapMemoryParameter('input_range_scale',
+                                     'params.input_range_scale'), 8)
+    self.bias_range_min = _DuplicateGeneralMemoryRegister(
+        32, emitter, registers,
+        registers.MapMemoryParameter('bias_range_min', 'params.bias_range_min'),
+        8)
+    self.bias_range_scale = _DuplicateGeneralMemoryRegister(
+        32, emitter, registers,
+        registers.MapMemoryParameter('bias_range_scale',
+                                     'params.bias_range_scale'), 8)
+    self.output_range_min = _DuplicateGeneralMemoryRegister(
+        32, emitter, registers,
+        registers.MapMemoryParameter('output_range_min',
+                                     'params.output_range_min'), 8)
+    self.one_over_output_range_scale = _DuplicateGeneralMemoryRegister(
+        32, emitter, registers,
+        registers.MapMemoryParameter('one_over_output_range_scale',
+                                     'params.one_over_output_range_scale'), 8)
+    self.output_range_offset = _DuplicateGeneralMemoryRegister(
+        32, emitter, registers,
+        registers.MapMemoryParameter('output_range_offset',
+                                     'params.output_range_offset'), 8)
+
+  def _ProcessRow(self, emitter, registers, kernel_size, leftovers):
+    const_count = registers.MapParameter('count', 'params.count')
+    const_bias = registers.MapParameter('bias', 'params.bias')
+
+    count = registers.GeneralRegister()
+    bias = registers.GeneralRegister()
+
+    input_address = registers.MapOutputParameter('input')
+    output_address = registers.MapOutputParameter('output')
+
+    emitter.EmitMov(count, const_count)
+    emitter.EmitMov(bias, const_bias)
+
+    if leftovers:
+      emitter.EmitSubs(count, count, emitter.ImmediateConstant(leftovers))
+      emitter.EmitBeqFront(3)
+
+    emitter.EmitNumericalLabel(2)
+    emitter.EmitSubs(count, count, emitter.ImmediateConstant(kernel_size))
+
+    self._BiasAdd(emitter, registers, kernel_size, input_address, bias,
+                  output_address)
+
+    emitter.EmitBneBack(2)
+
+    if leftovers:
+      emitter.EmitNumericalLabel(3)
+      self._BiasAdd(emitter, registers, leftovers, input_address, bias,
+                    output_address)
+
+  def _BiasAdd(self, emitter, registers, elements, input_address, bias,
+               output_address):
+    emitter.EmitNewline()
+    emitter.EmitComment('BiasAdd::Transform')
+    register_count = (elements + 3) / 4
+
+    load_input = [
+        registers.QuadRegister() for unused_i in range(register_count)
+    ]
+    load_bias = [registers.QuadRegister() for unused_i in range(register_count)]
+
+    emitter.EmitVLoadAE(8, elements, load_input, input_address, None)
+    emitter.EmitVLoadAE(8, elements, load_bias, bias, None)
+    emitter.EmitPldOffset(input_address, emitter.ImmediateConstant(32))
+
+    if len(load_input) is 1:
+      emitter.EmitVMovl('u8', load_input[0], load_input[0])
+      emitter.EmitVMovl('u8', load_bias[0], load_bias[0])
+      emitter.EmitVMovl('s16', load_input[0], load_input[0])
+      emitter.EmitVMovl('s16', load_bias[0], load_bias[0])
+    elif len(load_input) is 2:
+      emitter.EmitVMovl('u8', load_input[0], load_input[0])
+      emitter.EmitVMovl('u8', load_bias[0], load_bias[0])
+      emitter.EmitVMovl2('s16', load_input[0], load_input[1], load_input[0])
+      emitter.EmitVMovl2('s16', load_bias[0], load_bias[1], load_bias[0])
+    elif len(load_input) is 3:
+      emitter.EmitVMovl2('u8', load_input[0], load_input[1], load_input[0])
+      emitter.EmitVMovl2('u8', load_bias[0], load_bias[1], load_bias[0])
+      emitter.EmitVMovl('s16', load_input[2], load_input[1])
+      emitter.EmitVMovl('s16', load_bias[2], load_bias[1])
+      emitter.EmitVMovl2('s16', load_input[0], load_input[1], load_input[0])
+      emitter.EmitVMovl2('s16', load_bias[0], load_bias[1], load_bias[0])
+    elif len(load_input) is 4:
+      emitter.EmitVMovl2('u8', load_input[0], load_input[1], load_input[0])
+      emitter.EmitVMovl2('u8', load_bias[0], load_bias[1], load_bias[0])
+      emitter.EmitVMovl2('s16', load_input[2], load_input[3], load_input[1])
+      emitter.EmitVMovl2('s16', load_bias[2], load_bias[3], load_bias[1])
+      emitter.EmitVMovl2('s16', load_input[0], load_input[1], load_input[0])
+      emitter.EmitVMovl2('s16', load_bias[0], load_bias[1], load_bias[0])
+    else:
+      assert False
+
+    for register in load_input + load_bias:
+      emitter.EmitVCvt('f32', 's32', register, register)
+
+    for register in load_input:
+      emitter.EmitVMul('f32', register, register, self.input_range_scale)
+
+    for register in load_bias:
+      emitter.EmitVMul('f32', register, register, self.bias_range_scale)
+
+    for register in load_input:
+      emitter.EmitVAdd('f32', register, register, self.input_range_min)
+
+    for register in load_bias:
+      emitter.EmitVAdd('f32', register, register, self.bias_range_min)
+
+    for (register_1, register_2) in zip(load_input, load_bias):
+      emitter.EmitVAdd('f32', register_1, register_1, register_2)
+
+    for register in load_input:
+      emitter.EmitVSub('f32', register, register, self.output_range_min)
+
+    for register in load_input:
+      emitter.EmitVMul('f32', register, register,
+                       self.one_over_output_range_scale)
+
+    for register in load_input:
+      emitter.EmitVAdd('f32', register, register, self.output_range_offset)
+
+    for register in load_input:
+      emitter.EmitVCvt('s32', 'f32', register, register)
+
+    emitter.EmitNewline()
+    emitter.EmitVStoreAE(32, elements, load_input, output_address, None)
+    emitter.EmitPld(output_address)
+    registers.FreeRegisters(load_input + load_bias)
+
+
+def GenerateKernels(cc_emitter, asm_emitter, shapes):
+  """Generate the quantization/dequantization/requantization kernels."""
+  requantize = Requantize(cc_emitter, asm_emitter)
+  quantize = Quantize(cc_emitter, asm_emitter)
+  dequantize = Dequantize(cc_emitter, asm_emitter)
+  minmax = MinMax('uint8_t', cc_emitter, asm_emitter)
+  biasadd = BiasAdd('uint8_t', cc_emitter, asm_emitter)
+
+  for shape in shapes:
+    requantize.SpecializeTransform1DKernel('int32_t', 'uint8_t', shape[0],
+                                           shape[1])
+
+  for shape in shapes:
+    quantize.SpecializeTransform1DKernel('float', 'uint8_t', shape[0], shape[1])
+
+  for shape in shapes:
+    dequantize.SpecializeTransform1DKernel('uint8_t', 'float', shape[0],
+                                           shape[1])
+
+  for shape in shapes:
+    minmax.SpecializeTransform1DKernel('uint8_t', 'uint8_t', shape[0], shape[1])
+
+  for shape in shapes:
+    biasadd.SpecializeTransform1DKernel('uint8_t', 'int32_t', shape[0],
+                                        shape[1])

--- a/meta/multi_thread_common.h
+++ b/meta/multi_thread_common.h
@@ -1,0 +1,50 @@
+// Copyright 2016 The Gemmlowp Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GEMMLOWP_META_MULTI_THREAD_COMMON_H_
+#define GEMMLOWP_META_MULTI_THREAD_COMMON_H_
+
+#include "../internal/multi_thread_gemm.h"
+
+namespace gemmlowp {
+namespace meta {
+
+inline int ResolveMaxThreads(int max_threads) {
+  if (max_threads == 0) {
+    static const int hardware_threads_count =
+        static_cast<int>(sysconf(_SC_NPROCESSORS_CONF));
+    return hardware_threads_count;
+  }
+  return max_threads;
+}
+
+template <typename WorkersPool>
+class SimpleContext {
+ public:
+  SimpleContext(int max_num_threads, WorkersPool* pool)
+      : max_num_threads_(max_num_threads), pool_(pool) {}
+
+  WorkersPool* workers_pool() { return pool_; }
+
+  int max_num_threads() { return max_num_threads_; }
+
+ private:
+  int max_num_threads_;
+  WorkersPool* pool_;
+};
+
+}  // namespace meta
+}  // namespace gemmlowp
+
+#endif  // GEMMLOWP_META_MULTI_THREAD_COMMON_H_

--- a/meta/multi_thread_gemm.h
+++ b/meta/multi_thread_gemm.h
@@ -15,29 +15,20 @@
 #ifndef GEMMLOWP_META_MULTI_THREAD_GEMM_H_
 #define GEMMLOWP_META_MULTI_THREAD_GEMM_H_
 
-#include "../internal/multi_thread_gemm.h"
+#include "multi_thread_common.h"
 #include "single_thread_gemm.h"
 
 namespace gemmlowp {
 namespace meta {
 namespace internal {
 
-const std::int32_t kMinTaskSize = 16000;
-const std::int32_t kMinTaskDimension = 4;
-
-int ResolveMaxThreads(int max_threads) {
-  if (max_threads == 0) {
-    static const int hardware_threads_count =
-        static_cast<int>(sysconf(_SC_NPROCESSORS_CONF));
-    return hardware_threads_count;
-  }
-  return max_threads;
-}
+const std::int32_t kMinGemmTaskSize = 16000;
+const std::int32_t kMinGemmTaskDimension = 4;
 
 template <typename Executor, typename Params>
-uint8_t* PrepareTask(const Params& params, int kernel_m, int kernel_n,
-                     int kernel_k, uint8_t* scratch, int m_start, int m,
-                     int n_start, int n, std::vector<Params>* tasks) {
+uint8_t* PrepareGemmTask(const Params& params, int kernel_m, int kernel_n,
+                         int kernel_k, uint8_t* scratch, int m_start, int m,
+                         int n_start, int n, std::vector<Params>* tasks) {
   tasks->push_back(params);
   Params& task = tasks->back();
   task.scratch = scratch;
@@ -62,13 +53,14 @@ uint8_t* PrepareTask(const Params& params, int kernel_m, int kernel_n,
 }
 
 template <typename MultiThreadingContext, typename Executor, typename Params>
-bool PrepareTasks(MultiThreadingContext* context, const Params& params,
-                  int kernel_m, int kernel_n, int kernel_k,
-                  std::vector<Params>* tasks) {
+bool PrepareGemmTasks(MultiThreadingContext* context, const Params& params,
+                      int kernel_m, int kernel_n, int kernel_k,
+                      std::vector<Params>* tasks) {
   const int max_threads = ResolveMaxThreads(context->max_num_threads());
-  const int max_tasks_by_size = (params.m * params.n * params.k) / kMinTaskSize;
-  const int max_tasks_m = params.m / kMinTaskDimension;
-  const int max_tasks_n = params.n / kMinTaskDimension;
+  const int max_tasks_by_size =
+      (params.m * params.n * params.k) / kMinGemmTaskSize;
+  const int max_tasks_m = params.m / kMinGemmTaskDimension;
+  const int max_tasks_n = params.n / kMinGemmTaskDimension;
   const int max_tasks_dimension = std::max(max_tasks_m, max_tasks_n);
 
   const int real_tasks = std::max(
@@ -84,23 +76,25 @@ bool PrepareTasks(MultiThreadingContext* context, const Params& params,
   if (max_tasks_m > max_tasks_n) {
     const int m_chunk = params.m / real_tasks;
     for (int i = 0; i < real_tasks - 1; ++i) {
-      scratch = PrepareTask<Executor, Params>(params, kernel_m, kernel_n,
-                                              kernel_k, scratch, i * m_chunk,
-                                              m_chunk, 0, params.n, tasks);
+      scratch = PrepareGemmTask<Executor, Params>(
+          params, kernel_m, kernel_n, kernel_k, scratch, i * m_chunk, m_chunk,
+          0, params.n, tasks);
     }
     const int sum_m = (real_tasks - 1) * m_chunk;
-    PrepareTask<Executor, Params>(params, kernel_m, kernel_n, kernel_k, scratch,
-                                  sum_m, params.m - sum_m, 0, params.n, tasks);
+    PrepareGemmTask<Executor, Params>(params, kernel_m, kernel_n, kernel_k,
+                                      scratch, sum_m, params.m - sum_m, 0,
+                                      params.n, tasks);
   } else {
     const int n_chunk = params.n / real_tasks;
     for (int i = 0; i < real_tasks - 1; ++i) {
-      scratch = PrepareTask<Executor, Params>(params, kernel_m, kernel_n,
-                                              kernel_k, scratch, 0, params.m,
-                                              i * n_chunk, n_chunk, tasks);
+      scratch = PrepareGemmTask<Executor, Params>(
+          params, kernel_m, kernel_n, kernel_k, scratch, 0, params.m,
+          i * n_chunk, n_chunk, tasks);
     }
     int sum_n = (real_tasks - 1) * n_chunk;
-    PrepareTask<Executor, Params>(params, kernel_m, kernel_n, kernel_k, scratch,
-                                  0, params.m, sum_n, params.n - sum_n, tasks);
+    PrepareGemmTask<Executor, Params>(params, kernel_m, kernel_n, kernel_k,
+                                      scratch, 0, params.m, sum_n,
+                                      params.n - sum_n, tasks);
   }
 
   return true;
@@ -108,8 +102,8 @@ bool PrepareTasks(MultiThreadingContext* context, const Params& params,
 
 template <typename Executor, typename Params, int kernel_m, int kernel_n,
           int kernel_k>
-struct TaskRunner : gemmlowp::Task {
-  TaskRunner(const Params& params) : params(params) {}
+struct GemmTaskRunner : gemmlowp::Task {
+  GemmTaskRunner(const Params& params) : params(params) {}
 
   void Run() const override {
     Gemm<Executor, Params, kernel_m, kernel_n, kernel_k>(params);
@@ -122,18 +116,20 @@ struct TaskRunner : gemmlowp::Task {
 
 template <typename MultiThreadingContext, typename Executor, typename Params,
           int kernel_m, int kernel_n, int kernel_k>
-void MultiThreadGemm(MultiThreadingContext* context, const Params& params) {
-  typedef internal::TaskRunner<Executor, Params, kernel_m, kernel_n, kernel_k>
+inline void MultiThreadGemm(MultiThreadingContext* context,
+                            const Params& params) {
+  typedef internal::GemmTaskRunner<Executor, Params, kernel_m, kernel_n,
+                                   kernel_k>
       TaskRunnerType;
 
   std::vector<Params> tasks;
-  if (!internal::PrepareTasks<MultiThreadingContext, Executor, Params>(
+  if (!internal::PrepareGemmTasks<MultiThreadingContext, Executor, Params>(
           context, params, kernel_m, kernel_n, kernel_k, &tasks)) {
     Gemm<Executor, Params, kernel_m, kernel_n, kernel_k>(params);
     return;
   }
 
-  int worker_tasks_count = tasks.size() - 1;
+  const int worker_tasks_count = tasks.size() - 1;
   auto workers_pool = context->workers_pool();
 
   workers_pool->CreateWorkers(worker_tasks_count);
@@ -145,21 +141,6 @@ void MultiThreadGemm(MultiThreadingContext* context, const Params& params) {
   Gemm<Executor, Params, kernel_m, kernel_n, kernel_k>(tasks.back());
   workers_pool->Wait();
 }
-
-template <typename WorkersPool>
-class SimpleContext {
- public:
-  SimpleContext(int max_num_threads, WorkersPool* pool)
-      : max_num_threads_(max_num_threads), pool_(pool) {}
-
-  WorkersPool* workers_pool() { return pool_; }
-
-  int max_num_threads() { return max_num_threads_; }
-
- private:
-  int max_num_threads_;
-  WorkersPool* pool_;
-};
 
 }  // namespace meta
 }  // namespace gemmlowp

--- a/meta/multi_thread_transform.h
+++ b/meta/multi_thread_transform.h
@@ -1,0 +1,103 @@
+// Copyright 2016 The Gemmlowp Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GEMMLOWP_META_MULTI_THREAD_TRANSFORM_H_
+#define GEMMLOWP_META_MULTI_THREAD_TRANSFORM_H_
+
+#include "multi_thread_common.h"
+#include "single_thread_transform.h"
+
+namespace gemmlowp {
+namespace meta {
+namespace internal {
+
+const int kTransformTaskOverhead = 128000;
+const int kMinTransformTaskSize = 32000;
+
+template <typename MultiThreadingContext, typename Params>
+inline bool PrepareTransform1DTasks(MultiThreadingContext* context,
+                                    const Params& params, int kernel_size,
+                                    std::vector<Params>* tasks) {
+  typedef Transform1DUtil<typename Params::InType, typename Params::OutType,
+                          typename Params::Kernel>
+      Util;
+
+  const int max_threads = ResolveMaxThreads(context->max_num_threads());
+  const int task_size = Util::EstimateComputeCost(params.kernel);
+  const int max_tasks_by_size =
+      (task_size - kTransformTaskOverhead) / kMinTransformTaskSize;
+
+  const int real_tasks = std::max(1, std::min(max_threads, max_tasks_by_size));
+
+  if (real_tasks == 1) {
+    return false;
+  }
+
+  const int chunk = params.kernel.count / real_tasks;
+  for (int i = 0; i < real_tasks - 1; ++i) {
+    tasks->push_back(params);
+    Params& task = tasks->back();
+    task.kernel.count = chunk;
+    task.input = Util::OffsetInput(params.kernel, params.input, i * chunk);
+    task.output = Util::OffsetOutput(params.kernel, params.output, i * chunk);
+  }
+  tasks->push_back(params);
+  Params& task = tasks->back();
+  const int sum_chunk = (real_tasks - 1) * chunk;
+  task.kernel.count = params.kernel.count - sum_chunk;
+  task.input = Util::OffsetInput(params.kernel, params.input, sum_chunk);
+  task.output = Util::OffsetOutput(params.kernel, params.output, sum_chunk);
+  return true;
+}
+
+template <typename Params, int kernel_size>
+struct Transform1DTaskRunner : gemmlowp::Task {
+  Transform1DTaskRunner(const Params& params) : params(params) {}
+
+  void Run() const override { Transform1D<Params, kernel_size>(params); }
+
+  Params params;
+};
+
+}  // namespace internal
+
+template <typename MultiThreadingContext, typename Params, int kernel_size>
+inline void MultiThreadTransform1D(MultiThreadingContext* context,
+                                   const Params& params) {
+  typedef internal::Transform1DTaskRunner<Params, kernel_size> TaskRunnerType;
+
+  std::vector<Params> tasks;
+  if (!internal::PrepareTransform1DTasks<MultiThreadingContext, Params>(
+          context, params, kernel_size, &tasks)) {
+    Transform1D<Params, kernel_size>(params);
+    return;
+  }
+
+  const int worker_tasks_count = tasks.size() - 1;
+  auto workers_pool = context->workers_pool();
+
+  workers_pool->CreateWorkers(worker_tasks_count);
+  workers_pool->Prepare(worker_tasks_count);
+
+  for (int i = 0; i < worker_tasks_count; ++i) {
+    workers_pool->StartWorker(i, new TaskRunnerType(tasks[i]));
+  }
+  Transform1D<Params, kernel_size>(tasks.back());
+  workers_pool->Wait();
+}
+
+}  // namespace meta
+}  // namespace gemmlowp
+
+#endif  // GEMMLOWP_META_MULTI_THREAD_TRANSFORM_H_

--- a/meta/quantized_mul_kernels_arm_32.h
+++ b/meta/quantized_mul_kernels_arm_32.h
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gemmlowp Authors. All Rights Reserved.
+// Copyright 2016 The Gemmlowp Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,11 +24,12 @@ namespace gemmlowp {
 namespace meta {
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 1,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 1,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -97,11 +98,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 1,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 2,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 2,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -174,11 +176,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 2,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 3,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 3,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -257,11 +260,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 3,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 4,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 4,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -344,11 +348,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 4,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 5,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 5,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -444,11 +449,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 5,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 6,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 6,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -548,11 +554,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 6,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 7,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 7,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -658,11 +665,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 7,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 8,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 8,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -772,11 +780,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 8,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 1,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 1,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -860,11 +869,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 1,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 2,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 2,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -957,11 +967,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 2,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 3,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 3,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -1067,11 +1078,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 3,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 4,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 4,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -1185,11 +1197,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 4,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 1,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 1,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -1289,11 +1302,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 1,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 2,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 2,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -1406,11 +1420,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 2,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 3,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 3,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -1544,7 +1559,7 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 3,
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 1,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -1608,7 +1623,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 2,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -1676,7 +1691,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 3,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -1750,7 +1765,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 4,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -1828,7 +1843,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 5,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -1915,7 +1930,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 6,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -2005,7 +2020,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 7,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -2101,7 +2116,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 8,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -2202,7 +2217,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 1,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -2276,7 +2291,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 2,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -2359,7 +2374,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 3,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -2455,7 +2470,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 4,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -2559,7 +2574,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 1,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -2643,7 +2658,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 2,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -2741,7 +2756,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 3,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -2860,7 +2875,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 1,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -2928,7 +2943,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 2,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -3000,7 +3015,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 3,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -3078,7 +3093,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 4,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -3160,7 +3175,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 5,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -3253,7 +3268,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 6,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -3349,7 +3364,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 7,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -3451,7 +3466,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 8,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -3558,7 +3573,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 1,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -3638,7 +3653,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 2,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -3727,7 +3742,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 3,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -3829,7 +3844,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 4,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -3939,7 +3954,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 1,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -4031,7 +4046,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 2,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -4137,7 +4152,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 3,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,

--- a/meta/quantized_mul_kernels_arm_64.h
+++ b/meta/quantized_mul_kernels_arm_64.h
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gemmlowp Authors. All Rights Reserved.
+// Copyright 2016 The Gemmlowp Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,11 +24,12 @@ namespace gemmlowp {
 namespace meta {
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 1,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 1,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -96,11 +97,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 1,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 2,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 2,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -171,11 +173,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 2,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 3,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 3,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -252,11 +255,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 3,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 4,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 4,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -335,11 +339,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 4,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 5,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 5,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -431,11 +436,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 5,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 6,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 6,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -530,11 +536,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 6,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 7,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 7,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -634,11 +641,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 7,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 8,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 8,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -740,11 +748,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 8,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 1,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 1,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -828,11 +837,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 1,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 2,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 2,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -922,11 +932,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 2,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 3,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 3,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -1026,11 +1037,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 3,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 4,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 4,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -1136,11 +1148,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 4,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 1,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 1,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -1239,11 +1252,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 1,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 2,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 2,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -1351,11 +1365,12 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 2,
 }
 
 template <>
-void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 3,
-               8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
-                            const FusedKernelParams<QuantizedStaticPreprocessed,
-                                                    RowMajor>& params,
-                            uint8_t* result) {
+inline void
+MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 3,
+          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+                       const FusedKernelParams<QuantizedStaticPreprocessed,
+                                               RowMajor>& params,
+                       uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
@@ -1482,7 +1497,7 @@ void MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 3,
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 1,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -1545,7 +1560,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 2,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -1611,7 +1626,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 3,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -1683,7 +1698,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 4,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -1757,7 +1772,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 5,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -1840,7 +1855,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 6,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -1926,7 +1941,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 7,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -2017,7 +2032,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 8,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -2110,7 +2125,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 1,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -2183,7 +2198,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 2,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -2263,7 +2278,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 3,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -2353,7 +2368,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 4,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -2449,7 +2464,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 1,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -2533,7 +2548,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 2,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -2626,7 +2641,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 3,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
@@ -2738,7 +2753,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 1,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -2805,7 +2820,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 2,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -2875,7 +2890,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 3,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -2951,7 +2966,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 4,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -3029,7 +3044,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 5,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -3118,7 +3133,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 6,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -3210,7 +3225,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 7,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -3307,7 +3322,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 8,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -3406,7 +3421,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 1,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -3485,7 +3500,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 2,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -3571,7 +3586,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 3,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -3667,7 +3682,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 4,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -3769,7 +3784,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 1,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -3861,7 +3876,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 2,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
@@ -3962,7 +3977,7 @@ void MulKernel<
 }
 
 template <>
-void MulKernel<
+inline void MulKernel<
     uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 3,
     8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,

--- a/meta/single_thread_gemm.h
+++ b/meta/single_thread_gemm.h
@@ -399,9 +399,9 @@ class GemmExecutorPackLHS {
 
 namespace internal {
 
-int CalculateCacheFriendlyTasksCount(int cache_size, int constant_memory,
-                                     int per_chunk_memory, int total_dim,
-                                     int chunk_dim) {
+inline int CalculateCacheFriendlyTasksCount(int cache_size, int constant_memory,
+                                            int per_chunk_memory, int total_dim,
+                                            int chunk_dim) {
   assert(constant_memory + per_chunk_memory < cache_size);
   const int available_cache = cache_size - constant_memory;
   const int available_chunks = available_cache / per_chunk_memory;
@@ -410,8 +410,8 @@ int CalculateCacheFriendlyTasksCount(int cache_size, int constant_memory,
 }
 
 template <typename Params>
-void UpdateCacheFriendlyTask(int m_offset, int m, int n_offset, int n,
-                             const Params& params, Params* task_params) {
+inline void UpdateCacheFriendlyTask(int m_offset, int m, int n_offset, int n,
+                                    const Params& params, Params* task_params) {
   task_params->m = m;
   task_params->lhs =
       StreamUtil<typename Params::InType, typename Params::LeftStream>::Offset(
@@ -671,7 +671,7 @@ struct Dispatch3DStage1<E, P, dim_m, dim_n, dim_k, 0> {
 
 template <typename Executor, typename Params, int kernel_m, int kernel_n,
           int kernel_k>
-void Gemm(const Params& params) {
+inline void Gemm(const Params& params) {
   internal::Dispatch3DStage1<Executor, Params, kernel_m, kernel_n, kernel_k,
                              kernel_m - 1>::Execute(params, params.m % kernel_m,
                                                     params.n % kernel_n,

--- a/meta/single_thread_transform.h
+++ b/meta/single_thread_transform.h
@@ -1,0 +1,90 @@
+// Copyright 2016 The Gemmlowp Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GEMMLOWP_META_SINGLE_THREAD_TRANSFORM_H_
+#define GEMMLOWP_META_SINGLE_THREAD_TRANSFORM_H_
+
+#include <iostream>
+#include "base.h"
+
+namespace gemmlowp {
+namespace meta {
+
+template <typename Params, int kernel_size>
+void Transform1D(const Params& params);
+
+namespace internal {
+
+class Transform1DExecutor {
+ public:
+  template <typename P, int kernel_size, int leftovers>
+  static void ExecuteDispatch1D(const P& params) {
+    Transform1DKernel<typename P::InType, typename P::OutType,
+                      typename P::Kernel, kernel_size,
+                      leftovers>::Transform(params.input, params.kernel,
+                                            params.output);
+  }
+};
+
+template <typename E, typename P, int kernel_size, int variable_leftovers>
+struct Dispatch1D {
+  static void Execute(const P& params, int leftovers) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+    std::cout << "Dispatch(1): " << kernel_size << ":" << variable_leftovers
+              << std::endl
+              << std::flush;
+#endif
+#endif
+    if (leftovers == variable_leftovers) {
+      E::template ExecuteDispatch1D<P, kernel_size, variable_leftovers>(params);
+    } else {
+      Dispatch1D<E, P, kernel_size, variable_leftovers - 1>::Execute(params,
+                                                                     leftovers);
+    }
+  }
+};
+
+template <typename E, typename P, int kernel_size>
+struct Dispatch1D<E, P, kernel_size, 0> {
+  static void Execute(const P& params, int leftovers) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+    std::cout << "Dispatch(1): " << kernel_size << ": 0" << std::endl
+              << std::flush;
+#endif
+#endif
+    if (leftovers == 0) {
+      E::template ExecuteDispatch1D<P, kernel_size, 0>(params);
+    } else {
+      std::cerr << "FATAL: dispatch1D failed: ran out of cases." << std::endl
+                << std::flush;
+      std::exit(1);
+    }
+  }
+};
+
+}  // namespace internal
+
+template <typename Params, int kernel_size>
+inline void Transform1D(const Params& params) {
+  internal::Dispatch1D<internal::Transform1DExecutor, Params, kernel_size,
+                       kernel_size - 1>::Execute(params, params.kernel.count %
+                                                             kernel_size);
+}
+
+}  // namespace meta
+}  // namespace gemmlowp
+
+#endif  // GEMMLOWP_META_SINGLE_THREAD_TRANSFORM_H_

--- a/meta/streams_arm_32.h
+++ b/meta/streams_arm_32.h
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gemmlowp Authors. All Rights Reserved.
+// Copyright 2016 The Gemmlowp Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ namespace gemmlowp {
 namespace meta {
 
 template <>
-void Stream<uint8_t, 1, 8, 0, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 0, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -65,7 +65,7 @@ void Stream<uint8_t, 1, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 1, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 1, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -115,7 +115,7 @@ void Stream<uint8_t, 1, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 2, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 2, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -165,7 +165,7 @@ void Stream<uint8_t, 1, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 3, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 3, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -216,7 +216,7 @@ void Stream<uint8_t, 1, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 4, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 4, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -266,7 +266,7 @@ void Stream<uint8_t, 1, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 5, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 5, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -317,7 +317,7 @@ void Stream<uint8_t, 1, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 6, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 6, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -368,7 +368,7 @@ void Stream<uint8_t, 1, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 7, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 7, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -420,7 +420,7 @@ void Stream<uint8_t, 1, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 0, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 0, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -468,7 +468,7 @@ void Stream<uint8_t, 2, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 1, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 1, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -528,7 +528,7 @@ void Stream<uint8_t, 2, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 2, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 2, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -588,7 +588,7 @@ void Stream<uint8_t, 2, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 3, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 3, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -650,7 +650,7 @@ void Stream<uint8_t, 2, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 4, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 4, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -710,7 +710,7 @@ void Stream<uint8_t, 2, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 5, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 5, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -772,7 +772,7 @@ void Stream<uint8_t, 2, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 6, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 6, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -834,7 +834,7 @@ void Stream<uint8_t, 2, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 7, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 7, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -898,7 +898,7 @@ void Stream<uint8_t, 2, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 0, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 0, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -953,7 +953,7 @@ void Stream<uint8_t, 3, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 1, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 1, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1023,7 +1023,7 @@ void Stream<uint8_t, 3, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 2, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 2, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1093,7 +1093,7 @@ void Stream<uint8_t, 3, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 3, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 3, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1166,7 +1166,7 @@ void Stream<uint8_t, 3, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 4, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 4, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1236,7 +1236,7 @@ void Stream<uint8_t, 3, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 5, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 5, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1309,7 +1309,7 @@ void Stream<uint8_t, 3, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 6, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 6, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1382,7 +1382,7 @@ void Stream<uint8_t, 3, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 7, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 7, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1458,7 +1458,7 @@ void Stream<uint8_t, 3, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 0, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 0, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1519,7 +1519,7 @@ void Stream<uint8_t, 4, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 1, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 1, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1598,7 +1598,7 @@ void Stream<uint8_t, 4, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 2, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 2, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1677,7 +1677,7 @@ void Stream<uint8_t, 4, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 3, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 3, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1760,7 +1760,7 @@ void Stream<uint8_t, 4, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 4, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 4, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1839,7 +1839,7 @@ void Stream<uint8_t, 4, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 5, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 5, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1922,7 +1922,7 @@ void Stream<uint8_t, 4, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 6, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 6, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -2005,7 +2005,7 @@ void Stream<uint8_t, 4, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 7, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 7, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -2092,7 +2092,7 @@ void Stream<uint8_t, 4, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 0, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 0, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -2163,7 +2163,7 @@ void Stream<uint8_t, 5, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 1, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 1, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -2256,7 +2256,7 @@ void Stream<uint8_t, 5, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 2, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 2, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -2349,7 +2349,7 @@ void Stream<uint8_t, 5, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 3, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 3, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -2447,7 +2447,7 @@ void Stream<uint8_t, 5, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 4, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 4, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -2540,7 +2540,7 @@ void Stream<uint8_t, 5, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 5, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 5, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -2638,7 +2638,7 @@ void Stream<uint8_t, 5, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 6, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 6, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -2736,7 +2736,7 @@ void Stream<uint8_t, 5, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 7, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 7, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -2839,7 +2839,7 @@ void Stream<uint8_t, 5, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 0, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 0, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -2917,7 +2917,7 @@ void Stream<uint8_t, 6, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 1, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 1, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -3020,7 +3020,7 @@ void Stream<uint8_t, 6, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 2, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 2, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -3123,7 +3123,7 @@ void Stream<uint8_t, 6, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 3, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 3, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -3232,7 +3232,7 @@ void Stream<uint8_t, 6, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 4, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 4, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -3335,7 +3335,7 @@ void Stream<uint8_t, 6, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 5, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 5, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -3444,7 +3444,7 @@ void Stream<uint8_t, 6, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 6, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 6, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -3553,7 +3553,7 @@ void Stream<uint8_t, 6, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 7, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 7, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -3668,7 +3668,7 @@ void Stream<uint8_t, 6, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 0, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 0, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -3753,7 +3753,7 @@ void Stream<uint8_t, 7, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 1, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 1, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -3866,7 +3866,7 @@ void Stream<uint8_t, 7, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 2, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 2, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -3979,7 +3979,7 @@ void Stream<uint8_t, 7, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 3, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 3, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -4099,7 +4099,7 @@ void Stream<uint8_t, 7, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 4, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 4, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -4212,7 +4212,7 @@ void Stream<uint8_t, 7, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 5, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 5, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -4332,7 +4332,7 @@ void Stream<uint8_t, 7, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 6, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 6, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -4452,7 +4452,7 @@ void Stream<uint8_t, 7, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 7, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 7, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -4579,7 +4579,7 @@ void Stream<uint8_t, 7, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 0, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 0, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -4671,7 +4671,7 @@ void Stream<uint8_t, 8, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 1, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 1, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -4794,7 +4794,7 @@ void Stream<uint8_t, 8, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 2, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 2, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -4917,7 +4917,7 @@ void Stream<uint8_t, 8, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 3, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 3, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5048,7 +5048,7 @@ void Stream<uint8_t, 8, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 4, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 4, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5171,7 +5171,7 @@ void Stream<uint8_t, 8, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 5, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 5, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5302,7 +5302,7 @@ void Stream<uint8_t, 8, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 6, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 6, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5433,7 +5433,7 @@ void Stream<uint8_t, 8, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 7, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 7, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5572,7 +5572,7 @@ void Stream<uint8_t, 8, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 0, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 0, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5623,7 +5623,7 @@ void Stream<uint8_t, 1, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 1, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 1, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5684,7 +5684,7 @@ void Stream<uint8_t, 1, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 2, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 2, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5746,7 +5746,7 @@ void Stream<uint8_t, 1, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 3, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 3, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5809,7 +5809,7 @@ void Stream<uint8_t, 1, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 4, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 4, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5873,7 +5873,7 @@ void Stream<uint8_t, 1, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 5, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 5, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5938,7 +5938,7 @@ void Stream<uint8_t, 1, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 6, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 6, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6004,7 +6004,7 @@ void Stream<uint8_t, 1, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 7, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 7, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6071,7 +6071,7 @@ void Stream<uint8_t, 1, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 0, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 0, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6127,7 +6127,7 @@ void Stream<uint8_t, 2, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 1, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 1, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6196,7 +6196,7 @@ void Stream<uint8_t, 2, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 2, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 2, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6266,7 +6266,7 @@ void Stream<uint8_t, 2, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 3, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 3, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6337,7 +6337,7 @@ void Stream<uint8_t, 2, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 4, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 4, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6409,7 +6409,7 @@ void Stream<uint8_t, 2, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 5, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 5, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6482,7 +6482,7 @@ void Stream<uint8_t, 2, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 6, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 6, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6556,7 +6556,7 @@ void Stream<uint8_t, 2, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 7, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 7, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6631,7 +6631,7 @@ void Stream<uint8_t, 2, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 0, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 0, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6691,7 +6691,7 @@ void Stream<uint8_t, 3, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 1, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 1, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6764,7 +6764,7 @@ void Stream<uint8_t, 3, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 2, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 2, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6838,7 +6838,7 @@ void Stream<uint8_t, 3, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 3, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 3, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6913,7 +6913,7 @@ void Stream<uint8_t, 3, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 4, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 4, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6989,7 +6989,7 @@ void Stream<uint8_t, 3, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 5, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 5, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -7066,7 +7066,7 @@ void Stream<uint8_t, 3, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 6, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 6, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -7144,7 +7144,7 @@ void Stream<uint8_t, 3, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 7, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 7, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -7223,7 +7223,7 @@ void Stream<uint8_t, 3, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 0, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 0, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -7292,7 +7292,7 @@ void Stream<uint8_t, 4, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 1, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 1, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -7381,7 +7381,7 @@ void Stream<uint8_t, 4, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 2, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 2, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -7471,7 +7471,7 @@ void Stream<uint8_t, 4, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 3, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 3, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -7562,7 +7562,7 @@ void Stream<uint8_t, 4, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 4, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 4, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -7654,7 +7654,7 @@ void Stream<uint8_t, 4, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 5, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 5, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -7747,7 +7747,7 @@ void Stream<uint8_t, 4, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 6, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 6, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -7841,7 +7841,7 @@ void Stream<uint8_t, 4, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 7, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 7, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -7936,7 +7936,7 @@ void Stream<uint8_t, 4, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 0, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 0, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -8022,7 +8022,7 @@ void Stream<uint8_t, 5, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 1, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 1, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -8132,7 +8132,7 @@ void Stream<uint8_t, 5, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 2, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 2, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -8244,7 +8244,7 @@ void Stream<uint8_t, 5, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 3, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 3, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -8358,7 +8358,7 @@ void Stream<uint8_t, 5, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 4, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 4, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -8474,7 +8474,7 @@ void Stream<uint8_t, 5, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 5, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 5, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -8592,7 +8592,7 @@ void Stream<uint8_t, 5, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 6, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 6, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -8712,7 +8712,7 @@ void Stream<uint8_t, 5, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 7, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 7, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -8834,7 +8834,7 @@ void Stream<uint8_t, 5, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 0, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 0, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -8925,7 +8925,7 @@ void Stream<uint8_t, 6, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 1, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 1, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -9043,7 +9043,7 @@ void Stream<uint8_t, 6, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 2, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 2, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -9163,7 +9163,7 @@ void Stream<uint8_t, 6, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 3, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 3, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -9285,7 +9285,7 @@ void Stream<uint8_t, 6, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 4, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 4, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -9409,7 +9409,7 @@ void Stream<uint8_t, 6, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 5, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 5, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -9535,7 +9535,7 @@ void Stream<uint8_t, 6, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 6, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 6, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -9663,7 +9663,7 @@ void Stream<uint8_t, 6, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 7, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 7, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -9793,7 +9793,7 @@ void Stream<uint8_t, 6, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 0, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 0, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -9889,7 +9889,7 @@ void Stream<uint8_t, 7, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 1, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 1, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -10013,7 +10013,7 @@ void Stream<uint8_t, 7, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 2, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 2, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -10139,7 +10139,7 @@ void Stream<uint8_t, 7, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 3, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 3, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -10267,7 +10267,7 @@ void Stream<uint8_t, 7, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 4, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 4, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -10397,7 +10397,7 @@ void Stream<uint8_t, 7, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 5, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 5, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -10529,7 +10529,7 @@ void Stream<uint8_t, 7, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 6, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 6, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -10663,7 +10663,7 @@ void Stream<uint8_t, 7, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 7, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 7, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -10799,7 +10799,7 @@ void Stream<uint8_t, 7, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 0, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 0, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -10898,7 +10898,7 @@ void Stream<uint8_t, 8, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 1, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 1, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -11034,7 +11034,7 @@ void Stream<uint8_t, 8, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 2, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 2, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -11171,7 +11171,7 @@ void Stream<uint8_t, 8, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 3, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 3, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -11309,7 +11309,7 @@ void Stream<uint8_t, 8, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 4, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 4, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -11448,7 +11448,7 @@ void Stream<uint8_t, 8, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 5, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 5, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -11588,7 +11588,7 @@ void Stream<uint8_t, 8, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 6, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 6, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -11729,7 +11729,7 @@ void Stream<uint8_t, 8, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 7, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 7, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE

--- a/meta/streams_arm_64.h
+++ b/meta/streams_arm_64.h
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gemmlowp Authors. All Rights Reserved.
+// Copyright 2016 The Gemmlowp Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ namespace gemmlowp {
 namespace meta {
 
 template <>
-void Stream<uint8_t, 1, 8, 0, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 0, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -65,7 +65,7 @@ void Stream<uint8_t, 1, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 1, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 1, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -115,7 +115,7 @@ void Stream<uint8_t, 1, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 2, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 2, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -165,7 +165,7 @@ void Stream<uint8_t, 1, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 3, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 3, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -216,7 +216,7 @@ void Stream<uint8_t, 1, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 4, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 4, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -266,7 +266,7 @@ void Stream<uint8_t, 1, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 5, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 5, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -317,7 +317,7 @@ void Stream<uint8_t, 1, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 6, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 6, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -368,7 +368,7 @@ void Stream<uint8_t, 1, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 7, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 7, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -420,7 +420,7 @@ void Stream<uint8_t, 1, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 0, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 0, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -466,7 +466,7 @@ void Stream<uint8_t, 2, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 1, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 1, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -524,7 +524,7 @@ void Stream<uint8_t, 2, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 2, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 2, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -582,7 +582,7 @@ void Stream<uint8_t, 2, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 3, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 3, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -642,7 +642,7 @@ void Stream<uint8_t, 2, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 4, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 4, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -700,7 +700,7 @@ void Stream<uint8_t, 2, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 5, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 5, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -760,7 +760,7 @@ void Stream<uint8_t, 2, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 6, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 6, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -820,7 +820,7 @@ void Stream<uint8_t, 2, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 7, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 7, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -882,7 +882,7 @@ void Stream<uint8_t, 2, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 0, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 0, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -934,7 +934,7 @@ void Stream<uint8_t, 3, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 1, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 1, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1001,7 +1001,7 @@ void Stream<uint8_t, 3, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 2, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 2, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1068,7 +1068,7 @@ void Stream<uint8_t, 3, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 3, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 3, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1138,7 +1138,7 @@ void Stream<uint8_t, 3, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 4, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 4, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1205,7 +1205,7 @@ void Stream<uint8_t, 3, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 5, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 5, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1275,7 +1275,7 @@ void Stream<uint8_t, 3, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 6, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 6, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1345,7 +1345,7 @@ void Stream<uint8_t, 3, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 7, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 7, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1418,7 +1418,7 @@ void Stream<uint8_t, 3, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 0, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 0, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1476,7 +1476,7 @@ void Stream<uint8_t, 4, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 1, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 1, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1552,7 +1552,7 @@ void Stream<uint8_t, 4, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 2, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 2, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1628,7 +1628,7 @@ void Stream<uint8_t, 4, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 3, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 3, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1708,7 +1708,7 @@ void Stream<uint8_t, 4, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 4, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 4, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1784,7 +1784,7 @@ void Stream<uint8_t, 4, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 5, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 5, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1864,7 +1864,7 @@ void Stream<uint8_t, 4, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 6, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 6, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -1944,7 +1944,7 @@ void Stream<uint8_t, 4, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 7, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 7, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -2028,7 +2028,7 @@ void Stream<uint8_t, 4, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 0, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 0, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -2096,7 +2096,7 @@ void Stream<uint8_t, 5, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 1, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 1, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -2186,7 +2186,7 @@ void Stream<uint8_t, 5, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 2, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 2, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -2276,7 +2276,7 @@ void Stream<uint8_t, 5, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 3, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 3, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -2371,7 +2371,7 @@ void Stream<uint8_t, 5, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 4, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 4, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -2461,7 +2461,7 @@ void Stream<uint8_t, 5, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 5, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 5, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -2556,7 +2556,7 @@ void Stream<uint8_t, 5, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 6, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 6, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -2651,7 +2651,7 @@ void Stream<uint8_t, 5, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 7, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 7, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -2751,7 +2751,7 @@ void Stream<uint8_t, 5, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 0, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 0, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -2824,7 +2824,7 @@ void Stream<uint8_t, 6, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 1, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 1, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -2922,7 +2922,7 @@ void Stream<uint8_t, 6, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 2, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 2, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -3020,7 +3020,7 @@ void Stream<uint8_t, 6, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 3, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 3, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -3124,7 +3124,7 @@ void Stream<uint8_t, 6, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 4, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 4, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -3222,7 +3222,7 @@ void Stream<uint8_t, 6, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 5, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 5, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -3326,7 +3326,7 @@ void Stream<uint8_t, 6, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 6, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 6, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -3430,7 +3430,7 @@ void Stream<uint8_t, 6, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 7, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 7, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -3540,7 +3540,7 @@ void Stream<uint8_t, 6, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 0, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 0, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -3619,7 +3619,7 @@ void Stream<uint8_t, 7, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 1, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 1, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -3726,7 +3726,7 @@ void Stream<uint8_t, 7, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 2, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 2, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -3833,7 +3833,7 @@ void Stream<uint8_t, 7, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 3, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 3, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -3947,7 +3947,7 @@ void Stream<uint8_t, 7, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 4, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 4, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -4054,7 +4054,7 @@ void Stream<uint8_t, 7, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 5, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 5, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -4168,7 +4168,7 @@ void Stream<uint8_t, 7, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 6, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 6, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -4282,7 +4282,7 @@ void Stream<uint8_t, 7, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 7, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 7, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -4403,7 +4403,7 @@ void Stream<uint8_t, 7, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 0, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 0, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -4488,7 +4488,7 @@ void Stream<uint8_t, 8, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 1, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 1, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -4604,7 +4604,7 @@ void Stream<uint8_t, 8, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 2, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 2, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -4720,7 +4720,7 @@ void Stream<uint8_t, 8, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 3, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 3, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -4844,7 +4844,7 @@ void Stream<uint8_t, 8, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 4, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 4, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -4960,7 +4960,7 @@ void Stream<uint8_t, 8, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 5, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 5, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5084,7 +5084,7 @@ void Stream<uint8_t, 8, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 6, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 6, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5208,7 +5208,7 @@ void Stream<uint8_t, 8, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 7, RowMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 7, RowMajorWithSum>::Pack(
     const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5340,7 +5340,7 @@ void Stream<uint8_t, 8, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 0, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 0, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5391,7 +5391,7 @@ void Stream<uint8_t, 1, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 1, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 1, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5452,7 +5452,7 @@ void Stream<uint8_t, 1, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 2, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 2, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5514,7 +5514,7 @@ void Stream<uint8_t, 1, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 3, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 3, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5577,7 +5577,7 @@ void Stream<uint8_t, 1, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 4, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 4, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5641,7 +5641,7 @@ void Stream<uint8_t, 1, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 5, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 5, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5706,7 +5706,7 @@ void Stream<uint8_t, 1, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 6, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 6, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5772,7 +5772,7 @@ void Stream<uint8_t, 1, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 1, 8, 7, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 1, 8, 7, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5839,7 +5839,7 @@ void Stream<uint8_t, 1, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 0, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 0, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5895,7 +5895,7 @@ void Stream<uint8_t, 2, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 1, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 1, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -5965,7 +5965,7 @@ void Stream<uint8_t, 2, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 2, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 2, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6036,7 +6036,7 @@ void Stream<uint8_t, 2, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 3, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 3, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6108,7 +6108,7 @@ void Stream<uint8_t, 2, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 4, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 4, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6181,7 +6181,7 @@ void Stream<uint8_t, 2, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 5, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 5, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6255,7 +6255,7 @@ void Stream<uint8_t, 2, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 6, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 6, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6330,7 +6330,7 @@ void Stream<uint8_t, 2, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 2, 8, 7, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 2, 8, 7, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6406,7 +6406,7 @@ void Stream<uint8_t, 2, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 0, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 0, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6464,7 +6464,7 @@ void Stream<uint8_t, 3, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 1, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 1, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6536,7 +6536,7 @@ void Stream<uint8_t, 3, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 2, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 2, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6609,7 +6609,7 @@ void Stream<uint8_t, 3, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 3, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 3, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6683,7 +6683,7 @@ void Stream<uint8_t, 3, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 4, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 4, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6758,7 +6758,7 @@ void Stream<uint8_t, 3, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 5, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 5, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6834,7 +6834,7 @@ void Stream<uint8_t, 3, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 6, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 6, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6911,7 +6911,7 @@ void Stream<uint8_t, 3, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 3, 8, 7, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 3, 8, 7, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -6989,7 +6989,7 @@ void Stream<uint8_t, 3, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 0, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 0, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -7059,7 +7059,7 @@ void Stream<uint8_t, 4, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 1, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 1, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -7153,7 +7153,7 @@ void Stream<uint8_t, 4, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 2, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 2, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -7248,7 +7248,7 @@ void Stream<uint8_t, 4, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 3, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 3, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -7344,7 +7344,7 @@ void Stream<uint8_t, 4, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 4, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 4, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -7441,7 +7441,7 @@ void Stream<uint8_t, 4, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 5, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 5, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -7539,7 +7539,7 @@ void Stream<uint8_t, 4, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 6, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 6, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -7638,7 +7638,7 @@ void Stream<uint8_t, 4, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 4, 8, 7, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 4, 8, 7, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -7738,7 +7738,7 @@ void Stream<uint8_t, 4, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 0, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 0, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -7825,7 +7825,7 @@ void Stream<uint8_t, 5, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 1, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 1, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -7940,7 +7940,7 @@ void Stream<uint8_t, 5, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 2, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 2, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -8057,7 +8057,7 @@ void Stream<uint8_t, 5, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 3, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 3, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -8176,7 +8176,7 @@ void Stream<uint8_t, 5, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 4, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 4, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -8297,7 +8297,7 @@ void Stream<uint8_t, 5, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 5, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 5, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -8420,7 +8420,7 @@ void Stream<uint8_t, 5, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 6, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 6, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -8545,7 +8545,7 @@ void Stream<uint8_t, 5, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 5, 8, 7, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 5, 8, 7, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -8672,7 +8672,7 @@ void Stream<uint8_t, 5, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 0, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 0, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -8764,7 +8764,7 @@ void Stream<uint8_t, 6, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 1, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 1, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -8888,7 +8888,7 @@ void Stream<uint8_t, 6, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 2, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 2, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -9014,7 +9014,7 @@ void Stream<uint8_t, 6, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 3, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 3, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -9142,7 +9142,7 @@ void Stream<uint8_t, 6, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 4, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 4, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -9272,7 +9272,7 @@ void Stream<uint8_t, 6, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 5, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 5, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -9404,7 +9404,7 @@ void Stream<uint8_t, 6, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 6, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 6, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -9538,7 +9538,7 @@ void Stream<uint8_t, 6, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 6, 8, 7, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 6, 8, 7, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -9674,7 +9674,7 @@ void Stream<uint8_t, 6, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 0, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 0, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -9768,7 +9768,7 @@ void Stream<uint8_t, 7, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 1, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 1, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -9894,7 +9894,7 @@ void Stream<uint8_t, 7, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 2, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 2, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -10022,7 +10022,7 @@ void Stream<uint8_t, 7, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 3, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 3, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -10152,7 +10152,7 @@ void Stream<uint8_t, 7, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 4, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 4, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -10284,7 +10284,7 @@ void Stream<uint8_t, 7, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 5, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 5, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -10418,7 +10418,7 @@ void Stream<uint8_t, 7, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 6, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 6, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -10554,7 +10554,7 @@ void Stream<uint8_t, 7, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 7, 8, 7, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 7, 8, 7, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -10692,7 +10692,7 @@ void Stream<uint8_t, 7, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 0, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 0, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -10797,7 +10797,7 @@ void Stream<uint8_t, 8, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 1, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 1, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -10951,7 +10951,7 @@ void Stream<uint8_t, 8, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 2, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 2, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -11106,7 +11106,7 @@ void Stream<uint8_t, 8, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 3, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 3, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -11262,7 +11262,7 @@ void Stream<uint8_t, 8, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 4, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 4, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -11419,7 +11419,7 @@ void Stream<uint8_t, 8, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 5, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 5, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -11577,7 +11577,7 @@ void Stream<uint8_t, 8, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 6, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 6, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
@@ -11736,7 +11736,7 @@ void Stream<uint8_t, 8, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-void Stream<uint8_t, 8, 8, 7, ColumnMajorWithSum>::Pack(
+inline void Stream<uint8_t, 8, 8, 7, ColumnMajorWithSum>::Pack(
     const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE

--- a/meta/test_gemm_correctness.cc
+++ b/meta/test_gemm_correctness.cc
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gemmlowp Authors. All Rights Reserved.
+// Copyright 2016 The Gemmlowp Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/meta/test_streams_correctness.cc
+++ b/meta/test_streams_correctness.cc
@@ -1,4 +1,4 @@
-// Copyright 2015 The Gemmlowp Authors. All Rights Reserved.
+// Copyright 2016 The Gemmlowp Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/meta/test_transform_benchmark.cc
+++ b/meta/test_transform_benchmark.cc
@@ -1,0 +1,151 @@
+// Copyright 2016 The Gemmlowp Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <unistd.h>
+#ifdef __APPLE__
+#include <sys/time.h>
+#endif
+
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "multi_thread_transform.h"
+#include "transform_kernels.h"
+
+using namespace gemmlowp::meta;
+
+double time() {
+#ifdef __APPLE__
+  timeval t;
+  gettimeofday(&t, nullptr);
+  return t.tv_sec + 1e-6 * t.tv_usec;
+#else
+  timespec t;
+  clock_gettime(CLOCK_REALTIME, &t);
+  return t.tv_sec + 1e-9 * t.tv_nsec;
+#endif
+}
+
+#define kernel_size (16)
+
+template <typename Context, typename Params>
+void run_benchmark(const std::string& name, int repetitions, int elements,
+                   Context* context, const Params& params) {
+  std::cout << "Benchmark: " << name << std::endl;
+  std::cout << "Warmup single." << std::endl;
+
+  for (int i = 0; i < 10; ++i) {
+    Transform1D<Params, kernel_size>(params);
+  }
+
+  std::cout << "Benchmark single." << std::endl;
+
+  double start = time();
+
+  for (int i = 0; i < repetitions; ++i) {
+    Transform1D<Params, kernel_size>(params);
+  }
+
+  double wall_time = time() - start;
+  double ops = static_cast<double>(elements) * repetitions;
+  std::cout << "Avg: " << (wall_time / repetitions) << std::endl;
+  std::cout << "Perf: " << static_cast<int64_t>(ops / wall_time) << "/s."
+            << std::endl;
+
+  std::cout << "Warmup single." << std::endl;
+
+  for (int i = 0; i < 10; ++i) {
+    MultiThreadTransform1D<Context, Params, kernel_size>(context, params);
+  }
+
+  std::cout << "Benchmark multi." << std::endl;
+
+  start = time();
+
+  for (int i = 0; i < repetitions; ++i) {
+    MultiThreadTransform1D<Context, Params, kernel_size>(context, params);
+  }
+
+  wall_time = time() - start;
+  ops = static_cast<double>(elements) * repetitions;
+  std::cout << "Avg: " << (wall_time / repetitions) << std::endl;
+  std::cout << "Perf: " << static_cast<int64_t>(ops / wall_time) << "/s."
+            << std::endl;
+}
+
+int main() {
+  const int repetitions = 500;
+  const int elements = 4 * 1024 * 1024;
+
+  std::unique_ptr<int32_t[]> int32_array(new int32_t[elements]);
+  std::unique_ptr<uint8_t[]> uint8_array(new uint8_t[elements]);
+  std::unique_ptr<float[]> float_array(new float[elements]);
+
+  typedef SimpleContext<gemmlowp::WorkersPool> Context;
+  Context context(4, new gemmlowp::WorkersPool());
+
+  typedef Transform1DParams<int32_t, uint8_t, Requantize> RequantizeParams;
+  RequantizeParams requantize_params;
+  requantize_params.input = int32_array.get();
+  requantize_params.output = uint8_array.get();
+  requantize_params.kernel.count = elements;
+  requantize_params.kernel.input_range_min = -100.0f;
+  requantize_params.kernel.input_range_scale =
+      200.0f / ((static_cast<int64_t>(1) << 32) - 1);
+  requantize_params.kernel.input_range_offset =
+      static_cast<float>(std::numeric_limits<int32_t>::lowest());
+  requantize_params.kernel.output_range_min = -200.0f;
+  requantize_params.kernel.one_over_output_range_scale =
+      static_cast<float>((static_cast<int64_t>(1) << 8) - 1) / 500.0f;
+  requantize_params.kernel.output_range_offset =
+      static_cast<float>(std::numeric_limits<uint8_t>::lowest());
+
+  run_benchmark("Requantize", repetitions, elements, &context,
+                requantize_params);
+
+  typedef Transform1DParams<uint8_t, float, Dequantize> DequantizeParams;
+  DequantizeParams dequantize_params;
+  dequantize_params.input = uint8_array.get();
+  dequantize_params.output = float_array.get();
+  dequantize_params.kernel.count = elements;
+  dequantize_params.kernel.range_min = -100.0f;
+  dequantize_params.kernel.range_scale =
+      static_cast<float>((static_cast<int64_t>(1) << 8) - 1) / 200.0f;
+  dequantize_params.kernel.range_offset =
+      static_cast<float>(std::numeric_limits<uint8_t>::lowest());
+
+  run_benchmark("Dequantize", repetitions, elements, &context,
+                dequantize_params);
+
+  typedef Transform1DParams<float, uint8_t, Quantize> QuantizeParams;
+  QuantizeParams quantize_params;
+  quantize_params.input = float_array.get();
+  quantize_params.output = uint8_array.get();
+  quantize_params.kernel.count = elements;
+  quantize_params.kernel.range_min = -100.0f;
+  quantize_params.kernel.range_scale =
+      200.0f / ((static_cast<int64_t>(1) << 8) - 1);
+  quantize_params.kernel.range_offset =
+      static_cast<float>(std::numeric_limits<uint8_t>::lowest());
+
+  run_benchmark("Quantize", repetitions, elements, &context, quantize_params);
+
+  return 0;
+}

--- a/meta/test_transform_correctness.cc
+++ b/meta/test_transform_correctness.cc
@@ -1,0 +1,285 @@
+// Copyright 2016 The Gemmlowp Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <unistd.h>
+#ifdef __APPLE__
+#include <sys/time.h>
+#endif
+
+#include <cstdint>
+#include <cstdlib>
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "single_thread_transform.h"
+#include "transform_kernels.h"
+
+#define EPSILON (0.0001)
+
+using namespace gemmlowp::meta;
+
+typedef Transform1DParams<int32_t, uint8_t, Requantize> RequantizeParams;
+typedef Transform1DParams<float, uint8_t, Quantize> QuantizeParams;
+typedef Transform1DParams<uint8_t, float, Dequantize> DequantizeParams;
+typedef Transform1DParams<uint8_t, uint8_t, MinMax<uint8_t>> MinMaxParams;
+typedef Transform1DParams<uint8_t, int32_t, BiasAdd<uint8_t>> BiasAddParams;
+
+void prepare_data_requantize(int count, int32_t* data) {
+  float scale = 4000000000.0f / static_cast<float>(count - 1);
+  for (int i = 0; i < count; ++i) {
+    float temp = -2000000000.0f + scale * i;
+    data[i] = static_cast<int32_t>(temp);
+  }
+}
+
+void prepare_data_quantize(int count, float* data) {
+  float scale = 200.0f / static_cast<float>(count - 1);
+  for (int i = 0; i < count; ++i) {
+    data[i] = -100 + scale * i;
+  }
+}
+
+void prepare_data_dequantize(int count, uint8_t* data) {
+  for (int i = 0; i < count; ++i) {
+    data[i] = static_cast<uint8_t>(i % 256);
+  }
+}
+
+void prepare_data_minmax(int count, uint8_t* data) {
+  for (int i = 0; i < count; ++i) {
+    data[i] = static_cast<uint8_t>(i % 256);
+  }
+}
+
+void prepare_data_biasadd(int count, uint8_t* data) {
+  for (int i = 0; i < count; ++i) {
+    data[i] = static_cast<uint8_t>(i % 256);
+  }
+}
+
+void verify_requantize(const RequantizeParams& params) {
+  for (int i = 0; i < params.kernel.count; ++i) {
+    uint8_t actual = params.output[i];
+    float expected = static_cast<float>(params.input[i]);
+    expected -= params.kernel.input_range_offset;
+    expected *= params.kernel.input_range_scale;
+    expected += params.kernel.input_range_min;
+    expected -= params.kernel.output_range_min;
+    expected *= params.kernel.one_over_output_range_scale;
+    expected += params.kernel.output_range_offset;
+    uint8_t expected_uint8 = static_cast<uint8_t>(expected);
+
+    if (actual != expected_uint8) {
+      std::cout << "Wrong: " << i << " : " << actual << " vs. "
+                << expected_uint8 << std::endl;
+      std::exit(1);
+    }
+  }
+  std::cout << "Requantize: OK" << std::endl;
+}
+
+void verify_quantize(const QuantizeParams& params) {
+  for (int i = 0; i < params.kernel.count; ++i) {
+    uint8_t actual = params.output[i];
+    float expected = params.input[i];
+    expected -= params.kernel.range_min;
+    expected *= params.kernel.range_scale;
+    expected += params.kernel.range_offset;
+    uint8_t expected_uint8 = static_cast<uint8_t>(expected);
+
+    if (actual != expected_uint8) {
+      std::cout << "Wrong: " << i << " : " << actual << " vs. "
+                << expected_uint8 << std::endl;
+      std::exit(1);
+    }
+  }
+  std::cout << "Quantize: OK" << std::endl;
+}
+
+void verify_dequantize(const DequantizeParams& params) {
+  for (int i = 0; i < params.kernel.count; ++i) {
+    float actual = params.output[i];
+    float expected = static_cast<float>(params.input[i]);
+    expected -= params.kernel.range_offset;
+    expected *= params.kernel.range_scale;
+    expected += params.kernel.range_min;
+    if (std::abs(actual - expected) > EPSILON) {
+      std::cout << std::setprecision(9) << "Wrong: " << i << " : " << actual
+                << " vs. " << expected << std::endl;
+      std::exit(1);
+    }
+  }
+  std::cout << "Dequantize: OK" << std::endl;
+}
+
+void verify_minmax(const MinMaxParams& params) {
+  for (int i = 0; i < params.kernel.count; ++i) {
+    uint8_t actual = params.output[i];
+    uint8_t expected = params.input[i];
+    expected = std::min(expected, params.kernel.max);
+    expected = std::max(expected, params.kernel.min);
+
+    if (actual != expected) {
+      std::cout << "Wrong: " << i << " : " << actual << " vs. " << expected
+                << std::endl;
+      std::exit(1);
+    }
+  }
+  std::cout << "MinMax: OK" << std::endl;
+}
+
+void verify_biasadd(const BiasAddParams& params) {
+  for (int i = 0; i < params.kernel.rows * params.kernel.count; ++i) {
+    int32_t actual = params.output[i];
+    uint8_t input = params.input[i];
+    uint8_t bias = params.kernel.bias[i % params.kernel.count];
+    float input_float = static_cast<float>(input);
+    input_float -= params.kernel.input_range_offset;
+    input_float *= params.kernel.input_range_scale;
+    input_float += params.kernel.input_range_min;
+    float bias_float = static_cast<float>(bias);
+    bias_float -= params.kernel.bias_range_offset;
+    bias_float *= params.kernel.bias_range_scale;
+    bias_float += params.kernel.bias_range_min;
+    float sum = input_float + bias_float;
+    sum -= params.kernel.output_range_min;
+    sum *= params.kernel.one_over_output_range_scale;
+    sum += params.kernel.output_range_offset;
+    int32_t expected = static_cast<int32_t>(sum);
+    if (std::abs(actual - expected) > 1024) {
+      std::cout << "Wrong: " << i << " : " << actual << " vs. " << expected
+                << std::endl;
+      std::exit(1);
+    }
+  }
+  std::cout << "BiasAdd: OK" << std::endl;
+}
+
+int main() {
+  std::unique_ptr<int32_t[]> array_int32(new int32_t[128 * 1024]);
+  std::unique_ptr<uint8_t[]> array_uint8(new uint8_t[128 * 1024]);
+  std::unique_ptr<uint8_t[]> array_uint8_2(new uint8_t[128 * 1024]);
+  std::unique_ptr<float[]> array_float(new float[128 * 1024]);
+
+  {
+    RequantizeParams requantize_params;
+    requantize_params.input = array_int32.get();
+    requantize_params.output = array_uint8.get();
+    requantize_params.kernel.count = 12345;
+    requantize_params.kernel.input_range_min = -100.0f;
+    requantize_params.kernel.input_range_scale =
+        200.0f / ((static_cast<int64_t>(1) << 32) - 1);
+    requantize_params.kernel.input_range_offset =
+        static_cast<float>(std::numeric_limits<int32_t>::lowest());
+    requantize_params.kernel.output_range_min = -100.f;
+    requantize_params.kernel.one_over_output_range_scale =
+        static_cast<float>((static_cast<int64_t>(1) << 8) - 1) / 200.0f;
+    requantize_params.kernel.output_range_offset =
+        static_cast<float>(std::numeric_limits<uint8_t>::lowest());
+
+    prepare_data_requantize(12345, array_int32.get());
+
+    Transform1D<RequantizeParams, 16>(requantize_params);
+
+    verify_requantize(requantize_params);
+  }
+
+  {
+    QuantizeParams quantize_params;
+    quantize_params.input = array_float.get();
+    quantize_params.output = array_uint8.get();
+    quantize_params.kernel.count = 12345;
+    quantize_params.kernel.range_min = -100.0f;
+    quantize_params.kernel.range_scale =
+        static_cast<float>((static_cast<int64_t>(1) << 8) - 1) / 200.0f;
+    quantize_params.kernel.range_offset =
+        static_cast<float>(std::numeric_limits<uint8_t>::lowest());
+
+    prepare_data_quantize(12345, array_float.get());
+
+    Transform1D<QuantizeParams, 16>(quantize_params);
+
+    verify_quantize(quantize_params);
+  }
+
+  {
+    DequantizeParams dequantize_params;
+    dequantize_params.input = array_uint8.get();
+    dequantize_params.output = array_float.get();
+    dequantize_params.kernel.count = 12345;
+    dequantize_params.kernel.range_min = -100.0f;
+    dequantize_params.kernel.range_scale =
+        200.0f / ((static_cast<int64_t>(1) << 8) - 1);
+    dequantize_params.kernel.range_offset =
+        static_cast<float>(std::numeric_limits<uint8_t>::lowest());
+
+    prepare_data_dequantize(12345, array_uint8.get());
+
+    Transform1D<DequantizeParams, 16>(dequantize_params);
+
+    verify_dequantize(dequantize_params);
+  }
+
+  {
+    MinMaxParams minmax_params;
+    minmax_params.input = array_uint8.get();
+    minmax_params.output = array_uint8_2.get();
+    minmax_params.kernel.count = 12345;
+    minmax_params.kernel.min = 64;
+    minmax_params.kernel.max = 192;
+
+    prepare_data_minmax(12345, array_uint8.get());
+
+    Transform1D<MinMaxParams, 16>(minmax_params);
+
+    verify_minmax(minmax_params);
+  }
+
+  {
+    BiasAddParams biasadd_params;
+    biasadd_params.input = array_uint8.get();
+    biasadd_params.output = array_int32.get();
+    biasadd_params.kernel.count = 1234;
+    biasadd_params.kernel.rows = 11;
+    biasadd_params.kernel.input_range_min = -100.0f;
+    biasadd_params.kernel.bias_range_min = -100.0f;
+    biasadd_params.kernel.output_range_min = -250.0f;
+    biasadd_params.kernel.input_range_offset =
+        static_cast<float>(std::numeric_limits<uint8_t>::lowest());
+    biasadd_params.kernel.bias_range_offset =
+        static_cast<float>(std::numeric_limits<uint8_t>::lowest());
+    biasadd_params.kernel.output_range_offset =
+        static_cast<float>(std::numeric_limits<int32_t>::lowest());
+    biasadd_params.kernel.input_range_scale =
+        200.0f / ((static_cast<int64_t>(1) << 8) - 1);
+    biasadd_params.kernel.bias_range_scale =
+        200.0f / ((static_cast<int64_t>(1) << 8) - 1);
+    biasadd_params.kernel.one_over_output_range_scale =
+        static_cast<float>((static_cast<int64_t>(1) << 32) - 1) / 500.0f;
+    biasadd_params.kernel.bias = array_uint8_2.get();
+
+    prepare_data_biasadd(1234 * 11, array_uint8.get());
+    prepare_data_biasadd(1234, array_uint8_2.get());
+
+    Transform1D<BiasAddParams, 16>(biasadd_params);
+
+    verify_biasadd(biasadd_params);
+  }
+
+  return 0;
+}

--- a/meta/transform_kernels.h
+++ b/meta/transform_kernels.h
@@ -1,0 +1,244 @@
+// Copyright 2016 The Gemmlowp Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GEMMLOWP_META_TRANSFORM_KERNELS_H_
+#define GEMMLOWP_META_TRANSFORM_KERNELS_H_
+
+#include "base.h"
+
+namespace gemmlowp {
+namespace meta {
+
+struct Quantize {
+  float range_min;
+  float range_offset;
+  float range_scale;
+  int count;
+};
+
+struct Dequantize {
+  float range_min;
+  float range_offset;
+  float range_scale;
+  int count;
+};
+
+struct Requantize {
+  float input_range_min;
+  float input_range_offset;
+  float input_range_scale;
+  float output_range_min;
+  float output_range_offset;
+  float one_over_output_range_scale;
+  int count;
+};
+
+template <typename Type>
+struct MinMax {
+  Type min;
+  Type max;
+  int count;
+};
+
+template <typename BiasType>
+struct BiasAdd {
+  float input_range_min;
+  float input_range_offset;
+  float input_range_scale;
+  float bias_range_min;
+  float bias_range_offset;
+  float bias_range_scale;
+  float output_range_min;
+  float output_range_offset;
+  float one_over_output_range_scale;
+  int count;
+  int rows;
+  const BiasType* bias;
+};
+
+template <typename InType, typename OutType, int kernel_size, int leftovers>
+class Transform1DKernel<InType, OutType, Quantize, kernel_size, leftovers> {
+ public:
+  static void Transform(const InType* in, const Quantize& params,
+                        OutType* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+    std::cout << "Quantize::Transform(" << std::string(typeid(InType).name())
+              << ", " << std::string(typeid(OutType).name()) << ") -- "
+              << kernel_size << "x" << leftovers << std::endl;
+#endif
+#else
+    std::cerr << "FATAL: Quantize::Transform not implemented." << std::endl;
+    std::exit(1);
+#endif
+  }
+};
+
+template <typename InType, typename OutType, int kernel_size, int leftovers>
+class Transform1DKernel<InType, OutType, Dequantize, kernel_size, leftovers> {
+ public:
+  static void Transform(const InType* in, const Dequantize& params,
+                        OutType* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+    std::cout << "Dequantize::Transform(" << std::string(typeid(InType).name())
+              << ", " << std::string(typeid(OutType).name()) << ") -- "
+              << kernel_size << "x" << leftovers << std::endl;
+#endif
+#else
+    std::cerr << "FATAL: Dequantize::Transform not implemented." << std::endl;
+    std::exit(1);
+#endif
+  }
+};
+
+template <typename InType, typename OutType, int kernel_size, int leftovers>
+class Transform1DKernel<InType, OutType, Requantize, kernel_size, leftovers> {
+ public:
+  static void Transform(const InType* in, const Requantize& params,
+                        OutType* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+    std::cout << "Requantize::Transform(" << std::string(typeid(InType).name())
+              << ", " << std::string(typeid(OutType).name()) << ") -- "
+              << kernel_size << "x" << leftovers << std::endl;
+#endif
+#else
+    std::cerr << "FATAL: Requantize::Transform not implemented." << std::endl;
+    std::exit(1);
+#endif
+  }
+};
+
+template <typename InType, typename OutType, int kernel_size, int leftovers,
+          typename Type>
+class Transform1DKernel<InType, OutType, MinMax<Type>, kernel_size, leftovers> {
+ public:
+  static void Transform(const InType* in, const MinMax<Type>& params,
+                        OutType* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+    std::cout << "MinMax::Transform(" << std::string(typeid(InType).name())
+              << ", " << std::string(typeid(OutType).name()) << ") -- "
+              << kernel_size << "x" << leftovers << std::endl;
+#endif
+#else
+    std::cerr << "FATAL: MinMax::Transform not implemented." << std::endl;
+    std::exit(1);
+#endif
+  }
+};
+
+template <typename InType, typename OutType, int kernel_size, int leftovers,
+          typename Type>
+class Transform1DKernel<InType, OutType, BiasAdd<Type>, kernel_size,
+                        leftovers> {
+ public:
+  static void Transform(const InType* in, const BiasAdd<Type>& params,
+                        OutType* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+    std::cout << "BiasAdd::Transform(" << std::string(typeid(InType).name())
+              << ", " << std::string(typeid(OutType).name()) << ") -- "
+              << kernel_size << "x" << leftovers << std::endl;
+#endif
+#else
+    std::cerr << "FATAL: BiasAdd::Transform not implemented." << std::endl;
+    std::exit(1);
+#endif
+  }
+};
+
+template <typename InType, typename OutType>
+class Transform1DUtil<InType, OutType, Quantize> {
+ public:
+  static int EstimateComputeCost(const Quantize& params) {
+    return params.count * 8;
+  }
+
+  static const InType* OffsetInput(const Quantize& params, const InType* input,
+                                   int offset) {
+    return input + offset;
+  }
+
+  static OutType* OffsetOutput(const Quantize& params, OutType* output,
+                               int offset) {
+    return output + offset;
+  }
+};
+
+template <typename InType, typename OutType>
+class Transform1DUtil<InType, OutType, Requantize> {
+ public:
+  static int EstimateComputeCost(const Requantize& params) {
+    return params.count * 12;
+  }
+
+  static const InType* OffsetInput(const Requantize& params,
+                                   const InType* input, int offset) {
+    return input + offset;
+  }
+
+  static OutType* OffsetOutput(const Requantize& params, OutType* output,
+                               int offset) {
+    return output + offset;
+  }
+};
+
+template <typename InType, typename OutType>
+class Transform1DUtil<InType, OutType, Dequantize> {
+ public:
+  static int EstimateComputeCost(const Dequantize& params) {
+    return params.count * 12;
+  }
+
+  static const InType* OffsetInput(const Dequantize& params,
+                                   const InType* input, int offset) {
+    return input + offset;
+  }
+
+  static OutType* OffsetOutput(const Dequantize& params, OutType* output,
+                               int offset) {
+    return output + offset;
+  }
+};
+
+template <typename InType, typename OutType, typename MinMaxType>
+class Transform1DUtil<InType, OutType, MinMax<MinMaxType>> {
+ public:
+  static int EstimateComputeCost(const MinMax<MinMaxType>& params) {
+    return params.count * 4;
+  }
+
+  static const InType* OffsetInput(const MinMax<MinMaxType>& params,
+                                   const InType* input, int offset) {
+    return input + offset;
+  }
+
+  static OutType* OffsetOutput(const MinMax<MinMaxType>& params,
+                               OutType* output, int offset) {
+    return output + offset;
+  }
+};
+
+}  // namespace meta
+}  // namespace gemmlowp
+
+#ifdef GEMMLOWP_NEON_32
+#include "transform_kernels_arm_32.h"
+#elif defined(GEMMLOWP_NEON_64)
+#include "transform_kernels_arm_64.h"
+#endif
+
+#endif  // GEMMLOWP_META_TRANSFORM_KERNELS_H_

--- a/meta/transform_kernels_arm_32.h
+++ b/meta/transform_kernels_arm_32.h
@@ -1,0 +1,8109 @@
+// Copyright 2016 The Gemmlowp Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GEMMLOWP_META_TRANSFORM_KERNELS_ARM_32_H_
+#define GEMMLOWP_META_TRANSFORM_KERNELS_ARM_32_H_
+
+#ifdef GEMMLOWP_NEON_32
+
+#include <cassert>
+#include <cstdint>
+
+namespace gemmlowp {
+namespace meta {
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 0>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 0>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "vdup.32 q4, %[input_range_min]\n"
+      "vdup.32 q5, %[output_range_min]\n"
+      "vdup.32 q6, %[input_range_offset]\n"
+      "vdup.32 q7, %[input_range_scale]\n"
+      "vdup.32 q8, %[one_over_output_range_scale]\n"
+      "vsub.f32 q4, q4, q5\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vsub.f32 q3, q3, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vmul.f32 q3, q3, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vmul.f32 q3, q3, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "d14", "d15", "d16", "d17", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 1>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 1>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "vdup.32 q4, %[input_range_min]\n"
+      "vdup.32 q5, %[output_range_min]\n"
+      "vdup.32 q6, %[input_range_offset]\n"
+      "vdup.32 q7, %[input_range_scale]\n"
+      "vdup.32 q8, %[one_over_output_range_scale]\n"
+      "vsub.f32 q4, q4, q5\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #1\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vsub.f32 q3, q3, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vmul.f32 q3, q3, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vmul.f32 q3, q3, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "vld1.32 {d0[0]}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovun.s16 d0, q0\n"
+
+      "vst1.8 {d0[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "d14", "d15", "d16", "d17", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 2>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 2>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "vdup.32 q4, %[input_range_min]\n"
+      "vdup.32 q5, %[output_range_min]\n"
+      "vdup.32 q6, %[input_range_offset]\n"
+      "vdup.32 q7, %[input_range_scale]\n"
+      "vdup.32 q8, %[one_over_output_range_scale]\n"
+      "vsub.f32 q4, q4, q5\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #2\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vsub.f32 q3, q3, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vmul.f32 q3, q3, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vmul.f32 q3, q3, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovun.s16 d0, q0\n"
+
+      "vst1.16 {d0[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "d14", "d15", "d16", "d17", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 3>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 3>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "vdup.32 q4, %[input_range_min]\n"
+      "vdup.32 q5, %[output_range_min]\n"
+      "vdup.32 q6, %[input_range_offset]\n"
+      "vdup.32 q7, %[input_range_scale]\n"
+      "vdup.32 q8, %[one_over_output_range_scale]\n"
+      "vsub.f32 q4, q4, q5\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #3\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vsub.f32 q3, q3, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vmul.f32 q3, q3, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vmul.f32 q3, q3, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.32 {d1[0]}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovun.s16 d0, q0\n"
+
+      "vst1.16 {d0[0]}, [%[output]]!\n"
+      "vst1.8 {d0[2]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "d14", "d15", "d16", "d17", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 4>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 4>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "vdup.32 q4, %[input_range_min]\n"
+      "vdup.32 q5, %[output_range_min]\n"
+      "vdup.32 q6, %[input_range_offset]\n"
+      "vdup.32 q7, %[input_range_scale]\n"
+      "vdup.32 q8, %[one_over_output_range_scale]\n"
+      "vsub.f32 q4, q4, q5\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #4\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vsub.f32 q3, q3, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vmul.f32 q3, q3, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vmul.f32 q3, q3, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovun.s16 d0, q0\n"
+
+      "vst1.32 {d0[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "d14", "d15", "d16", "d17", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 5>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 5>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "vdup.32 q4, %[input_range_min]\n"
+      "vdup.32 q5, %[output_range_min]\n"
+      "vdup.32 q6, %[input_range_offset]\n"
+      "vdup.32 q7, %[input_range_scale]\n"
+      "vdup.32 q8, %[one_over_output_range_scale]\n"
+      "vsub.f32 q4, q4, q5\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #5\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vsub.f32 q3, q3, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vmul.f32 q3, q3, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vmul.f32 q3, q3, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "vld1.32 {d2[0]}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovun.s16 d0, q0\n"
+
+      "vst1.32 {d0[0]}, [%[output]]!\n"
+      "vst1.8 {d0[4]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "d14", "d15", "d16", "d17", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 6>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 6>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "vdup.32 q4, %[input_range_min]\n"
+      "vdup.32 q5, %[output_range_min]\n"
+      "vdup.32 q6, %[input_range_offset]\n"
+      "vdup.32 q7, %[input_range_scale]\n"
+      "vdup.32 q8, %[one_over_output_range_scale]\n"
+      "vsub.f32 q4, q4, q5\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #6\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vsub.f32 q3, q3, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vmul.f32 q3, q3, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vmul.f32 q3, q3, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovun.s16 d0, q0\n"
+
+      "vst1.32 {d0[0]}, [%[output]]!\n"
+      "vst1.16 {d0[2]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "d14", "d15", "d16", "d17", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 7>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 7>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "vdup.32 q4, %[input_range_min]\n"
+      "vdup.32 q5, %[output_range_min]\n"
+      "vdup.32 q6, %[input_range_offset]\n"
+      "vdup.32 q7, %[input_range_scale]\n"
+      "vdup.32 q8, %[one_over_output_range_scale]\n"
+      "vsub.f32 q4, q4, q5\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #7\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vsub.f32 q3, q3, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vmul.f32 q3, q3, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vmul.f32 q3, q3, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2}, [%[input]]!\n"
+      "vld1.32 {d3[0]}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovun.s16 d0, q0\n"
+
+      "vst1.32 {d0[0]}, [%[output]]!\n"
+      "vst1.16 {d0[2]}, [%[output]]!\n"
+      "vst1.8 {d0[6]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "d14", "d15", "d16", "d17", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 8>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 8>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "vdup.32 q4, %[input_range_min]\n"
+      "vdup.32 q5, %[output_range_min]\n"
+      "vdup.32 q6, %[input_range_offset]\n"
+      "vdup.32 q7, %[input_range_scale]\n"
+      "vdup.32 q8, %[one_over_output_range_scale]\n"
+      "vsub.f32 q4, q4, q5\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #8\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vsub.f32 q3, q3, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vmul.f32 q3, q3, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vmul.f32 q3, q3, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovun.s16 d0, q0\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "d14", "d15", "d16", "d17", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 9>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 9>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "vdup.32 q4, %[input_range_min]\n"
+      "vdup.32 q5, %[output_range_min]\n"
+      "vdup.32 q6, %[input_range_offset]\n"
+      "vdup.32 q7, %[input_range_scale]\n"
+      "vdup.32 q8, %[one_over_output_range_scale]\n"
+      "vsub.f32 q4, q4, q5\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #9\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vsub.f32 q3, q3, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vmul.f32 q3, q3, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vmul.f32 q3, q3, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4[0]}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.8 {d1[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "d14", "d15", "d16", "d17", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 10>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 10>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "vdup.32 q4, %[input_range_min]\n"
+      "vdup.32 q5, %[output_range_min]\n"
+      "vdup.32 q6, %[input_range_offset]\n"
+      "vdup.32 q7, %[input_range_scale]\n"
+      "vdup.32 q8, %[one_over_output_range_scale]\n"
+      "vsub.f32 q4, q4, q5\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #10\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vsub.f32 q3, q3, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vmul.f32 q3, q3, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vmul.f32 q3, q3, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.16 {d1[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "d14", "d15", "d16", "d17", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 11>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 11>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "vdup.32 q4, %[input_range_min]\n"
+      "vdup.32 q5, %[output_range_min]\n"
+      "vdup.32 q6, %[input_range_offset]\n"
+      "vdup.32 q7, %[input_range_scale]\n"
+      "vdup.32 q8, %[one_over_output_range_scale]\n"
+      "vsub.f32 q4, q4, q5\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #11\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vsub.f32 q3, q3, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vmul.f32 q3, q3, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vmul.f32 q3, q3, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4}, [%[input]]!\n"
+      "vld1.32 {d5[0]}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.16 {d1[0]}, [%[output]]!\n"
+      "vst1.8 {d1[2]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "d14", "d15", "d16", "d17", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 12>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 12>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "vdup.32 q4, %[input_range_min]\n"
+      "vdup.32 q5, %[output_range_min]\n"
+      "vdup.32 q6, %[input_range_offset]\n"
+      "vdup.32 q7, %[input_range_scale]\n"
+      "vdup.32 q8, %[one_over_output_range_scale]\n"
+      "vsub.f32 q4, q4, q5\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #12\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vsub.f32 q3, q3, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vmul.f32 q3, q3, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vmul.f32 q3, q3, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.32 {d1[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "d14", "d15", "d16", "d17", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 13>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 13>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "vdup.32 q4, %[input_range_min]\n"
+      "vdup.32 q5, %[output_range_min]\n"
+      "vdup.32 q6, %[input_range_offset]\n"
+      "vdup.32 q7, %[input_range_scale]\n"
+      "vdup.32 q8, %[one_over_output_range_scale]\n"
+      "vsub.f32 q4, q4, q5\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #13\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vsub.f32 q3, q3, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vmul.f32 q3, q3, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vmul.f32 q3, q3, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5}, [%[input]]!\n"
+      "vld1.32 {d6[0]}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vsub.f32 q3, q3, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vmul.f32 q3, q3, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vmul.f32 q3, q3, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.32 {d1[0]}, [%[output]]!\n"
+      "vst1.8 {d1[4]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "d14", "d15", "d16", "d17", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 14>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 14>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "vdup.32 q4, %[input_range_min]\n"
+      "vdup.32 q5, %[output_range_min]\n"
+      "vdup.32 q6, %[input_range_offset]\n"
+      "vdup.32 q7, %[input_range_scale]\n"
+      "vdup.32 q8, %[one_over_output_range_scale]\n"
+      "vsub.f32 q4, q4, q5\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #14\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vsub.f32 q3, q3, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vmul.f32 q3, q3, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vmul.f32 q3, q3, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vsub.f32 q3, q3, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vmul.f32 q3, q3, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vmul.f32 q3, q3, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.32 {d1[0]}, [%[output]]!\n"
+      "vst1.16 {d1[2]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "d14", "d15", "d16", "d17", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 15>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 15>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "vdup.32 q4, %[input_range_min]\n"
+      "vdup.32 q5, %[output_range_min]\n"
+      "vdup.32 q6, %[input_range_offset]\n"
+      "vdup.32 q7, %[input_range_scale]\n"
+      "vdup.32 q8, %[one_over_output_range_scale]\n"
+      "vsub.f32 q4, q4, q5\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #15\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vsub.f32 q3, q3, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vmul.f32 q3, q3, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vmul.f32 q3, q3, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6}, [%[input]]!\n"
+      "vld1.32 {d7[0]}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q6\n"
+      "vsub.f32 q1, q1, q6\n"
+      "vsub.f32 q2, q2, q6\n"
+      "vsub.f32 q3, q3, q6\n"
+      "vmul.f32 q0, q0, q7\n"
+      "vmul.f32 q1, q1, q7\n"
+      "vmul.f32 q2, q2, q7\n"
+      "vmul.f32 q3, q3, q7\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q8\n"
+      "vmul.f32 q1, q1, q8\n"
+      "vmul.f32 q2, q2, q8\n"
+      "vmul.f32 q3, q3, q8\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.32 {d1[0]}, [%[output]]!\n"
+      "vst1.16 {d1[2]}, [%[output]]!\n"
+      "vst1.8 {d1[6]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "d14", "d15", "d16", "d17", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 0>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 0>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vsub.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vadd.f32 q3, q3, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 1>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 1>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #1\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vsub.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vadd.f32 q3, q3, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "vld1.32 {d0[0]}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovun.s16 d0, q0\n"
+
+      "vst1.8 {d0[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 2>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 2>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #2\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vsub.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vadd.f32 q3, q3, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovun.s16 d0, q0\n"
+
+      "vst1.16 {d0[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 3>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 3>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #3\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vsub.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vadd.f32 q3, q3, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.32 {d1[0]}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovun.s16 d0, q0\n"
+
+      "vst1.16 {d0[0]}, [%[output]]!\n"
+      "vst1.8 {d0[2]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 4>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 4>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #4\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vsub.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vadd.f32 q3, q3, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovun.s16 d0, q0\n"
+
+      "vst1.32 {d0[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 5>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 5>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #5\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vsub.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vadd.f32 q3, q3, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "vld1.32 {d2[0]}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovun.s16 d0, q0\n"
+
+      "vst1.32 {d0[0]}, [%[output]]!\n"
+      "vst1.8 {d0[4]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 6>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 6>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #6\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vsub.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vadd.f32 q3, q3, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovun.s16 d0, q0\n"
+
+      "vst1.32 {d0[0]}, [%[output]]!\n"
+      "vst1.16 {d0[2]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 7>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 7>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #7\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vsub.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vadd.f32 q3, q3, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2}, [%[input]]!\n"
+      "vld1.32 {d3[0]}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovun.s16 d0, q0\n"
+
+      "vst1.32 {d0[0]}, [%[output]]!\n"
+      "vst1.16 {d0[2]}, [%[output]]!\n"
+      "vst1.8 {d0[6]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 8>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 8>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #8\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vsub.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vadd.f32 q3, q3, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovun.s16 d0, q0\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 9>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 9>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #9\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vsub.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vadd.f32 q3, q3, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4[0]}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.8 {d1[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 10>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 10>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #10\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vsub.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vadd.f32 q3, q3, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.16 {d1[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 11>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 11>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #11\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vsub.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vadd.f32 q3, q3, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4}, [%[input]]!\n"
+      "vld1.32 {d5[0]}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.16 {d1[0]}, [%[output]]!\n"
+      "vst1.8 {d1[2]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 12>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 12>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #12\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vsub.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vadd.f32 q3, q3, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.32 {d1[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 13>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 13>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #13\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vsub.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vadd.f32 q3, q3, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5}, [%[input]]!\n"
+      "vld1.32 {d6[0]}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vsub.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vadd.f32 q3, q3, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.32 {d1[0]}, [%[output]]!\n"
+      "vst1.8 {d1[4]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 14>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 14>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #14\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vsub.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vadd.f32 q3, q3, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vsub.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vadd.f32 q3, q3, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.32 {d1[0]}, [%[output]]!\n"
+      "vst1.16 {d1[2]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 15>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 15>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #15\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6, d7}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vsub.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vadd.f32 q3, q3, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "vld1.32 {d0, d1, d2, d3}, [%[input]]!\n"
+      "vld1.32 {d4, d5, d6}, [%[input]]!\n"
+      "vld1.32 {d7[0]}, [%[input]]!\n"
+      "pld [%[input], #64]\n"
+      "vsub.f32 q0, q0, q4\n"
+      "vsub.f32 q1, q1, q4\n"
+      "vsub.f32 q2, q2, q4\n"
+      "vsub.f32 q3, q3, q4\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q5\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vadd.f32 q3, q3, q5\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+      "vqmovn.s32 d0, q0\n"
+      "vqmovn.s32 d1, q1\n"
+      "vqmovn.s32 d4, q2\n"
+      "vqmovn.s32 d5, q3\n"
+      "vqmovun.s16 d0, q0\n"
+      "vqmovun.s16 d1, q2\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.32 {d1[0]}, [%[output]]!\n"
+      "vst1.16 {d1[2]}, [%[output]]!\n"
+      "vst1.8 {d1[6]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 0>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 0>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Dequantize::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vsub.f32 q3, q3, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 1>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 1>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #1\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Dequantize::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vsub.f32 q3, q3, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "vld1.8 {d0[0]}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+
+      "vst1.32 {d0[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 2>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 2>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #2\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Dequantize::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vsub.f32 q3, q3, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "vld1.16 {d0[0]}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 3>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 3>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #3\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Dequantize::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vsub.f32 q3, q3, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "vld1.16 {d0[0]}, [%[input]]!\n"
+      "vld1.8 {d0[2]}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.32 {d1[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 4>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 4>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #4\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Dequantize::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vsub.f32 q3, q3, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "vld1.32 {d0[0]}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 5>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 5>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #5\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Dequantize::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vsub.f32 q3, q3, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "vld1.32 {d0[0]}, [%[input]]!\n"
+      "vld1.8 {d0[4]}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "vst1.32 {d2[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 6>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 6>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #6\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Dequantize::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vsub.f32 q3, q3, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "vld1.32 {d0[0]}, [%[input]]!\n"
+      "vld1.16 {d0[2]}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+
+      "vst1.32 {d0, d1, d2}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 7>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 7>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #7\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Dequantize::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vsub.f32 q3, q3, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "vld1.32 {d0[0]}, [%[input]]!\n"
+      "vld1.16 {d0[2]}, [%[input]]!\n"
+      "vld1.8 {d0[6]}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+
+      "vst1.32 {d0, d1, d2}, [%[output]]!\n"
+      "vst1.32 {d3[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 8>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 8>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #8\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Dequantize::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vsub.f32 q3, q3, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 9>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 9>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #9\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Dequantize::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vsub.f32 q3, q3, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.8 {d1[0]}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 10>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 10>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #10\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Dequantize::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vsub.f32 q3, q3, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.16 {d1[0]}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 11>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 11>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #11\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Dequantize::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vsub.f32 q3, q3, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.16 {d1[0]}, [%[input]]!\n"
+      "vld1.8 {d1[2]}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4}, [%[output]]!\n"
+      "vst1.32 {d5[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 12>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 12>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #12\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Dequantize::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vsub.f32 q3, q3, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.32 {d1[0]}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 13>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 13>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #13\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Dequantize::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vsub.f32 q3, q3, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.32 {d1[0]}, [%[input]]!\n"
+      "vld1.8 {d1[4]}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vsub.f32 q3, q3, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5}, [%[output]]!\n"
+      "vst1.32 {d6[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 14>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 14>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #14\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Dequantize::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vsub.f32 q3, q3, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.32 {d1[0]}, [%[input]]!\n"
+      "vld1.16 {d1[2]}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vsub.f32 q3, q3, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 15>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 15>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "vdup.32 q4, %[range_min]\n"
+      "vdup.32 q5, %[range_offset]\n"
+      "vdup.32 q6, %[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #15\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // Dequantize::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vsub.f32 q3, q3, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.32 {d1[0]}, [%[input]]!\n"
+      "vld1.16 {d1[2]}, [%[input]]!\n"
+      "vld1.8 {d1[6]}, [%[input]]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vsub.f32 q0, q0, q5\n"
+      "vsub.f32 q1, q1, q5\n"
+      "vsub.f32 q2, q2, q5\n"
+      "vsub.f32 q3, q3, q5\n"
+      "vmul.f32 q0, q0, q6\n"
+      "vmul.f32 q1, q1, q6\n"
+      "vmul.f32 q2, q2, q6\n"
+      "vmul.f32 q3, q3, q6\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q4\n"
+      "vadd.f32 q3, q3, q4\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6}, [%[output]]!\n"
+      "vst1.32 {d7[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10",
+        "d11", "d12", "d13", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              0>::Transform(const uint8_t* input,
+                                            const MinMax<uint8_t>& params,
+                                            uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "0>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "vdup.8 q4, %[min]\n"
+      "vdup.8 q5, %[max]\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // MinMax::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "d0", "d1", "d8", "d9", "d10", "d11", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              1>::Transform(const uint8_t* input,
+                                            const MinMax<uint8_t>& params,
+                                            uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "1>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "vdup.8 q4, %[min]\n"
+      "vdup.8 q5, %[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #1\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // MinMax::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "vld1.8 {d0[0]}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.8 {d0[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "d0", "d1", "d8", "d9", "d10", "d11", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              2>::Transform(const uint8_t* input,
+                                            const MinMax<uint8_t>& params,
+                                            uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "2>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "vdup.8 q4, %[min]\n"
+      "vdup.8 q5, %[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #2\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // MinMax::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "vld1.16 {d0[0]}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.16 {d0[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "d0", "d1", "d8", "d9", "d10", "d11", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              3>::Transform(const uint8_t* input,
+                                            const MinMax<uint8_t>& params,
+                                            uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "3>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "vdup.8 q4, %[min]\n"
+      "vdup.8 q5, %[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #3\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // MinMax::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "vld1.16 {d0[0]}, [%[input]]!\n"
+      "vld1.8 {d0[2]}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.16 {d0[0]}, [%[output]]!\n"
+      "vst1.8 {d0[2]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "d0", "d1", "d8", "d9", "d10", "d11", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              4>::Transform(const uint8_t* input,
+                                            const MinMax<uint8_t>& params,
+                                            uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "4>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "vdup.8 q4, %[min]\n"
+      "vdup.8 q5, %[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #4\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // MinMax::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "vld1.32 {d0[0]}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "d0", "d1", "d8", "d9", "d10", "d11", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              5>::Transform(const uint8_t* input,
+                                            const MinMax<uint8_t>& params,
+                                            uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "5>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "vdup.8 q4, %[min]\n"
+      "vdup.8 q5, %[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #5\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // MinMax::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "vld1.32 {d0[0]}, [%[input]]!\n"
+      "vld1.8 {d0[4]}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0[0]}, [%[output]]!\n"
+      "vst1.8 {d0[4]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "d0", "d1", "d8", "d9", "d10", "d11", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              6>::Transform(const uint8_t* input,
+                                            const MinMax<uint8_t>& params,
+                                            uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "6>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "vdup.8 q4, %[min]\n"
+      "vdup.8 q5, %[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #6\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // MinMax::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "vld1.32 {d0[0]}, [%[input]]!\n"
+      "vld1.16 {d0[2]}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0[0]}, [%[output]]!\n"
+      "vst1.16 {d0[2]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "d0", "d1", "d8", "d9", "d10", "d11", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              7>::Transform(const uint8_t* input,
+                                            const MinMax<uint8_t>& params,
+                                            uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "7>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "vdup.8 q4, %[min]\n"
+      "vdup.8 q5, %[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #7\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // MinMax::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "vld1.32 {d0[0]}, [%[input]]!\n"
+      "vld1.16 {d0[2]}, [%[input]]!\n"
+      "vld1.8 {d0[6]}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0[0]}, [%[output]]!\n"
+      "vst1.16 {d0[2]}, [%[output]]!\n"
+      "vst1.8 {d0[6]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "d0", "d1", "d8", "d9", "d10", "d11", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              8>::Transform(const uint8_t* input,
+                                            const MinMax<uint8_t>& params,
+                                            uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "8>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "vdup.8 q4, %[min]\n"
+      "vdup.8 q5, %[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #8\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // MinMax::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "d0", "d1", "d8", "d9", "d10", "d11", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              9>::Transform(const uint8_t* input,
+                                            const MinMax<uint8_t>& params,
+                                            uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "9>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "vdup.8 q4, %[min]\n"
+      "vdup.8 q5, %[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #9\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // MinMax::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.8 {d1[0]}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.8 {d1[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "d0", "d1", "d8", "d9", "d10", "d11", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              10>::Transform(const uint8_t* input,
+                                             const MinMax<uint8_t>& params,
+                                             uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "10>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "vdup.8 q4, %[min]\n"
+      "vdup.8 q5, %[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #10\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // MinMax::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.16 {d1[0]}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.16 {d1[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "d0", "d1", "d8", "d9", "d10", "d11", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              11>::Transform(const uint8_t* input,
+                                             const MinMax<uint8_t>& params,
+                                             uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "11>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "vdup.8 q4, %[min]\n"
+      "vdup.8 q5, %[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #11\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // MinMax::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.16 {d1[0]}, [%[input]]!\n"
+      "vld1.8 {d1[2]}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.16 {d1[0]}, [%[output]]!\n"
+      "vst1.8 {d1[2]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "d0", "d1", "d8", "d9", "d10", "d11", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              12>::Transform(const uint8_t* input,
+                                             const MinMax<uint8_t>& params,
+                                             uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "12>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "vdup.8 q4, %[min]\n"
+      "vdup.8 q5, %[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #12\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // MinMax::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.32 {d1[0]}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.32 {d1[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "d0", "d1", "d8", "d9", "d10", "d11", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              13>::Transform(const uint8_t* input,
+                                             const MinMax<uint8_t>& params,
+                                             uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "13>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "vdup.8 q4, %[min]\n"
+      "vdup.8 q5, %[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #13\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // MinMax::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.32 {d1[0]}, [%[input]]!\n"
+      "vld1.8 {d1[4]}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.32 {d1[0]}, [%[output]]!\n"
+      "vst1.8 {d1[4]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "d0", "d1", "d8", "d9", "d10", "d11", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              14>::Transform(const uint8_t* input,
+                                             const MinMax<uint8_t>& params,
+                                             uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "14>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "vdup.8 q4, %[min]\n"
+      "vdup.8 q5, %[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #14\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // MinMax::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.32 {d1[0]}, [%[input]]!\n"
+      "vld1.16 {d1[2]}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.32 {d1[0]}, [%[output]]!\n"
+      "vst1.16 {d1[2]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "d0", "d1", "d8", "d9", "d10", "d11", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              15>::Transform(const uint8_t* input,
+                                             const MinMax<uint8_t>& params,
+                                             uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "15>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "vdup.8 q4, %[min]\n"
+      "vdup.8 q5, %[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %[count], %[count], #15\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %[count], %[count], #16\n"
+
+      // MinMax::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.32 {d1[0]}, [%[input]]!\n"
+      "vld1.16 {d1[2]}, [%[input]]!\n"
+      "vld1.8 {d1[6]}, [%[input]]!\n"
+      "pld [%[input], #16]\n"
+      "vmax.u8 q0, q0, q4\n"
+      "vmin.u8 q0, q0, q5\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.32 {d1[0]}, [%[output]]!\n"
+      "vst1.16 {d1[2]}, [%[output]]!\n"
+      "vst1.8 {d1[6]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "d0", "d1", "d8", "d9", "d10", "d11", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              0>::Transform(const uint8_t* input,
+                                            const BiasAdd<uint8_t>& params,
+                                            int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "0>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr r0, %[input_range_min]\n"
+      "vdup.32 q8, r0\n"
+      "ldr r0, %[input_range_scale]\n"
+      "vdup.32 q9, r0\n"
+      "ldr r0, %[bias_range_min]\n"
+      "vdup.32 q10, r0\n"
+      "ldr r0, %[bias_range_scale]\n"
+      "vdup.32 q11, r0\n"
+      "ldr r0, %[output_range_min]\n"
+      "vdup.32 q12, r0\n"
+      "ldr r0, %[one_over_output_range_scale]\n"
+      "vdup.32 q13, r0\n"
+      "ldr r0, %[output_range_offset]\n"
+      "vdup.32 q14, r0\n"
+      "1:"
+      "mov r0, %[count]\n"
+      "mov r1, %[bias]\n"
+      "2:"
+      "subs r0, r0, #16\n"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "vld1.32 {d8, d9}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q5, d9\n"
+      "vmovl.u8 q4, d8\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q7, d11\n"
+      "vmovl.s16 q6, d10\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q5, d9\n"
+      "vmovl.s16 q4, d8\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vcvt.f32.s32 q6, q6\n"
+      "vcvt.f32.s32 q7, q7\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q9\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vmul.f32 q6, q6, q11\n"
+      "vmul.f32 q7, q7, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q8\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q6, q6, q10\n"
+      "vadd.f32 q7, q7, q10\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q6\n"
+      "vadd.f32 q3, q3, q7\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vsub.f32 q3, q3, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vmul.f32 q3, q3, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vadd.f32 q3, q3, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "bne 2b\n"
+      "subs %[rows], %[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27", "d28", "d29",
+        "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              1>::Transform(const uint8_t* input,
+                                            const BiasAdd<uint8_t>& params,
+                                            int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "1>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr r0, %[input_range_min]\n"
+      "vdup.32 q8, r0\n"
+      "ldr r0, %[input_range_scale]\n"
+      "vdup.32 q9, r0\n"
+      "ldr r0, %[bias_range_min]\n"
+      "vdup.32 q10, r0\n"
+      "ldr r0, %[bias_range_scale]\n"
+      "vdup.32 q11, r0\n"
+      "ldr r0, %[output_range_min]\n"
+      "vdup.32 q12, r0\n"
+      "ldr r0, %[one_over_output_range_scale]\n"
+      "vdup.32 q13, r0\n"
+      "ldr r0, %[output_range_offset]\n"
+      "vdup.32 q14, r0\n"
+      "1:"
+      "mov r0, %[count]\n"
+      "mov r1, %[bias]\n"
+      "subs r0, r0, #1\n"
+      "beq 3f\n"
+      "2:"
+      "subs r0, r0, #16\n"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "vld1.32 {d8, d9}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q5, d9\n"
+      "vmovl.u8 q4, d8\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q7, d11\n"
+      "vmovl.s16 q6, d10\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q5, d9\n"
+      "vmovl.s16 q4, d8\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vcvt.f32.s32 q6, q6\n"
+      "vcvt.f32.s32 q7, q7\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q9\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vmul.f32 q6, q6, q11\n"
+      "vmul.f32 q7, q7, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q8\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q6, q6, q10\n"
+      "vadd.f32 q7, q7, q10\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q6\n"
+      "vadd.f32 q3, q3, q7\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vsub.f32 q3, q3, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vmul.f32 q3, q3, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vadd.f32 q3, q3, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "vld1.8 {d0[0]}, [%[input]]!\n"
+      "vld1.8 {d2[0]}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q1, d2\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q1, d2\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q10\n"
+      "vadd.f32 q0, q0, q1\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+
+      "vst1.32 {d0[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "subs %[rows], %[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27", "d28", "d29",
+        "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              2>::Transform(const uint8_t* input,
+                                            const BiasAdd<uint8_t>& params,
+                                            int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "2>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr r0, %[input_range_min]\n"
+      "vdup.32 q8, r0\n"
+      "ldr r0, %[input_range_scale]\n"
+      "vdup.32 q9, r0\n"
+      "ldr r0, %[bias_range_min]\n"
+      "vdup.32 q10, r0\n"
+      "ldr r0, %[bias_range_scale]\n"
+      "vdup.32 q11, r0\n"
+      "ldr r0, %[output_range_min]\n"
+      "vdup.32 q12, r0\n"
+      "ldr r0, %[one_over_output_range_scale]\n"
+      "vdup.32 q13, r0\n"
+      "ldr r0, %[output_range_offset]\n"
+      "vdup.32 q14, r0\n"
+      "1:"
+      "mov r0, %[count]\n"
+      "mov r1, %[bias]\n"
+      "subs r0, r0, #2\n"
+      "beq 3f\n"
+      "2:"
+      "subs r0, r0, #16\n"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "vld1.32 {d8, d9}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q5, d9\n"
+      "vmovl.u8 q4, d8\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q7, d11\n"
+      "vmovl.s16 q6, d10\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q5, d9\n"
+      "vmovl.s16 q4, d8\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vcvt.f32.s32 q6, q6\n"
+      "vcvt.f32.s32 q7, q7\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q9\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vmul.f32 q6, q6, q11\n"
+      "vmul.f32 q7, q7, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q8\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q6, q6, q10\n"
+      "vadd.f32 q7, q7, q10\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q6\n"
+      "vadd.f32 q3, q3, q7\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vsub.f32 q3, q3, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vmul.f32 q3, q3, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vadd.f32 q3, q3, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "vld1.16 {d0[0]}, [%[input]]!\n"
+      "vld1.16 {d2[0]}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q1, d2\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q1, d2\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q10\n"
+      "vadd.f32 q0, q0, q1\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "subs %[rows], %[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27", "d28", "d29",
+        "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              3>::Transform(const uint8_t* input,
+                                            const BiasAdd<uint8_t>& params,
+                                            int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "3>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr r0, %[input_range_min]\n"
+      "vdup.32 q8, r0\n"
+      "ldr r0, %[input_range_scale]\n"
+      "vdup.32 q9, r0\n"
+      "ldr r0, %[bias_range_min]\n"
+      "vdup.32 q10, r0\n"
+      "ldr r0, %[bias_range_scale]\n"
+      "vdup.32 q11, r0\n"
+      "ldr r0, %[output_range_min]\n"
+      "vdup.32 q12, r0\n"
+      "ldr r0, %[one_over_output_range_scale]\n"
+      "vdup.32 q13, r0\n"
+      "ldr r0, %[output_range_offset]\n"
+      "vdup.32 q14, r0\n"
+      "1:"
+      "mov r0, %[count]\n"
+      "mov r1, %[bias]\n"
+      "subs r0, r0, #3\n"
+      "beq 3f\n"
+      "2:"
+      "subs r0, r0, #16\n"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "vld1.32 {d8, d9}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q5, d9\n"
+      "vmovl.u8 q4, d8\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q7, d11\n"
+      "vmovl.s16 q6, d10\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q5, d9\n"
+      "vmovl.s16 q4, d8\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vcvt.f32.s32 q6, q6\n"
+      "vcvt.f32.s32 q7, q7\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q9\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vmul.f32 q6, q6, q11\n"
+      "vmul.f32 q7, q7, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q8\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q6, q6, q10\n"
+      "vadd.f32 q7, q7, q10\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q6\n"
+      "vadd.f32 q3, q3, q7\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vsub.f32 q3, q3, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vmul.f32 q3, q3, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vadd.f32 q3, q3, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "vld1.16 {d0[0]}, [%[input]]!\n"
+      "vld1.8 {d0[2]}, [%[input]]!\n"
+      "vld1.16 {d2[0]}, [r1]!\n"
+      "vld1.8 {d2[2]}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q1, d2\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q1, d2\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q10\n"
+      "vadd.f32 q0, q0, q1\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+
+      "vst1.32 {d0}, [%[output]]!\n"
+      "vst1.32 {d1[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "subs %[rows], %[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27", "d28", "d29",
+        "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              4>::Transform(const uint8_t* input,
+                                            const BiasAdd<uint8_t>& params,
+                                            int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "4>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr r0, %[input_range_min]\n"
+      "vdup.32 q8, r0\n"
+      "ldr r0, %[input_range_scale]\n"
+      "vdup.32 q9, r0\n"
+      "ldr r0, %[bias_range_min]\n"
+      "vdup.32 q10, r0\n"
+      "ldr r0, %[bias_range_scale]\n"
+      "vdup.32 q11, r0\n"
+      "ldr r0, %[output_range_min]\n"
+      "vdup.32 q12, r0\n"
+      "ldr r0, %[one_over_output_range_scale]\n"
+      "vdup.32 q13, r0\n"
+      "ldr r0, %[output_range_offset]\n"
+      "vdup.32 q14, r0\n"
+      "1:"
+      "mov r0, %[count]\n"
+      "mov r1, %[bias]\n"
+      "subs r0, r0, #4\n"
+      "beq 3f\n"
+      "2:"
+      "subs r0, r0, #16\n"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "vld1.32 {d8, d9}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q5, d9\n"
+      "vmovl.u8 q4, d8\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q7, d11\n"
+      "vmovl.s16 q6, d10\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q5, d9\n"
+      "vmovl.s16 q4, d8\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vcvt.f32.s32 q6, q6\n"
+      "vcvt.f32.s32 q7, q7\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q9\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vmul.f32 q6, q6, q11\n"
+      "vmul.f32 q7, q7, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q8\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q6, q6, q10\n"
+      "vadd.f32 q7, q7, q10\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q6\n"
+      "vadd.f32 q3, q3, q7\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vsub.f32 q3, q3, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vmul.f32 q3, q3, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vadd.f32 q3, q3, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0[0]}, [%[input]]!\n"
+      "vld1.32 {d2[0]}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q1, d2\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q1, d2\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q10\n"
+      "vadd.f32 q0, q0, q1\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "subs %[rows], %[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27", "d28", "d29",
+        "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              5>::Transform(const uint8_t* input,
+                                            const BiasAdd<uint8_t>& params,
+                                            int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "5>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr r0, %[input_range_min]\n"
+      "vdup.32 q8, r0\n"
+      "ldr r0, %[input_range_scale]\n"
+      "vdup.32 q9, r0\n"
+      "ldr r0, %[bias_range_min]\n"
+      "vdup.32 q10, r0\n"
+      "ldr r0, %[bias_range_scale]\n"
+      "vdup.32 q11, r0\n"
+      "ldr r0, %[output_range_min]\n"
+      "vdup.32 q12, r0\n"
+      "ldr r0, %[one_over_output_range_scale]\n"
+      "vdup.32 q13, r0\n"
+      "ldr r0, %[output_range_offset]\n"
+      "vdup.32 q14, r0\n"
+      "1:"
+      "mov r0, %[count]\n"
+      "mov r1, %[bias]\n"
+      "subs r0, r0, #5\n"
+      "beq 3f\n"
+      "2:"
+      "subs r0, r0, #16\n"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "vld1.32 {d8, d9}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q5, d9\n"
+      "vmovl.u8 q4, d8\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q7, d11\n"
+      "vmovl.s16 q6, d10\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q5, d9\n"
+      "vmovl.s16 q4, d8\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vcvt.f32.s32 q6, q6\n"
+      "vcvt.f32.s32 q7, q7\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q9\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vmul.f32 q6, q6, q11\n"
+      "vmul.f32 q7, q7, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q8\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q6, q6, q10\n"
+      "vadd.f32 q7, q7, q10\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q6\n"
+      "vadd.f32 q3, q3, q7\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vsub.f32 q3, q3, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vmul.f32 q3, q3, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vadd.f32 q3, q3, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0[0]}, [%[input]]!\n"
+      "vld1.8 {d0[4]}, [%[input]]!\n"
+      "vld1.32 {d4[0]}, [r1]!\n"
+      "vld1.8 {d4[4]}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q2, d4\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q3, d5\n"
+      "vmovl.s16 q2, d4\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q11\n"
+      "vmul.f32 q3, q3, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q10\n"
+      "vadd.f32 q3, q3, q10\n"
+      "vadd.f32 q0, q0, q2\n"
+      "vadd.f32 q1, q1, q3\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+
+      "vst1.32 {d0, d1}, [%[output]]!\n"
+      "vst1.32 {d2[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "subs %[rows], %[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27", "d28", "d29",
+        "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              6>::Transform(const uint8_t* input,
+                                            const BiasAdd<uint8_t>& params,
+                                            int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "6>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr r0, %[input_range_min]\n"
+      "vdup.32 q8, r0\n"
+      "ldr r0, %[input_range_scale]\n"
+      "vdup.32 q9, r0\n"
+      "ldr r0, %[bias_range_min]\n"
+      "vdup.32 q10, r0\n"
+      "ldr r0, %[bias_range_scale]\n"
+      "vdup.32 q11, r0\n"
+      "ldr r0, %[output_range_min]\n"
+      "vdup.32 q12, r0\n"
+      "ldr r0, %[one_over_output_range_scale]\n"
+      "vdup.32 q13, r0\n"
+      "ldr r0, %[output_range_offset]\n"
+      "vdup.32 q14, r0\n"
+      "1:"
+      "mov r0, %[count]\n"
+      "mov r1, %[bias]\n"
+      "subs r0, r0, #6\n"
+      "beq 3f\n"
+      "2:"
+      "subs r0, r0, #16\n"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "vld1.32 {d8, d9}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q5, d9\n"
+      "vmovl.u8 q4, d8\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q7, d11\n"
+      "vmovl.s16 q6, d10\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q5, d9\n"
+      "vmovl.s16 q4, d8\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vcvt.f32.s32 q6, q6\n"
+      "vcvt.f32.s32 q7, q7\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q9\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vmul.f32 q6, q6, q11\n"
+      "vmul.f32 q7, q7, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q8\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q6, q6, q10\n"
+      "vadd.f32 q7, q7, q10\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q6\n"
+      "vadd.f32 q3, q3, q7\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vsub.f32 q3, q3, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vmul.f32 q3, q3, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vadd.f32 q3, q3, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0[0]}, [%[input]]!\n"
+      "vld1.16 {d0[2]}, [%[input]]!\n"
+      "vld1.32 {d4[0]}, [r1]!\n"
+      "vld1.16 {d4[2]}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q2, d4\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q3, d5\n"
+      "vmovl.s16 q2, d4\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q11\n"
+      "vmul.f32 q3, q3, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q10\n"
+      "vadd.f32 q3, q3, q10\n"
+      "vadd.f32 q0, q0, q2\n"
+      "vadd.f32 q1, q1, q3\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+
+      "vst1.32 {d0, d1, d2}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "subs %[rows], %[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27", "d28", "d29",
+        "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              7>::Transform(const uint8_t* input,
+                                            const BiasAdd<uint8_t>& params,
+                                            int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "7>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr r0, %[input_range_min]\n"
+      "vdup.32 q8, r0\n"
+      "ldr r0, %[input_range_scale]\n"
+      "vdup.32 q9, r0\n"
+      "ldr r0, %[bias_range_min]\n"
+      "vdup.32 q10, r0\n"
+      "ldr r0, %[bias_range_scale]\n"
+      "vdup.32 q11, r0\n"
+      "ldr r0, %[output_range_min]\n"
+      "vdup.32 q12, r0\n"
+      "ldr r0, %[one_over_output_range_scale]\n"
+      "vdup.32 q13, r0\n"
+      "ldr r0, %[output_range_offset]\n"
+      "vdup.32 q14, r0\n"
+      "1:"
+      "mov r0, %[count]\n"
+      "mov r1, %[bias]\n"
+      "subs r0, r0, #7\n"
+      "beq 3f\n"
+      "2:"
+      "subs r0, r0, #16\n"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "vld1.32 {d8, d9}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q5, d9\n"
+      "vmovl.u8 q4, d8\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q7, d11\n"
+      "vmovl.s16 q6, d10\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q5, d9\n"
+      "vmovl.s16 q4, d8\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vcvt.f32.s32 q6, q6\n"
+      "vcvt.f32.s32 q7, q7\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q9\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vmul.f32 q6, q6, q11\n"
+      "vmul.f32 q7, q7, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q8\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q6, q6, q10\n"
+      "vadd.f32 q7, q7, q10\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q6\n"
+      "vadd.f32 q3, q3, q7\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vsub.f32 q3, q3, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vmul.f32 q3, q3, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vadd.f32 q3, q3, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0[0]}, [%[input]]!\n"
+      "vld1.16 {d0[2]}, [%[input]]!\n"
+      "vld1.8 {d0[6]}, [%[input]]!\n"
+      "vld1.32 {d4[0]}, [r1]!\n"
+      "vld1.16 {d4[2]}, [r1]!\n"
+      "vld1.8 {d4[6]}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q2, d4\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q3, d5\n"
+      "vmovl.s16 q2, d4\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q11\n"
+      "vmul.f32 q3, q3, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q10\n"
+      "vadd.f32 q3, q3, q10\n"
+      "vadd.f32 q0, q0, q2\n"
+      "vadd.f32 q1, q1, q3\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+
+      "vst1.32 {d0, d1, d2}, [%[output]]!\n"
+      "vst1.32 {d3[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "subs %[rows], %[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27", "d28", "d29",
+        "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              8>::Transform(const uint8_t* input,
+                                            const BiasAdd<uint8_t>& params,
+                                            int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "8>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr r0, %[input_range_min]\n"
+      "vdup.32 q8, r0\n"
+      "ldr r0, %[input_range_scale]\n"
+      "vdup.32 q9, r0\n"
+      "ldr r0, %[bias_range_min]\n"
+      "vdup.32 q10, r0\n"
+      "ldr r0, %[bias_range_scale]\n"
+      "vdup.32 q11, r0\n"
+      "ldr r0, %[output_range_min]\n"
+      "vdup.32 q12, r0\n"
+      "ldr r0, %[one_over_output_range_scale]\n"
+      "vdup.32 q13, r0\n"
+      "ldr r0, %[output_range_offset]\n"
+      "vdup.32 q14, r0\n"
+      "1:"
+      "mov r0, %[count]\n"
+      "mov r1, %[bias]\n"
+      "subs r0, r0, #8\n"
+      "beq 3f\n"
+      "2:"
+      "subs r0, r0, #16\n"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "vld1.32 {d8, d9}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q5, d9\n"
+      "vmovl.u8 q4, d8\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q7, d11\n"
+      "vmovl.s16 q6, d10\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q5, d9\n"
+      "vmovl.s16 q4, d8\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vcvt.f32.s32 q6, q6\n"
+      "vcvt.f32.s32 q7, q7\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q9\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vmul.f32 q6, q6, q11\n"
+      "vmul.f32 q7, q7, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q8\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q6, q6, q10\n"
+      "vadd.f32 q7, q7, q10\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q6\n"
+      "vadd.f32 q3, q3, q7\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vsub.f32 q3, q3, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vmul.f32 q3, q3, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vadd.f32 q3, q3, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.32 {d4}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q2, d4\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q3, d5\n"
+      "vmovl.s16 q2, d4\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q11\n"
+      "vmul.f32 q3, q3, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q10\n"
+      "vadd.f32 q3, q3, q10\n"
+      "vadd.f32 q0, q0, q2\n"
+      "vadd.f32 q1, q1, q3\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "subs %[rows], %[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27", "d28", "d29",
+        "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              9>::Transform(const uint8_t* input,
+                                            const BiasAdd<uint8_t>& params,
+                                            int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "9>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr r0, %[input_range_min]\n"
+      "vdup.32 q8, r0\n"
+      "ldr r0, %[input_range_scale]\n"
+      "vdup.32 q9, r0\n"
+      "ldr r0, %[bias_range_min]\n"
+      "vdup.32 q10, r0\n"
+      "ldr r0, %[bias_range_scale]\n"
+      "vdup.32 q11, r0\n"
+      "ldr r0, %[output_range_min]\n"
+      "vdup.32 q12, r0\n"
+      "ldr r0, %[one_over_output_range_scale]\n"
+      "vdup.32 q13, r0\n"
+      "ldr r0, %[output_range_offset]\n"
+      "vdup.32 q14, r0\n"
+      "1:"
+      "mov r0, %[count]\n"
+      "mov r1, %[bias]\n"
+      "subs r0, r0, #9\n"
+      "beq 3f\n"
+      "2:"
+      "subs r0, r0, #16\n"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "vld1.32 {d8, d9}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q5, d9\n"
+      "vmovl.u8 q4, d8\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q7, d11\n"
+      "vmovl.s16 q6, d10\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q5, d9\n"
+      "vmovl.s16 q4, d8\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vcvt.f32.s32 q6, q6\n"
+      "vcvt.f32.s32 q7, q7\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q9\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vmul.f32 q6, q6, q11\n"
+      "vmul.f32 q7, q7, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q8\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q6, q6, q10\n"
+      "vadd.f32 q7, q7, q10\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q6\n"
+      "vadd.f32 q3, q3, q7\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vsub.f32 q3, q3, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vmul.f32 q3, q3, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vadd.f32 q3, q3, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.8 {d1[0]}, [%[input]]!\n"
+      "vld1.32 {d6}, [r1]!\n"
+      "vld1.8 {d7[0]}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q4, d7\n"
+      "vmovl.u8 q3, d6\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q5, d8\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q4, d7\n"
+      "vmovl.s16 q3, d6\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q11\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q10\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q0, q0, q3\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "subs %[rows], %[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27", "d28", "d29",
+        "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              10>::Transform(const uint8_t* input,
+                                             const BiasAdd<uint8_t>& params,
+                                             int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "10>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr r0, %[input_range_min]\n"
+      "vdup.32 q8, r0\n"
+      "ldr r0, %[input_range_scale]\n"
+      "vdup.32 q9, r0\n"
+      "ldr r0, %[bias_range_min]\n"
+      "vdup.32 q10, r0\n"
+      "ldr r0, %[bias_range_scale]\n"
+      "vdup.32 q11, r0\n"
+      "ldr r0, %[output_range_min]\n"
+      "vdup.32 q12, r0\n"
+      "ldr r0, %[one_over_output_range_scale]\n"
+      "vdup.32 q13, r0\n"
+      "ldr r0, %[output_range_offset]\n"
+      "vdup.32 q14, r0\n"
+      "1:"
+      "mov r0, %[count]\n"
+      "mov r1, %[bias]\n"
+      "subs r0, r0, #10\n"
+      "beq 3f\n"
+      "2:"
+      "subs r0, r0, #16\n"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "vld1.32 {d8, d9}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q5, d9\n"
+      "vmovl.u8 q4, d8\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q7, d11\n"
+      "vmovl.s16 q6, d10\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q5, d9\n"
+      "vmovl.s16 q4, d8\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vcvt.f32.s32 q6, q6\n"
+      "vcvt.f32.s32 q7, q7\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q9\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vmul.f32 q6, q6, q11\n"
+      "vmul.f32 q7, q7, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q8\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q6, q6, q10\n"
+      "vadd.f32 q7, q7, q10\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q6\n"
+      "vadd.f32 q3, q3, q7\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vsub.f32 q3, q3, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vmul.f32 q3, q3, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vadd.f32 q3, q3, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.16 {d1[0]}, [%[input]]!\n"
+      "vld1.32 {d6}, [r1]!\n"
+      "vld1.16 {d7[0]}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q4, d7\n"
+      "vmovl.u8 q3, d6\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q5, d8\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q4, d7\n"
+      "vmovl.s16 q3, d6\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q11\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q10\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q0, q0, q3\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "subs %[rows], %[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27", "d28", "d29",
+        "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              11>::Transform(const uint8_t* input,
+                                             const BiasAdd<uint8_t>& params,
+                                             int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "11>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr r0, %[input_range_min]\n"
+      "vdup.32 q8, r0\n"
+      "ldr r0, %[input_range_scale]\n"
+      "vdup.32 q9, r0\n"
+      "ldr r0, %[bias_range_min]\n"
+      "vdup.32 q10, r0\n"
+      "ldr r0, %[bias_range_scale]\n"
+      "vdup.32 q11, r0\n"
+      "ldr r0, %[output_range_min]\n"
+      "vdup.32 q12, r0\n"
+      "ldr r0, %[one_over_output_range_scale]\n"
+      "vdup.32 q13, r0\n"
+      "ldr r0, %[output_range_offset]\n"
+      "vdup.32 q14, r0\n"
+      "1:"
+      "mov r0, %[count]\n"
+      "mov r1, %[bias]\n"
+      "subs r0, r0, #11\n"
+      "beq 3f\n"
+      "2:"
+      "subs r0, r0, #16\n"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "vld1.32 {d8, d9}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q5, d9\n"
+      "vmovl.u8 q4, d8\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q7, d11\n"
+      "vmovl.s16 q6, d10\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q5, d9\n"
+      "vmovl.s16 q4, d8\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vcvt.f32.s32 q6, q6\n"
+      "vcvt.f32.s32 q7, q7\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q9\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vmul.f32 q6, q6, q11\n"
+      "vmul.f32 q7, q7, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q8\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q6, q6, q10\n"
+      "vadd.f32 q7, q7, q10\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q6\n"
+      "vadd.f32 q3, q3, q7\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vsub.f32 q3, q3, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vmul.f32 q3, q3, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vadd.f32 q3, q3, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.16 {d1[0]}, [%[input]]!\n"
+      "vld1.8 {d1[2]}, [%[input]]!\n"
+      "vld1.32 {d6}, [r1]!\n"
+      "vld1.16 {d7[0]}, [r1]!\n"
+      "vld1.8 {d7[2]}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q4, d7\n"
+      "vmovl.u8 q3, d6\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q5, d8\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q4, d7\n"
+      "vmovl.s16 q3, d6\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q11\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q10\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q0, q0, q3\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4}, [%[output]]!\n"
+      "vst1.32 {d5[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "subs %[rows], %[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27", "d28", "d29",
+        "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              12>::Transform(const uint8_t* input,
+                                             const BiasAdd<uint8_t>& params,
+                                             int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "12>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr r0, %[input_range_min]\n"
+      "vdup.32 q8, r0\n"
+      "ldr r0, %[input_range_scale]\n"
+      "vdup.32 q9, r0\n"
+      "ldr r0, %[bias_range_min]\n"
+      "vdup.32 q10, r0\n"
+      "ldr r0, %[bias_range_scale]\n"
+      "vdup.32 q11, r0\n"
+      "ldr r0, %[output_range_min]\n"
+      "vdup.32 q12, r0\n"
+      "ldr r0, %[one_over_output_range_scale]\n"
+      "vdup.32 q13, r0\n"
+      "ldr r0, %[output_range_offset]\n"
+      "vdup.32 q14, r0\n"
+      "1:"
+      "mov r0, %[count]\n"
+      "mov r1, %[bias]\n"
+      "subs r0, r0, #12\n"
+      "beq 3f\n"
+      "2:"
+      "subs r0, r0, #16\n"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "vld1.32 {d8, d9}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q5, d9\n"
+      "vmovl.u8 q4, d8\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q7, d11\n"
+      "vmovl.s16 q6, d10\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q5, d9\n"
+      "vmovl.s16 q4, d8\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vcvt.f32.s32 q6, q6\n"
+      "vcvt.f32.s32 q7, q7\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q9\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vmul.f32 q6, q6, q11\n"
+      "vmul.f32 q7, q7, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q8\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q6, q6, q10\n"
+      "vadd.f32 q7, q7, q10\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q6\n"
+      "vadd.f32 q3, q3, q7\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vsub.f32 q3, q3, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vmul.f32 q3, q3, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vadd.f32 q3, q3, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.32 {d1[0]}, [%[input]]!\n"
+      "vld1.32 {d6}, [r1]!\n"
+      "vld1.32 {d7[0]}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q4, d7\n"
+      "vmovl.u8 q3, d6\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q5, d8\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q4, d7\n"
+      "vmovl.s16 q3, d6\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q11\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q10\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q0, q0, q3\n"
+      "vadd.f32 q1, q1, q4\n"
+      "vadd.f32 q2, q2, q5\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "subs %[rows], %[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27", "d28", "d29",
+        "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              13>::Transform(const uint8_t* input,
+                                             const BiasAdd<uint8_t>& params,
+                                             int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "13>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr r0, %[input_range_min]\n"
+      "vdup.32 q8, r0\n"
+      "ldr r0, %[input_range_scale]\n"
+      "vdup.32 q9, r0\n"
+      "ldr r0, %[bias_range_min]\n"
+      "vdup.32 q10, r0\n"
+      "ldr r0, %[bias_range_scale]\n"
+      "vdup.32 q11, r0\n"
+      "ldr r0, %[output_range_min]\n"
+      "vdup.32 q12, r0\n"
+      "ldr r0, %[one_over_output_range_scale]\n"
+      "vdup.32 q13, r0\n"
+      "ldr r0, %[output_range_offset]\n"
+      "vdup.32 q14, r0\n"
+      "1:"
+      "mov r0, %[count]\n"
+      "mov r1, %[bias]\n"
+      "subs r0, r0, #13\n"
+      "beq 3f\n"
+      "2:"
+      "subs r0, r0, #16\n"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "vld1.32 {d8, d9}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q5, d9\n"
+      "vmovl.u8 q4, d8\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q7, d11\n"
+      "vmovl.s16 q6, d10\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q5, d9\n"
+      "vmovl.s16 q4, d8\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vcvt.f32.s32 q6, q6\n"
+      "vcvt.f32.s32 q7, q7\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q9\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vmul.f32 q6, q6, q11\n"
+      "vmul.f32 q7, q7, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q8\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q6, q6, q10\n"
+      "vadd.f32 q7, q7, q10\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q6\n"
+      "vadd.f32 q3, q3, q7\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vsub.f32 q3, q3, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vmul.f32 q3, q3, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vadd.f32 q3, q3, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.32 {d1[0]}, [%[input]]!\n"
+      "vld1.8 {d1[4]}, [%[input]]!\n"
+      "vld1.32 {d8}, [r1]!\n"
+      "vld1.32 {d9[0]}, [r1]!\n"
+      "vld1.8 {d9[4]}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q5, d9\n"
+      "vmovl.u8 q4, d8\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q7, d11\n"
+      "vmovl.s16 q6, d10\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q5, d9\n"
+      "vmovl.s16 q4, d8\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vcvt.f32.s32 q6, q6\n"
+      "vcvt.f32.s32 q7, q7\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q9\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vmul.f32 q6, q6, q11\n"
+      "vmul.f32 q7, q7, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q8\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q6, q6, q10\n"
+      "vadd.f32 q7, q7, q10\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q6\n"
+      "vadd.f32 q3, q3, q7\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vsub.f32 q3, q3, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vmul.f32 q3, q3, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vadd.f32 q3, q3, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5}, [%[output]]!\n"
+      "vst1.32 {d6[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "subs %[rows], %[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27", "d28", "d29",
+        "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              14>::Transform(const uint8_t* input,
+                                             const BiasAdd<uint8_t>& params,
+                                             int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "14>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr r0, %[input_range_min]\n"
+      "vdup.32 q8, r0\n"
+      "ldr r0, %[input_range_scale]\n"
+      "vdup.32 q9, r0\n"
+      "ldr r0, %[bias_range_min]\n"
+      "vdup.32 q10, r0\n"
+      "ldr r0, %[bias_range_scale]\n"
+      "vdup.32 q11, r0\n"
+      "ldr r0, %[output_range_min]\n"
+      "vdup.32 q12, r0\n"
+      "ldr r0, %[one_over_output_range_scale]\n"
+      "vdup.32 q13, r0\n"
+      "ldr r0, %[output_range_offset]\n"
+      "vdup.32 q14, r0\n"
+      "1:"
+      "mov r0, %[count]\n"
+      "mov r1, %[bias]\n"
+      "subs r0, r0, #14\n"
+      "beq 3f\n"
+      "2:"
+      "subs r0, r0, #16\n"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "vld1.32 {d8, d9}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q5, d9\n"
+      "vmovl.u8 q4, d8\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q7, d11\n"
+      "vmovl.s16 q6, d10\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q5, d9\n"
+      "vmovl.s16 q4, d8\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vcvt.f32.s32 q6, q6\n"
+      "vcvt.f32.s32 q7, q7\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q9\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vmul.f32 q6, q6, q11\n"
+      "vmul.f32 q7, q7, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q8\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q6, q6, q10\n"
+      "vadd.f32 q7, q7, q10\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q6\n"
+      "vadd.f32 q3, q3, q7\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vsub.f32 q3, q3, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vmul.f32 q3, q3, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vadd.f32 q3, q3, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.32 {d1[0]}, [%[input]]!\n"
+      "vld1.16 {d1[2]}, [%[input]]!\n"
+      "vld1.32 {d8}, [r1]!\n"
+      "vld1.32 {d9[0]}, [r1]!\n"
+      "vld1.16 {d9[2]}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q5, d9\n"
+      "vmovl.u8 q4, d8\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q7, d11\n"
+      "vmovl.s16 q6, d10\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q5, d9\n"
+      "vmovl.s16 q4, d8\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vcvt.f32.s32 q6, q6\n"
+      "vcvt.f32.s32 q7, q7\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q9\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vmul.f32 q6, q6, q11\n"
+      "vmul.f32 q7, q7, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q8\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q6, q6, q10\n"
+      "vadd.f32 q7, q7, q10\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q6\n"
+      "vadd.f32 q3, q3, q7\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vsub.f32 q3, q3, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vmul.f32 q3, q3, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vadd.f32 q3, q3, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "subs %[rows], %[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27", "d28", "d29",
+        "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              15>::Transform(const uint8_t* input,
+                                             const BiasAdd<uint8_t>& params,
+                                             int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "15>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr r0, %[input_range_min]\n"
+      "vdup.32 q8, r0\n"
+      "ldr r0, %[input_range_scale]\n"
+      "vdup.32 q9, r0\n"
+      "ldr r0, %[bias_range_min]\n"
+      "vdup.32 q10, r0\n"
+      "ldr r0, %[bias_range_scale]\n"
+      "vdup.32 q11, r0\n"
+      "ldr r0, %[output_range_min]\n"
+      "vdup.32 q12, r0\n"
+      "ldr r0, %[one_over_output_range_scale]\n"
+      "vdup.32 q13, r0\n"
+      "ldr r0, %[output_range_offset]\n"
+      "vdup.32 q14, r0\n"
+      "1:"
+      "mov r0, %[count]\n"
+      "mov r1, %[bias]\n"
+      "subs r0, r0, #15\n"
+      "beq 3f\n"
+      "2:"
+      "subs r0, r0, #16\n"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0, d1}, [%[input]]!\n"
+      "vld1.32 {d8, d9}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q5, d9\n"
+      "vmovl.u8 q4, d8\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q7, d11\n"
+      "vmovl.s16 q6, d10\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q5, d9\n"
+      "vmovl.s16 q4, d8\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vcvt.f32.s32 q6, q6\n"
+      "vcvt.f32.s32 q7, q7\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q9\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vmul.f32 q6, q6, q11\n"
+      "vmul.f32 q7, q7, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q8\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q6, q6, q10\n"
+      "vadd.f32 q7, q7, q10\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q6\n"
+      "vadd.f32 q3, q3, q7\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vsub.f32 q3, q3, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vmul.f32 q3, q3, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vadd.f32 q3, q3, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6, d7}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "vld1.32 {d0}, [%[input]]!\n"
+      "vld1.32 {d1[0]}, [%[input]]!\n"
+      "vld1.16 {d1[2]}, [%[input]]!\n"
+      "vld1.8 {d1[6]}, [%[input]]!\n"
+      "vld1.32 {d8}, [r1]!\n"
+      "vld1.32 {d9[0]}, [r1]!\n"
+      "vld1.16 {d9[2]}, [r1]!\n"
+      "vld1.8 {d9[6]}, [r1]!\n"
+      "pld [%[input], #32]\n"
+      "vmovl.u8 q1, d1\n"
+      "vmovl.u8 q0, d0\n"
+      "vmovl.u8 q5, d9\n"
+      "vmovl.u8 q4, d8\n"
+      "vmovl.s16 q3, d3\n"
+      "vmovl.s16 q2, d2\n"
+      "vmovl.s16 q7, d11\n"
+      "vmovl.s16 q6, d10\n"
+      "vmovl.s16 q1, d1\n"
+      "vmovl.s16 q0, d0\n"
+      "vmovl.s16 q5, d9\n"
+      "vmovl.s16 q4, d8\n"
+      "vcvt.f32.s32 q0, q0\n"
+      "vcvt.f32.s32 q1, q1\n"
+      "vcvt.f32.s32 q2, q2\n"
+      "vcvt.f32.s32 q3, q3\n"
+      "vcvt.f32.s32 q4, q4\n"
+      "vcvt.f32.s32 q5, q5\n"
+      "vcvt.f32.s32 q6, q6\n"
+      "vcvt.f32.s32 q7, q7\n"
+      "vmul.f32 q0, q0, q9\n"
+      "vmul.f32 q1, q1, q9\n"
+      "vmul.f32 q2, q2, q9\n"
+      "vmul.f32 q3, q3, q9\n"
+      "vmul.f32 q4, q4, q11\n"
+      "vmul.f32 q5, q5, q11\n"
+      "vmul.f32 q6, q6, q11\n"
+      "vmul.f32 q7, q7, q11\n"
+      "vadd.f32 q0, q0, q8\n"
+      "vadd.f32 q1, q1, q8\n"
+      "vadd.f32 q2, q2, q8\n"
+      "vadd.f32 q3, q3, q8\n"
+      "vadd.f32 q4, q4, q10\n"
+      "vadd.f32 q5, q5, q10\n"
+      "vadd.f32 q6, q6, q10\n"
+      "vadd.f32 q7, q7, q10\n"
+      "vadd.f32 q0, q0, q4\n"
+      "vadd.f32 q1, q1, q5\n"
+      "vadd.f32 q2, q2, q6\n"
+      "vadd.f32 q3, q3, q7\n"
+      "vsub.f32 q0, q0, q12\n"
+      "vsub.f32 q1, q1, q12\n"
+      "vsub.f32 q2, q2, q12\n"
+      "vsub.f32 q3, q3, q12\n"
+      "vmul.f32 q0, q0, q13\n"
+      "vmul.f32 q1, q1, q13\n"
+      "vmul.f32 q2, q2, q13\n"
+      "vmul.f32 q3, q3, q13\n"
+      "vadd.f32 q0, q0, q14\n"
+      "vadd.f32 q1, q1, q14\n"
+      "vadd.f32 q2, q2, q14\n"
+      "vadd.f32 q3, q3, q14\n"
+      "vcvt.s32.f32 q0, q0\n"
+      "vcvt.s32.f32 q1, q1\n"
+      "vcvt.s32.f32 q2, q2\n"
+      "vcvt.s32.f32 q3, q3\n"
+
+      "vst1.32 {d0, d1, d2, d3}, [%[output]]!\n"
+      "vst1.32 {d4, d5, d6}, [%[output]]!\n"
+      "vst1.32 {d7[0]}, [%[output]]!\n"
+      "pld [%[output]]\n"
+      "subs %[rows], %[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "r0", "r1", "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9",
+        "d10", "d11", "d12", "d13", "d14", "d15", "d16", "d17", "d18", "d19",
+        "d20", "d21", "d22", "d23", "d24", "d25", "d26", "d27", "d28", "d29",
+        "cc", "memory");
+}
+
+}  // namespace meta
+}  // namespace gemmlowp
+
+#else
+#warning "Meta gemm for arm32 requires: GEMMLOWP_NEON_32!"
+#endif
+
+#endif  // GEMMLOWP_META_TRANSFORM_KERNELS_ARM_32_H_

--- a/meta/transform_kernels_arm_64.h
+++ b/meta/transform_kernels_arm_64.h
@@ -1,0 +1,7965 @@
+// Copyright 2016 The Gemmlowp Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GEMMLOWP_META_TRANSFORM_KERNELS_ARM_64_H_
+#define GEMMLOWP_META_TRANSFORM_KERNELS_ARM_64_H_
+
+#ifdef GEMMLOWP_NEON_64
+
+#include <cassert>
+#include <cstdint>
+
+namespace gemmlowp {
+namespace meta {
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 0>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 0>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "dup v4.4s, %w[input_range_min]\n"
+      "dup v5.4s, %w[output_range_min]\n"
+      "dup v6.4s, %w[input_range_offset]\n"
+      "dup v7.4s, %w[input_range_scale]\n"
+      "dup v8.4s, %w[one_over_output_range_scale]\n"
+      "fsub v4.4s, v4.4s, v5.4s\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fsub v3.4s, v3.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fmul v3.4s, v3.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fmul v3.4s, v3.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 1>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 1>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "dup v4.4s, %w[input_range_min]\n"
+      "dup v5.4s, %w[output_range_min]\n"
+      "dup v6.4s, %w[input_range_offset]\n"
+      "dup v7.4s, %w[input_range_scale]\n"
+      "dup v8.4s, %w[one_over_output_range_scale]\n"
+      "fsub v4.4s, v4.4s, v5.4s\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #1\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fsub v3.4s, v3.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fmul v3.4s, v3.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fmul v3.4s, v3.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "ld1 {v0.s}[0], [%x[input]], #4\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+
+      "st1 {v0.b}[0], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 2>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 2>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "dup v4.4s, %w[input_range_min]\n"
+      "dup v5.4s, %w[output_range_min]\n"
+      "dup v6.4s, %w[input_range_offset]\n"
+      "dup v7.4s, %w[input_range_scale]\n"
+      "dup v8.4s, %w[one_over_output_range_scale]\n"
+      "fsub v4.4s, v4.4s, v5.4s\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #2\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fsub v3.4s, v3.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fmul v3.4s, v3.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fmul v3.4s, v3.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+
+      "st1 {v0.h}[0], [%x[output]], #2\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 3>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 3>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "dup v4.4s, %w[input_range_min]\n"
+      "dup v5.4s, %w[output_range_min]\n"
+      "dup v6.4s, %w[input_range_offset]\n"
+      "dup v7.4s, %w[input_range_scale]\n"
+      "dup v8.4s, %w[one_over_output_range_scale]\n"
+      "fsub v4.4s, v4.4s, v5.4s\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #3\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fsub v3.4s, v3.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fmul v3.4s, v3.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fmul v3.4s, v3.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.s}[2], [%x[input]], #4\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+
+      "st1 {v0.h}[0], [%x[output]], #2\n"
+      "st1 {v0.b}[2], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 4>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 4>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "dup v4.4s, %w[input_range_min]\n"
+      "dup v5.4s, %w[output_range_min]\n"
+      "dup v6.4s, %w[input_range_offset]\n"
+      "dup v7.4s, %w[input_range_scale]\n"
+      "dup v8.4s, %w[one_over_output_range_scale]\n"
+      "fsub v4.4s, v4.4s, v5.4s\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #4\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fsub v3.4s, v3.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fmul v3.4s, v3.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fmul v3.4s, v3.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+
+      "st1 {v0.s}[0], [%x[output]], #4\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 5>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 5>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "dup v4.4s, %w[input_range_min]\n"
+      "dup v5.4s, %w[output_range_min]\n"
+      "dup v6.4s, %w[input_range_offset]\n"
+      "dup v7.4s, %w[input_range_scale]\n"
+      "dup v8.4s, %w[one_over_output_range_scale]\n"
+      "fsub v4.4s, v4.4s, v5.4s\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #5\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fsub v3.4s, v3.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fmul v3.4s, v3.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fmul v3.4s, v3.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "ld1 {v1.s}[0], [%x[input]], #4\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+
+      "st1 {v0.s}[0], [%x[output]], #4\n"
+      "st1 {v0.b}[4], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 6>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 6>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "dup v4.4s, %w[input_range_min]\n"
+      "dup v5.4s, %w[output_range_min]\n"
+      "dup v6.4s, %w[input_range_offset]\n"
+      "dup v7.4s, %w[input_range_scale]\n"
+      "dup v8.4s, %w[one_over_output_range_scale]\n"
+      "fsub v4.4s, v4.4s, v5.4s\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #6\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fsub v3.4s, v3.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fmul v3.4s, v3.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fmul v3.4s, v3.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "ld1 {v1.2s}, [%x[input]], #8\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+
+      "st1 {v0.s}[0], [%x[output]], #4\n"
+      "st1 {v0.h}[2], [%x[output]], #2\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 7>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 7>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "dup v4.4s, %w[input_range_min]\n"
+      "dup v5.4s, %w[output_range_min]\n"
+      "dup v6.4s, %w[input_range_offset]\n"
+      "dup v7.4s, %w[input_range_scale]\n"
+      "dup v8.4s, %w[one_over_output_range_scale]\n"
+      "fsub v4.4s, v4.4s, v5.4s\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #7\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fsub v3.4s, v3.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fmul v3.4s, v3.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fmul v3.4s, v3.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "ld1 {v1.2s}, [%x[input]], #8\n"
+      "ld1 {v1.s}[2], [%x[input]], #4\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+
+      "st1 {v0.s}[0], [%x[output]], #4\n"
+      "st1 {v0.h}[2], [%x[output]], #2\n"
+      "st1 {v0.b}[6], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 8>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 8>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "dup v4.4s, %w[input_range_min]\n"
+      "dup v5.4s, %w[output_range_min]\n"
+      "dup v6.4s, %w[input_range_offset]\n"
+      "dup v7.4s, %w[input_range_scale]\n"
+      "dup v8.4s, %w[one_over_output_range_scale]\n"
+      "fsub v4.4s, v4.4s, v5.4s\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #8\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fsub v3.4s, v3.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fmul v3.4s, v3.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fmul v3.4s, v3.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s}, [%x[input]], #32\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 9>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 9>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "dup v4.4s, %w[input_range_min]\n"
+      "dup v5.4s, %w[output_range_min]\n"
+      "dup v6.4s, %w[input_range_offset]\n"
+      "dup v7.4s, %w[input_range_scale]\n"
+      "dup v8.4s, %w[one_over_output_range_scale]\n"
+      "fsub v4.4s, v4.4s, v5.4s\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #9\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fsub v3.4s, v3.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fmul v3.4s, v3.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fmul v3.4s, v3.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s}, [%x[input]], #32\n"
+      "ld1 {v2.s}[0], [%x[input]], #4\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.b}[8], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 10>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 10>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "dup v4.4s, %w[input_range_min]\n"
+      "dup v5.4s, %w[output_range_min]\n"
+      "dup v6.4s, %w[input_range_offset]\n"
+      "dup v7.4s, %w[input_range_scale]\n"
+      "dup v8.4s, %w[one_over_output_range_scale]\n"
+      "fsub v4.4s, v4.4s, v5.4s\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #10\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fsub v3.4s, v3.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fmul v3.4s, v3.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fmul v3.4s, v3.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s}, [%x[input]], #32\n"
+      "ld1 {v2.2s}, [%x[input]], #8\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.h}[4], [%x[output]], #2\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 11>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 11>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "dup v4.4s, %w[input_range_min]\n"
+      "dup v5.4s, %w[output_range_min]\n"
+      "dup v6.4s, %w[input_range_offset]\n"
+      "dup v7.4s, %w[input_range_scale]\n"
+      "dup v8.4s, %w[one_over_output_range_scale]\n"
+      "fsub v4.4s, v4.4s, v5.4s\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #11\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fsub v3.4s, v3.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fmul v3.4s, v3.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fmul v3.4s, v3.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s}, [%x[input]], #32\n"
+      "ld1 {v2.2s}, [%x[input]], #8\n"
+      "ld1 {v2.s}[2], [%x[input]], #4\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.h}[4], [%x[output]], #2\n"
+      "st1 {v0.b}[10], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 12>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 12>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "dup v4.4s, %w[input_range_min]\n"
+      "dup v5.4s, %w[output_range_min]\n"
+      "dup v6.4s, %w[input_range_offset]\n"
+      "dup v7.4s, %w[input_range_scale]\n"
+      "dup v8.4s, %w[one_over_output_range_scale]\n"
+      "fsub v4.4s, v4.4s, v5.4s\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #12\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fsub v3.4s, v3.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fmul v3.4s, v3.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fmul v3.4s, v3.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s}, [%x[input]], #48\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.s}[2], [%x[output]], #4\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 13>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 13>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "dup v4.4s, %w[input_range_min]\n"
+      "dup v5.4s, %w[output_range_min]\n"
+      "dup v6.4s, %w[input_range_offset]\n"
+      "dup v7.4s, %w[input_range_scale]\n"
+      "dup v8.4s, %w[one_over_output_range_scale]\n"
+      "fsub v4.4s, v4.4s, v5.4s\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #13\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fsub v3.4s, v3.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fmul v3.4s, v3.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fmul v3.4s, v3.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s}, [%x[input]], #48\n"
+      "ld1 {v3.s}[0], [%x[input]], #4\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fsub v3.4s, v3.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fmul v3.4s, v3.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fmul v3.4s, v3.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.s}[2], [%x[output]], #4\n"
+      "st1 {v0.b}[12], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 14>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 14>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "dup v4.4s, %w[input_range_min]\n"
+      "dup v5.4s, %w[output_range_min]\n"
+      "dup v6.4s, %w[input_range_offset]\n"
+      "dup v7.4s, %w[input_range_scale]\n"
+      "dup v8.4s, %w[one_over_output_range_scale]\n"
+      "fsub v4.4s, v4.4s, v5.4s\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #14\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fsub v3.4s, v3.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fmul v3.4s, v3.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fmul v3.4s, v3.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s}, [%x[input]], #48\n"
+      "ld1 {v3.2s}, [%x[input]], #8\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fsub v3.4s, v3.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fmul v3.4s, v3.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fmul v3.4s, v3.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.s}[2], [%x[output]], #4\n"
+      "st1 {v0.h}[6], [%x[output]], #2\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 15>::Transform(
+    const int32_t* input, const Requantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Requantize<int32_t, uint8_t, Requantize, 16, 15>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Requantize::Prepare
+      "dup v4.4s, %w[input_range_min]\n"
+      "dup v5.4s, %w[output_range_min]\n"
+      "dup v6.4s, %w[input_range_offset]\n"
+      "dup v7.4s, %w[input_range_scale]\n"
+      "dup v8.4s, %w[one_over_output_range_scale]\n"
+      "fsub v4.4s, v4.4s, v5.4s\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #15\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fsub v3.4s, v3.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fmul v3.4s, v3.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fmul v3.4s, v3.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Requantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s}, [%x[input]], #48\n"
+      "ld1 {v3.2s}, [%x[input]], #8\n"
+      "ld1 {v3.s}[2], [%x[input]], #4\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v6.4s\n"
+      "fsub v1.4s, v1.4s, v6.4s\n"
+      "fsub v2.4s, v2.4s, v6.4s\n"
+      "fsub v3.4s, v3.4s, v6.4s\n"
+      "fmul v0.4s, v0.4s, v7.4s\n"
+      "fmul v1.4s, v1.4s, v7.4s\n"
+      "fmul v2.4s, v2.4s, v7.4s\n"
+      "fmul v3.4s, v3.4s, v7.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v8.4s\n"
+      "fmul v1.4s, v1.4s, v8.4s\n"
+      "fmul v2.4s, v2.4s, v8.4s\n"
+      "fmul v3.4s, v3.4s, v8.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.s}[2], [%x[output]], #4\n"
+      "st1 {v0.h}[6], [%x[output]], #2\n"
+      "st1 {v0.b}[14], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [input_range_min] "r"(params.input_range_min),
+        [output_range_min] "r"(params.output_range_min),
+        [input_range_offset] "r"(params.input_range_offset),
+        [one_over_output_range_scale] "r"(params.one_over_output_range_scale),
+        [input_range_scale] "r"(params.input_range_scale)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 0>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 0>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fsub v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fadd v3.4s, v3.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 1>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 1>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #1\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fsub v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fadd v3.4s, v3.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "ld1 {v0.s}[0], [%x[input]], #4\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+
+      "st1 {v0.b}[0], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 2>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 2>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #2\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fsub v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fadd v3.4s, v3.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+
+      "st1 {v0.h}[0], [%x[output]], #2\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 3>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 3>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #3\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fsub v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fadd v3.4s, v3.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.s}[2], [%x[input]], #4\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+
+      "st1 {v0.h}[0], [%x[output]], #2\n"
+      "st1 {v0.b}[2], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 4>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 4>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #4\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fsub v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fadd v3.4s, v3.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+
+      "st1 {v0.s}[0], [%x[output]], #4\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 5>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 5>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #5\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fsub v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fadd v3.4s, v3.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "ld1 {v1.s}[0], [%x[input]], #4\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+
+      "st1 {v0.s}[0], [%x[output]], #4\n"
+      "st1 {v0.b}[4], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 6>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 6>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #6\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fsub v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fadd v3.4s, v3.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "ld1 {v1.2s}, [%x[input]], #8\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+
+      "st1 {v0.s}[0], [%x[output]], #4\n"
+      "st1 {v0.h}[2], [%x[output]], #2\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 7>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 7>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #7\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fsub v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fadd v3.4s, v3.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "ld1 {v1.2s}, [%x[input]], #8\n"
+      "ld1 {v1.s}[2], [%x[input]], #4\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+
+      "st1 {v0.s}[0], [%x[output]], #4\n"
+      "st1 {v0.h}[2], [%x[output]], #2\n"
+      "st1 {v0.b}[6], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 8>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 8>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #8\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fsub v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fadd v3.4s, v3.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s}, [%x[input]], #32\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 9>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 9>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #9\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fsub v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fadd v3.4s, v3.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s}, [%x[input]], #32\n"
+      "ld1 {v2.s}[0], [%x[input]], #4\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.b}[8], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 10>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 10>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #10\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fsub v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fadd v3.4s, v3.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s}, [%x[input]], #32\n"
+      "ld1 {v2.2s}, [%x[input]], #8\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.h}[4], [%x[output]], #2\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 11>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 11>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #11\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fsub v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fadd v3.4s, v3.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s}, [%x[input]], #32\n"
+      "ld1 {v2.2s}, [%x[input]], #8\n"
+      "ld1 {v2.s}[2], [%x[input]], #4\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.h}[4], [%x[output]], #2\n"
+      "st1 {v0.b}[10], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 12>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 12>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #12\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fsub v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fadd v3.4s, v3.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s}, [%x[input]], #48\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.s}[2], [%x[output]], #4\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 13>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 13>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #13\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fsub v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fadd v3.4s, v3.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s}, [%x[input]], #48\n"
+      "ld1 {v3.s}[0], [%x[input]], #4\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fsub v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fadd v3.4s, v3.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.s}[2], [%x[output]], #4\n"
+      "st1 {v0.b}[12], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 14>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 14>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #14\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fsub v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fadd v3.4s, v3.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s}, [%x[input]], #48\n"
+      "ld1 {v3.2s}, [%x[input]], #8\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fsub v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fadd v3.4s, v3.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.s}[2], [%x[output]], #4\n"
+      "st1 {v0.h}[6], [%x[output]], #2\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<float, uint8_t, Quantize, 16, 15>::Transform(
+    const float* input, const Quantize& params, uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Quantize<float, uint8_t, Quantize, 16, 15>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Quantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #15\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[input]], #64\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fsub v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fadd v3.4s, v3.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Quantize::Transform
+      "ld1 {v0.4s, v1.4s, v2.4s}, [%x[input]], #48\n"
+      "ld1 {v3.2s}, [%x[input]], #8\n"
+      "ld1 {v3.s}[2], [%x[input]], #4\n"
+      "prfm pldl1keep, [%x[input], #64]\n"
+      "fsub v0.4s, v0.4s, v4.4s\n"
+      "fsub v1.4s, v1.4s, v4.4s\n"
+      "fsub v2.4s, v2.4s, v4.4s\n"
+      "fsub v3.4s, v3.4s, v4.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v5.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fadd v3.4s, v3.4s, v5.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+      "sqxtn v0.4h, v0.4s\n"
+      "sqxtn2 v0.8h, v1.4s\n"
+      "sqxtn v2.4h, v2.4s\n"
+      "sqxtn2 v2.8h, v3.4s\n"
+      "sqxtun v0.8b, v0.8h\n"
+      "sqxtun2 v0.16b, v2.8h\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.s}[2], [%x[output]], #4\n"
+      "st1 {v0.h}[6], [%x[output]], #2\n"
+      "st1 {v0.b}[14], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 0>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 0>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Dequantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fsub v3.4s, v3.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 1>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 1>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #1\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Dequantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fsub v3.4s, v3.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "ld1 {v0.b}[0], [%x[input]], #1\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+
+      "st1 {v0.s}[0], [%x[output]], #4\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 2>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 2>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #2\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Dequantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fsub v3.4s, v3.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "ld1 {v0.h}[0], [%x[input]], #2\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 3>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 3>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #3\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Dequantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fsub v3.4s, v3.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "ld1 {v0.h}[0], [%x[input]], #2\n"
+      "ld1 {v0.b}[2], [%x[input]], #1\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.s}[2], [%x[output]], #4\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 4>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 4>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #4\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Dequantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fsub v3.4s, v3.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "ld1 {v0.s}[0], [%x[input]], #4\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 5>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 5>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #5\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Dequantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fsub v3.4s, v3.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "ld1 {v0.s}[0], [%x[input]], #4\n"
+      "ld1 {v0.b}[4], [%x[input]], #1\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "st1 {v1.s}[0], [%x[output]], #4\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 6>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 6>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #6\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Dequantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fsub v3.4s, v3.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "ld1 {v0.s}[0], [%x[input]], #4\n"
+      "ld1 {v0.h}[2], [%x[input]], #2\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "st1 {v1.2s}, [%x[output]], #8\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 7>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 7>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #7\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Dequantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fsub v3.4s, v3.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "ld1 {v0.s}[0], [%x[input]], #4\n"
+      "ld1 {v0.h}[2], [%x[input]], #2\n"
+      "ld1 {v0.b}[6], [%x[input]], #1\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "st1 {v1.2s}, [%x[output]], #8\n"
+      "st1 {v1.s}[2], [%x[output]], #4\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 8>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 8>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #8\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Dequantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fsub v3.4s, v3.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s}, [%x[output]], #32\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 9>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 9>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #9\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Dequantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fsub v3.4s, v3.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.b}[8], [%x[input]], #1\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s}, [%x[output]], #32\n"
+      "st1 {v2.s}[0], [%x[output]], #4\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 10>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 10>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #10\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Dequantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fsub v3.4s, v3.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.h}[4], [%x[input]], #2\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s}, [%x[output]], #32\n"
+      "st1 {v2.2s}, [%x[output]], #8\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 11>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 11>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #11\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Dequantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fsub v3.4s, v3.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.h}[4], [%x[input]], #2\n"
+      "ld1 {v0.b}[10], [%x[input]], #1\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s}, [%x[output]], #32\n"
+      "st1 {v2.2s}, [%x[output]], #8\n"
+      "st1 {v2.s}[2], [%x[output]], #4\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 12>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 12>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #12\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Dequantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fsub v3.4s, v3.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.s}[2], [%x[input]], #4\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s}, [%x[output]], #48\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 13>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 13>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #13\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Dequantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fsub v3.4s, v3.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.s}[2], [%x[input]], #4\n"
+      "ld1 {v0.b}[12], [%x[input]], #1\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fsub v3.4s, v3.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s}, [%x[output]], #48\n"
+      "st1 {v3.s}[0], [%x[output]], #4\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 14>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 14>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #14\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Dequantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fsub v3.4s, v3.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.s}[2], [%x[input]], #4\n"
+      "ld1 {v0.h}[6], [%x[input]], #2\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fsub v3.4s, v3.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s}, [%x[output]], #48\n"
+      "st1 {v3.2s}, [%x[output]], #8\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 15>::Transform(
+    const uint8_t* input, const Dequantize& params, float* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") Dequantize<uint8_t, float, Dequantize, 16, 15>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // Dequantize::Prepare
+      "dup v4.4s, %w[range_min]\n"
+      "dup v5.4s, %w[range_offset]\n"
+      "dup v6.4s, %w[range_scale]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #15\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // Dequantize::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fsub v3.4s, v3.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // Dequantize::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.s}[2], [%x[input]], #4\n"
+      "ld1 {v0.h}[6], [%x[input]], #2\n"
+      "ld1 {v0.b}[14], [%x[input]], #1\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v5.4s\n"
+      "fsub v1.4s, v1.4s, v5.4s\n"
+      "fsub v2.4s, v2.4s, v5.4s\n"
+      "fsub v3.4s, v3.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v6.4s\n"
+      "fmul v1.4s, v1.4s, v6.4s\n"
+      "fmul v2.4s, v2.4s, v6.4s\n"
+      "fmul v3.4s, v3.4s, v6.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v4.4s\n"
+      "fadd v3.4s, v3.4s, v4.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s}, [%x[output]], #48\n"
+      "st1 {v3.2s}, [%x[output]], #8\n"
+      "st1 {v3.s}[2], [%x[output]], #4\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [range_offset] "r"(params.range_offset),
+        [range_scale] "r"(params.range_scale), [range_min] "r"(params.range_min)
+      : "v0", "v1", "v2", "v3", "v4", "v5", "v6", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              0>::Transform(const uint8_t* input,
+                                            const MinMax<uint8_t>& params,
+                                            uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "0>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "dup v4.16b, %w[min]\n"
+      "dup v5.16b, %w[max]\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // MinMax::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "v0", "v4", "v5", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              1>::Transform(const uint8_t* input,
+                                            const MinMax<uint8_t>& params,
+                                            uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "1>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "dup v4.16b, %w[min]\n"
+      "dup v5.16b, %w[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #1\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // MinMax::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "ld1 {v0.b}[0], [%x[input]], #1\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.b}[0], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "v0", "v4", "v5", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              2>::Transform(const uint8_t* input,
+                                            const MinMax<uint8_t>& params,
+                                            uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "2>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "dup v4.16b, %w[min]\n"
+      "dup v5.16b, %w[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #2\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // MinMax::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "ld1 {v0.h}[0], [%x[input]], #2\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.h}[0], [%x[output]], #2\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "v0", "v4", "v5", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              3>::Transform(const uint8_t* input,
+                                            const MinMax<uint8_t>& params,
+                                            uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "3>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "dup v4.16b, %w[min]\n"
+      "dup v5.16b, %w[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #3\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // MinMax::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "ld1 {v0.h}[0], [%x[input]], #2\n"
+      "ld1 {v0.b}[2], [%x[input]], #1\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.h}[0], [%x[output]], #2\n"
+      "st1 {v0.b}[2], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "v0", "v4", "v5", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              4>::Transform(const uint8_t* input,
+                                            const MinMax<uint8_t>& params,
+                                            uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "4>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "dup v4.16b, %w[min]\n"
+      "dup v5.16b, %w[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #4\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // MinMax::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "ld1 {v0.s}[0], [%x[input]], #4\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.s}[0], [%x[output]], #4\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "v0", "v4", "v5", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              5>::Transform(const uint8_t* input,
+                                            const MinMax<uint8_t>& params,
+                                            uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "5>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "dup v4.16b, %w[min]\n"
+      "dup v5.16b, %w[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #5\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // MinMax::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "ld1 {v0.s}[0], [%x[input]], #4\n"
+      "ld1 {v0.b}[4], [%x[input]], #1\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.s}[0], [%x[output]], #4\n"
+      "st1 {v0.b}[4], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "v0", "v4", "v5", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              6>::Transform(const uint8_t* input,
+                                            const MinMax<uint8_t>& params,
+                                            uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "6>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "dup v4.16b, %w[min]\n"
+      "dup v5.16b, %w[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #6\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // MinMax::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "ld1 {v0.s}[0], [%x[input]], #4\n"
+      "ld1 {v0.h}[2], [%x[input]], #2\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.s}[0], [%x[output]], #4\n"
+      "st1 {v0.h}[2], [%x[output]], #2\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "v0", "v4", "v5", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              7>::Transform(const uint8_t* input,
+                                            const MinMax<uint8_t>& params,
+                                            uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "7>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "dup v4.16b, %w[min]\n"
+      "dup v5.16b, %w[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #7\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // MinMax::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "ld1 {v0.s}[0], [%x[input]], #4\n"
+      "ld1 {v0.h}[2], [%x[input]], #2\n"
+      "ld1 {v0.b}[6], [%x[input]], #1\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.s}[0], [%x[output]], #4\n"
+      "st1 {v0.h}[2], [%x[output]], #2\n"
+      "st1 {v0.b}[6], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "v0", "v4", "v5", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              8>::Transform(const uint8_t* input,
+                                            const MinMax<uint8_t>& params,
+                                            uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "8>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "dup v4.16b, %w[min]\n"
+      "dup v5.16b, %w[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #8\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // MinMax::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "v0", "v4", "v5", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              9>::Transform(const uint8_t* input,
+                                            const MinMax<uint8_t>& params,
+                                            uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "9>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "dup v4.16b, %w[min]\n"
+      "dup v5.16b, %w[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #9\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // MinMax::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.b}[8], [%x[input]], #1\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.b}[8], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "v0", "v4", "v5", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              10>::Transform(const uint8_t* input,
+                                             const MinMax<uint8_t>& params,
+                                             uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "10>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "dup v4.16b, %w[min]\n"
+      "dup v5.16b, %w[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #10\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // MinMax::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.h}[4], [%x[input]], #2\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.h}[4], [%x[output]], #2\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "v0", "v4", "v5", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              11>::Transform(const uint8_t* input,
+                                             const MinMax<uint8_t>& params,
+                                             uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "11>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "dup v4.16b, %w[min]\n"
+      "dup v5.16b, %w[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #11\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // MinMax::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.h}[4], [%x[input]], #2\n"
+      "ld1 {v0.b}[10], [%x[input]], #1\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.h}[4], [%x[output]], #2\n"
+      "st1 {v0.b}[10], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "v0", "v4", "v5", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              12>::Transform(const uint8_t* input,
+                                             const MinMax<uint8_t>& params,
+                                             uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "12>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "dup v4.16b, %w[min]\n"
+      "dup v5.16b, %w[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #12\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // MinMax::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.s}[2], [%x[input]], #4\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.s}[2], [%x[output]], #4\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "v0", "v4", "v5", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              13>::Transform(const uint8_t* input,
+                                             const MinMax<uint8_t>& params,
+                                             uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "13>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "dup v4.16b, %w[min]\n"
+      "dup v5.16b, %w[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #13\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // MinMax::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.s}[2], [%x[input]], #4\n"
+      "ld1 {v0.b}[12], [%x[input]], #1\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.s}[2], [%x[output]], #4\n"
+      "st1 {v0.b}[12], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "v0", "v4", "v5", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              14>::Transform(const uint8_t* input,
+                                             const MinMax<uint8_t>& params,
+                                             uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "14>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "dup v4.16b, %w[min]\n"
+      "dup v5.16b, %w[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #14\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // MinMax::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.s}[2], [%x[input]], #4\n"
+      "ld1 {v0.h}[6], [%x[input]], #2\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.s}[2], [%x[output]], #4\n"
+      "st1 {v0.h}[6], [%x[output]], #2\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "v0", "v4", "v5", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
+                              15>::Transform(const uint8_t* input,
+                                             const MinMax<uint8_t>& params,
+                                             uint8_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+               "15>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_count_copy = params.count;
+  asm volatile(
+
+      // MinMax::Prepare
+      "dup v4.16b, %w[min]\n"
+      "dup v5.16b, %w[max]\n"
+
+      // Reduce count by leftovers.
+      "subs %x[count], %x[count], #15\n"
+      "beq 2f\n"
+
+      "1:"
+      "subs %x[count], %x[count], #16\n"
+
+      // MinMax::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+
+      "bne 1b\n"
+      "2:"
+
+      // Handle leftovers.
+
+      // MinMax::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.s}[2], [%x[input]], #4\n"
+      "ld1 {v0.h}[6], [%x[input]], #2\n"
+      "ld1 {v0.b}[14], [%x[input]], #1\n"
+      "prfm pldl1keep, [%x[input], #16]\n"
+      "umax v0.16b, v0.16b, v4.16b\n"
+      "umin v0.16b, v0.16b, v5.16b\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.s}[2], [%x[output]], #4\n"
+      "st1 {v0.h}[6], [%x[output]], #2\n"
+      "st1 {v0.b}[14], [%x[output]], #1\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      : [count] "+r"(params_count_copy), [input] "+r"(input),
+        [output] "+r"(output)
+      : [max] "r"(params.max), [min] "r"(params.min)
+      : "v0", "v4", "v5", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              0>::Transform(const uint8_t* input,
+                                            const BiasAdd<uint8_t>& params,
+                                            int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "0>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr x0, %x[input_range_min]\n"
+      "dup v8.4s, w0\n"
+      "ldr x0, %x[input_range_scale]\n"
+      "dup v9.4s, w0\n"
+      "ldr x0, %x[bias_range_min]\n"
+      "dup v10.4s, w0\n"
+      "ldr x0, %x[bias_range_scale]\n"
+      "dup v11.4s, w0\n"
+      "ldr x0, %x[output_range_min]\n"
+      "dup v12.4s, w0\n"
+      "ldr x0, %x[one_over_output_range_scale]\n"
+      "dup v13.4s, w0\n"
+      "ldr x0, %x[output_range_offset]\n"
+      "dup v14.4s, w0\n"
+      "1:"
+      "mov x0, %x[count]\n"
+      "mov x1, %x[bias]\n"
+      "2:"
+      "subs x0, x0, #16\n"
+
+      // BiasAdd::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "ld1 {v4.4s}, [x1], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v5.8h, v4.16b\n"
+      "uxtl v4.8h, v4.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v7.4s, v5.8h\n"
+      "sxtl v6.4s, v5.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v5.4s, v4.8h\n"
+      "sxtl v4.4s, v4.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "scvtf v6.4s, v6.4s\n"
+      "scvtf v7.4s, v7.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v9.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fmul v6.4s, v6.4s, v11.4s\n"
+      "fmul v7.4s, v7.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v8.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v6.4s, v6.4s, v10.4s\n"
+      "fadd v7.4s, v7.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v6.4s\n"
+      "fadd v3.4s, v3.4s, v7.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fsub v3.4s, v3.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fmul v3.4s, v3.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fadd v3.4s, v3.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "bne 2b\n"
+      "subs %x[rows], %x[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "x0", "x1", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9",
+        "v10", "v11", "v12", "v13", "v14", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              1>::Transform(const uint8_t* input,
+                                            const BiasAdd<uint8_t>& params,
+                                            int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "1>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr x0, %x[input_range_min]\n"
+      "dup v8.4s, w0\n"
+      "ldr x0, %x[input_range_scale]\n"
+      "dup v9.4s, w0\n"
+      "ldr x0, %x[bias_range_min]\n"
+      "dup v10.4s, w0\n"
+      "ldr x0, %x[bias_range_scale]\n"
+      "dup v11.4s, w0\n"
+      "ldr x0, %x[output_range_min]\n"
+      "dup v12.4s, w0\n"
+      "ldr x0, %x[one_over_output_range_scale]\n"
+      "dup v13.4s, w0\n"
+      "ldr x0, %x[output_range_offset]\n"
+      "dup v14.4s, w0\n"
+      "1:"
+      "mov x0, %x[count]\n"
+      "mov x1, %x[bias]\n"
+      "subs x0, x0, #1\n"
+      "beq 3f\n"
+      "2:"
+      "subs x0, x0, #16\n"
+
+      // BiasAdd::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "ld1 {v4.4s}, [x1], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v5.8h, v4.16b\n"
+      "uxtl v4.8h, v4.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v7.4s, v5.8h\n"
+      "sxtl v6.4s, v5.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v5.4s, v4.8h\n"
+      "sxtl v4.4s, v4.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "scvtf v6.4s, v6.4s\n"
+      "scvtf v7.4s, v7.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v9.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fmul v6.4s, v6.4s, v11.4s\n"
+      "fmul v7.4s, v7.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v8.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v6.4s, v6.4s, v10.4s\n"
+      "fadd v7.4s, v7.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v6.4s\n"
+      "fadd v3.4s, v3.4s, v7.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fsub v3.4s, v3.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fmul v3.4s, v3.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fadd v3.4s, v3.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "ld1 {v0.b}[0], [%x[input]], #1\n"
+      "ld1 {v1.b}[0], [x1], #1\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl v1.8h, v1.8b\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl v1.4s, v1.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v1.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+
+      "st1 {v0.s}[0], [%x[output]], #4\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "subs %x[rows], %x[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "x0", "x1", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9",
+        "v10", "v11", "v12", "v13", "v14", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              2>::Transform(const uint8_t* input,
+                                            const BiasAdd<uint8_t>& params,
+                                            int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "2>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr x0, %x[input_range_min]\n"
+      "dup v8.4s, w0\n"
+      "ldr x0, %x[input_range_scale]\n"
+      "dup v9.4s, w0\n"
+      "ldr x0, %x[bias_range_min]\n"
+      "dup v10.4s, w0\n"
+      "ldr x0, %x[bias_range_scale]\n"
+      "dup v11.4s, w0\n"
+      "ldr x0, %x[output_range_min]\n"
+      "dup v12.4s, w0\n"
+      "ldr x0, %x[one_over_output_range_scale]\n"
+      "dup v13.4s, w0\n"
+      "ldr x0, %x[output_range_offset]\n"
+      "dup v14.4s, w0\n"
+      "1:"
+      "mov x0, %x[count]\n"
+      "mov x1, %x[bias]\n"
+      "subs x0, x0, #2\n"
+      "beq 3f\n"
+      "2:"
+      "subs x0, x0, #16\n"
+
+      // BiasAdd::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "ld1 {v4.4s}, [x1], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v5.8h, v4.16b\n"
+      "uxtl v4.8h, v4.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v7.4s, v5.8h\n"
+      "sxtl v6.4s, v5.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v5.4s, v4.8h\n"
+      "sxtl v4.4s, v4.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "scvtf v6.4s, v6.4s\n"
+      "scvtf v7.4s, v7.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v9.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fmul v6.4s, v6.4s, v11.4s\n"
+      "fmul v7.4s, v7.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v8.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v6.4s, v6.4s, v10.4s\n"
+      "fadd v7.4s, v7.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v6.4s\n"
+      "fadd v3.4s, v3.4s, v7.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fsub v3.4s, v3.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fmul v3.4s, v3.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fadd v3.4s, v3.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "ld1 {v0.h}[0], [%x[input]], #2\n"
+      "ld1 {v1.h}[0], [x1], #2\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl v1.8h, v1.8b\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl v1.4s, v1.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v1.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "subs %x[rows], %x[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "x0", "x1", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9",
+        "v10", "v11", "v12", "v13", "v14", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              3>::Transform(const uint8_t* input,
+                                            const BiasAdd<uint8_t>& params,
+                                            int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "3>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr x0, %x[input_range_min]\n"
+      "dup v8.4s, w0\n"
+      "ldr x0, %x[input_range_scale]\n"
+      "dup v9.4s, w0\n"
+      "ldr x0, %x[bias_range_min]\n"
+      "dup v10.4s, w0\n"
+      "ldr x0, %x[bias_range_scale]\n"
+      "dup v11.4s, w0\n"
+      "ldr x0, %x[output_range_min]\n"
+      "dup v12.4s, w0\n"
+      "ldr x0, %x[one_over_output_range_scale]\n"
+      "dup v13.4s, w0\n"
+      "ldr x0, %x[output_range_offset]\n"
+      "dup v14.4s, w0\n"
+      "1:"
+      "mov x0, %x[count]\n"
+      "mov x1, %x[bias]\n"
+      "subs x0, x0, #3\n"
+      "beq 3f\n"
+      "2:"
+      "subs x0, x0, #16\n"
+
+      // BiasAdd::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "ld1 {v4.4s}, [x1], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v5.8h, v4.16b\n"
+      "uxtl v4.8h, v4.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v7.4s, v5.8h\n"
+      "sxtl v6.4s, v5.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v5.4s, v4.8h\n"
+      "sxtl v4.4s, v4.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "scvtf v6.4s, v6.4s\n"
+      "scvtf v7.4s, v7.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v9.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fmul v6.4s, v6.4s, v11.4s\n"
+      "fmul v7.4s, v7.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v8.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v6.4s, v6.4s, v10.4s\n"
+      "fadd v7.4s, v7.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v6.4s\n"
+      "fadd v3.4s, v3.4s, v7.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fsub v3.4s, v3.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fmul v3.4s, v3.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fadd v3.4s, v3.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "ld1 {v0.h}[0], [%x[input]], #2\n"
+      "ld1 {v0.b}[2], [%x[input]], #1\n"
+      "ld1 {v1.h}[0], [x1], #2\n"
+      "ld1 {v1.b}[2], [x1], #1\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl v1.8h, v1.8b\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl v1.4s, v1.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v1.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+
+      "st1 {v0.2s}, [%x[output]], #8\n"
+      "st1 {v0.s}[2], [%x[output]], #4\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "subs %x[rows], %x[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "x0", "x1", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9",
+        "v10", "v11", "v12", "v13", "v14", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              4>::Transform(const uint8_t* input,
+                                            const BiasAdd<uint8_t>& params,
+                                            int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "4>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr x0, %x[input_range_min]\n"
+      "dup v8.4s, w0\n"
+      "ldr x0, %x[input_range_scale]\n"
+      "dup v9.4s, w0\n"
+      "ldr x0, %x[bias_range_min]\n"
+      "dup v10.4s, w0\n"
+      "ldr x0, %x[bias_range_scale]\n"
+      "dup v11.4s, w0\n"
+      "ldr x0, %x[output_range_min]\n"
+      "dup v12.4s, w0\n"
+      "ldr x0, %x[one_over_output_range_scale]\n"
+      "dup v13.4s, w0\n"
+      "ldr x0, %x[output_range_offset]\n"
+      "dup v14.4s, w0\n"
+      "1:"
+      "mov x0, %x[count]\n"
+      "mov x1, %x[bias]\n"
+      "subs x0, x0, #4\n"
+      "beq 3f\n"
+      "2:"
+      "subs x0, x0, #16\n"
+
+      // BiasAdd::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "ld1 {v4.4s}, [x1], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v5.8h, v4.16b\n"
+      "uxtl v4.8h, v4.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v7.4s, v5.8h\n"
+      "sxtl v6.4s, v5.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v5.4s, v4.8h\n"
+      "sxtl v4.4s, v4.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "scvtf v6.4s, v6.4s\n"
+      "scvtf v7.4s, v7.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v9.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fmul v6.4s, v6.4s, v11.4s\n"
+      "fmul v7.4s, v7.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v8.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v6.4s, v6.4s, v10.4s\n"
+      "fadd v7.4s, v7.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v6.4s\n"
+      "fadd v3.4s, v3.4s, v7.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fsub v3.4s, v3.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fmul v3.4s, v3.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fadd v3.4s, v3.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "ld1 {v0.s}[0], [%x[input]], #4\n"
+      "ld1 {v1.s}[0], [x1], #4\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl v1.8h, v1.8b\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl v1.4s, v1.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v1.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "subs %x[rows], %x[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "x0", "x1", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9",
+        "v10", "v11", "v12", "v13", "v14", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              5>::Transform(const uint8_t* input,
+                                            const BiasAdd<uint8_t>& params,
+                                            int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "5>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr x0, %x[input_range_min]\n"
+      "dup v8.4s, w0\n"
+      "ldr x0, %x[input_range_scale]\n"
+      "dup v9.4s, w0\n"
+      "ldr x0, %x[bias_range_min]\n"
+      "dup v10.4s, w0\n"
+      "ldr x0, %x[bias_range_scale]\n"
+      "dup v11.4s, w0\n"
+      "ldr x0, %x[output_range_min]\n"
+      "dup v12.4s, w0\n"
+      "ldr x0, %x[one_over_output_range_scale]\n"
+      "dup v13.4s, w0\n"
+      "ldr x0, %x[output_range_offset]\n"
+      "dup v14.4s, w0\n"
+      "1:"
+      "mov x0, %x[count]\n"
+      "mov x1, %x[bias]\n"
+      "subs x0, x0, #5\n"
+      "beq 3f\n"
+      "2:"
+      "subs x0, x0, #16\n"
+
+      // BiasAdd::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "ld1 {v4.4s}, [x1], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v5.8h, v4.16b\n"
+      "uxtl v4.8h, v4.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v7.4s, v5.8h\n"
+      "sxtl v6.4s, v5.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v5.4s, v4.8h\n"
+      "sxtl v4.4s, v4.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "scvtf v6.4s, v6.4s\n"
+      "scvtf v7.4s, v7.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v9.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fmul v6.4s, v6.4s, v11.4s\n"
+      "fmul v7.4s, v7.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v8.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v6.4s, v6.4s, v10.4s\n"
+      "fadd v7.4s, v7.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v6.4s\n"
+      "fadd v3.4s, v3.4s, v7.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fsub v3.4s, v3.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fmul v3.4s, v3.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fadd v3.4s, v3.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "ld1 {v0.s}[0], [%x[input]], #4\n"
+      "ld1 {v0.b}[4], [%x[input]], #1\n"
+      "ld1 {v2.s}[0], [x1], #4\n"
+      "ld1 {v2.b}[4], [x1], #1\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl v2.8h, v2.8b\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v3.4s, v2.8h\n"
+      "sxtl v2.4s, v2.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v11.4s\n"
+      "fmul v3.4s, v3.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v10.4s\n"
+      "fadd v3.4s, v3.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v2.4s\n"
+      "fadd v1.4s, v1.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "st1 {v1.s}[0], [%x[output]], #4\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "subs %x[rows], %x[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "x0", "x1", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9",
+        "v10", "v11", "v12", "v13", "v14", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              6>::Transform(const uint8_t* input,
+                                            const BiasAdd<uint8_t>& params,
+                                            int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "6>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr x0, %x[input_range_min]\n"
+      "dup v8.4s, w0\n"
+      "ldr x0, %x[input_range_scale]\n"
+      "dup v9.4s, w0\n"
+      "ldr x0, %x[bias_range_min]\n"
+      "dup v10.4s, w0\n"
+      "ldr x0, %x[bias_range_scale]\n"
+      "dup v11.4s, w0\n"
+      "ldr x0, %x[output_range_min]\n"
+      "dup v12.4s, w0\n"
+      "ldr x0, %x[one_over_output_range_scale]\n"
+      "dup v13.4s, w0\n"
+      "ldr x0, %x[output_range_offset]\n"
+      "dup v14.4s, w0\n"
+      "1:"
+      "mov x0, %x[count]\n"
+      "mov x1, %x[bias]\n"
+      "subs x0, x0, #6\n"
+      "beq 3f\n"
+      "2:"
+      "subs x0, x0, #16\n"
+
+      // BiasAdd::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "ld1 {v4.4s}, [x1], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v5.8h, v4.16b\n"
+      "uxtl v4.8h, v4.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v7.4s, v5.8h\n"
+      "sxtl v6.4s, v5.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v5.4s, v4.8h\n"
+      "sxtl v4.4s, v4.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "scvtf v6.4s, v6.4s\n"
+      "scvtf v7.4s, v7.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v9.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fmul v6.4s, v6.4s, v11.4s\n"
+      "fmul v7.4s, v7.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v8.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v6.4s, v6.4s, v10.4s\n"
+      "fadd v7.4s, v7.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v6.4s\n"
+      "fadd v3.4s, v3.4s, v7.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fsub v3.4s, v3.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fmul v3.4s, v3.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fadd v3.4s, v3.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "ld1 {v0.s}[0], [%x[input]], #4\n"
+      "ld1 {v0.h}[2], [%x[input]], #2\n"
+      "ld1 {v2.s}[0], [x1], #4\n"
+      "ld1 {v2.h}[2], [x1], #2\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl v2.8h, v2.8b\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v3.4s, v2.8h\n"
+      "sxtl v2.4s, v2.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v11.4s\n"
+      "fmul v3.4s, v3.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v10.4s\n"
+      "fadd v3.4s, v3.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v2.4s\n"
+      "fadd v1.4s, v1.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "st1 {v1.2s}, [%x[output]], #8\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "subs %x[rows], %x[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "x0", "x1", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9",
+        "v10", "v11", "v12", "v13", "v14", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              7>::Transform(const uint8_t* input,
+                                            const BiasAdd<uint8_t>& params,
+                                            int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "7>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr x0, %x[input_range_min]\n"
+      "dup v8.4s, w0\n"
+      "ldr x0, %x[input_range_scale]\n"
+      "dup v9.4s, w0\n"
+      "ldr x0, %x[bias_range_min]\n"
+      "dup v10.4s, w0\n"
+      "ldr x0, %x[bias_range_scale]\n"
+      "dup v11.4s, w0\n"
+      "ldr x0, %x[output_range_min]\n"
+      "dup v12.4s, w0\n"
+      "ldr x0, %x[one_over_output_range_scale]\n"
+      "dup v13.4s, w0\n"
+      "ldr x0, %x[output_range_offset]\n"
+      "dup v14.4s, w0\n"
+      "1:"
+      "mov x0, %x[count]\n"
+      "mov x1, %x[bias]\n"
+      "subs x0, x0, #7\n"
+      "beq 3f\n"
+      "2:"
+      "subs x0, x0, #16\n"
+
+      // BiasAdd::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "ld1 {v4.4s}, [x1], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v5.8h, v4.16b\n"
+      "uxtl v4.8h, v4.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v7.4s, v5.8h\n"
+      "sxtl v6.4s, v5.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v5.4s, v4.8h\n"
+      "sxtl v4.4s, v4.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "scvtf v6.4s, v6.4s\n"
+      "scvtf v7.4s, v7.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v9.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fmul v6.4s, v6.4s, v11.4s\n"
+      "fmul v7.4s, v7.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v8.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v6.4s, v6.4s, v10.4s\n"
+      "fadd v7.4s, v7.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v6.4s\n"
+      "fadd v3.4s, v3.4s, v7.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fsub v3.4s, v3.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fmul v3.4s, v3.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fadd v3.4s, v3.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "ld1 {v0.s}[0], [%x[input]], #4\n"
+      "ld1 {v0.h}[2], [%x[input]], #2\n"
+      "ld1 {v0.b}[6], [%x[input]], #1\n"
+      "ld1 {v2.s}[0], [x1], #4\n"
+      "ld1 {v2.h}[2], [x1], #2\n"
+      "ld1 {v2.b}[6], [x1], #1\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl v2.8h, v2.8b\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v3.4s, v2.8h\n"
+      "sxtl v2.4s, v2.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v11.4s\n"
+      "fmul v3.4s, v3.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v10.4s\n"
+      "fadd v3.4s, v3.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v2.4s\n"
+      "fadd v1.4s, v1.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+
+      "st1 {v0.4s}, [%x[output]], #16\n"
+      "st1 {v1.2s}, [%x[output]], #8\n"
+      "st1 {v1.s}[2], [%x[output]], #4\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "subs %x[rows], %x[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "x0", "x1", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9",
+        "v10", "v11", "v12", "v13", "v14", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              8>::Transform(const uint8_t* input,
+                                            const BiasAdd<uint8_t>& params,
+                                            int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "8>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr x0, %x[input_range_min]\n"
+      "dup v8.4s, w0\n"
+      "ldr x0, %x[input_range_scale]\n"
+      "dup v9.4s, w0\n"
+      "ldr x0, %x[bias_range_min]\n"
+      "dup v10.4s, w0\n"
+      "ldr x0, %x[bias_range_scale]\n"
+      "dup v11.4s, w0\n"
+      "ldr x0, %x[output_range_min]\n"
+      "dup v12.4s, w0\n"
+      "ldr x0, %x[one_over_output_range_scale]\n"
+      "dup v13.4s, w0\n"
+      "ldr x0, %x[output_range_offset]\n"
+      "dup v14.4s, w0\n"
+      "1:"
+      "mov x0, %x[count]\n"
+      "mov x1, %x[bias]\n"
+      "subs x0, x0, #8\n"
+      "beq 3f\n"
+      "2:"
+      "subs x0, x0, #16\n"
+
+      // BiasAdd::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "ld1 {v4.4s}, [x1], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v5.8h, v4.16b\n"
+      "uxtl v4.8h, v4.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v7.4s, v5.8h\n"
+      "sxtl v6.4s, v5.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v5.4s, v4.8h\n"
+      "sxtl v4.4s, v4.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "scvtf v6.4s, v6.4s\n"
+      "scvtf v7.4s, v7.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v9.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fmul v6.4s, v6.4s, v11.4s\n"
+      "fmul v7.4s, v7.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v8.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v6.4s, v6.4s, v10.4s\n"
+      "fadd v7.4s, v7.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v6.4s\n"
+      "fadd v3.4s, v3.4s, v7.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fsub v3.4s, v3.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fmul v3.4s, v3.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fadd v3.4s, v3.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v2.2s}, [x1], #8\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl v2.8h, v2.8b\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v3.4s, v2.8h\n"
+      "sxtl v2.4s, v2.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v11.4s\n"
+      "fmul v3.4s, v3.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v10.4s\n"
+      "fadd v3.4s, v3.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v2.4s\n"
+      "fadd v1.4s, v1.4s, v3.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+
+      "st1 {v0.4s, v1.4s}, [%x[output]], #32\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "subs %x[rows], %x[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "x0", "x1", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9",
+        "v10", "v11", "v12", "v13", "v14", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              9>::Transform(const uint8_t* input,
+                                            const BiasAdd<uint8_t>& params,
+                                            int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "9>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr x0, %x[input_range_min]\n"
+      "dup v8.4s, w0\n"
+      "ldr x0, %x[input_range_scale]\n"
+      "dup v9.4s, w0\n"
+      "ldr x0, %x[bias_range_min]\n"
+      "dup v10.4s, w0\n"
+      "ldr x0, %x[bias_range_scale]\n"
+      "dup v11.4s, w0\n"
+      "ldr x0, %x[output_range_min]\n"
+      "dup v12.4s, w0\n"
+      "ldr x0, %x[one_over_output_range_scale]\n"
+      "dup v13.4s, w0\n"
+      "ldr x0, %x[output_range_offset]\n"
+      "dup v14.4s, w0\n"
+      "1:"
+      "mov x0, %x[count]\n"
+      "mov x1, %x[bias]\n"
+      "subs x0, x0, #9\n"
+      "beq 3f\n"
+      "2:"
+      "subs x0, x0, #16\n"
+
+      // BiasAdd::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "ld1 {v4.4s}, [x1], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v5.8h, v4.16b\n"
+      "uxtl v4.8h, v4.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v7.4s, v5.8h\n"
+      "sxtl v6.4s, v5.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v5.4s, v4.8h\n"
+      "sxtl v4.4s, v4.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "scvtf v6.4s, v6.4s\n"
+      "scvtf v7.4s, v7.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v9.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fmul v6.4s, v6.4s, v11.4s\n"
+      "fmul v7.4s, v7.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v8.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v6.4s, v6.4s, v10.4s\n"
+      "fadd v7.4s, v7.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v6.4s\n"
+      "fadd v3.4s, v3.4s, v7.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fsub v3.4s, v3.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fmul v3.4s, v3.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fadd v3.4s, v3.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.b}[8], [%x[input]], #1\n"
+      "ld1 {v3.2s}, [x1], #8\n"
+      "ld1 {v3.b}[8], [x1], #1\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v4.8h, v3.16b\n"
+      "uxtl v3.8h, v3.8b\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl v5.4s, v4.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v4.4s, v3.8h\n"
+      "sxtl v3.4s, v3.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v11.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v10.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v3.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+
+      "st1 {v0.4s, v1.4s}, [%x[output]], #32\n"
+      "st1 {v2.s}[0], [%x[output]], #4\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "subs %x[rows], %x[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "x0", "x1", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9",
+        "v10", "v11", "v12", "v13", "v14", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              10>::Transform(const uint8_t* input,
+                                             const BiasAdd<uint8_t>& params,
+                                             int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "10>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr x0, %x[input_range_min]\n"
+      "dup v8.4s, w0\n"
+      "ldr x0, %x[input_range_scale]\n"
+      "dup v9.4s, w0\n"
+      "ldr x0, %x[bias_range_min]\n"
+      "dup v10.4s, w0\n"
+      "ldr x0, %x[bias_range_scale]\n"
+      "dup v11.4s, w0\n"
+      "ldr x0, %x[output_range_min]\n"
+      "dup v12.4s, w0\n"
+      "ldr x0, %x[one_over_output_range_scale]\n"
+      "dup v13.4s, w0\n"
+      "ldr x0, %x[output_range_offset]\n"
+      "dup v14.4s, w0\n"
+      "1:"
+      "mov x0, %x[count]\n"
+      "mov x1, %x[bias]\n"
+      "subs x0, x0, #10\n"
+      "beq 3f\n"
+      "2:"
+      "subs x0, x0, #16\n"
+
+      // BiasAdd::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "ld1 {v4.4s}, [x1], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v5.8h, v4.16b\n"
+      "uxtl v4.8h, v4.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v7.4s, v5.8h\n"
+      "sxtl v6.4s, v5.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v5.4s, v4.8h\n"
+      "sxtl v4.4s, v4.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "scvtf v6.4s, v6.4s\n"
+      "scvtf v7.4s, v7.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v9.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fmul v6.4s, v6.4s, v11.4s\n"
+      "fmul v7.4s, v7.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v8.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v6.4s, v6.4s, v10.4s\n"
+      "fadd v7.4s, v7.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v6.4s\n"
+      "fadd v3.4s, v3.4s, v7.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fsub v3.4s, v3.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fmul v3.4s, v3.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fadd v3.4s, v3.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.h}[4], [%x[input]], #2\n"
+      "ld1 {v3.2s}, [x1], #8\n"
+      "ld1 {v3.h}[4], [x1], #2\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v4.8h, v3.16b\n"
+      "uxtl v3.8h, v3.8b\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl v5.4s, v4.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v4.4s, v3.8h\n"
+      "sxtl v3.4s, v3.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v11.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v10.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v3.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+
+      "st1 {v0.4s, v1.4s}, [%x[output]], #32\n"
+      "st1 {v2.2s}, [%x[output]], #8\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "subs %x[rows], %x[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "x0", "x1", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9",
+        "v10", "v11", "v12", "v13", "v14", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              11>::Transform(const uint8_t* input,
+                                             const BiasAdd<uint8_t>& params,
+                                             int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "11>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr x0, %x[input_range_min]\n"
+      "dup v8.4s, w0\n"
+      "ldr x0, %x[input_range_scale]\n"
+      "dup v9.4s, w0\n"
+      "ldr x0, %x[bias_range_min]\n"
+      "dup v10.4s, w0\n"
+      "ldr x0, %x[bias_range_scale]\n"
+      "dup v11.4s, w0\n"
+      "ldr x0, %x[output_range_min]\n"
+      "dup v12.4s, w0\n"
+      "ldr x0, %x[one_over_output_range_scale]\n"
+      "dup v13.4s, w0\n"
+      "ldr x0, %x[output_range_offset]\n"
+      "dup v14.4s, w0\n"
+      "1:"
+      "mov x0, %x[count]\n"
+      "mov x1, %x[bias]\n"
+      "subs x0, x0, #11\n"
+      "beq 3f\n"
+      "2:"
+      "subs x0, x0, #16\n"
+
+      // BiasAdd::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "ld1 {v4.4s}, [x1], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v5.8h, v4.16b\n"
+      "uxtl v4.8h, v4.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v7.4s, v5.8h\n"
+      "sxtl v6.4s, v5.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v5.4s, v4.8h\n"
+      "sxtl v4.4s, v4.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "scvtf v6.4s, v6.4s\n"
+      "scvtf v7.4s, v7.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v9.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fmul v6.4s, v6.4s, v11.4s\n"
+      "fmul v7.4s, v7.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v8.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v6.4s, v6.4s, v10.4s\n"
+      "fadd v7.4s, v7.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v6.4s\n"
+      "fadd v3.4s, v3.4s, v7.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fsub v3.4s, v3.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fmul v3.4s, v3.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fadd v3.4s, v3.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.h}[4], [%x[input]], #2\n"
+      "ld1 {v0.b}[10], [%x[input]], #1\n"
+      "ld1 {v3.2s}, [x1], #8\n"
+      "ld1 {v3.h}[4], [x1], #2\n"
+      "ld1 {v3.b}[10], [x1], #1\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v4.8h, v3.16b\n"
+      "uxtl v3.8h, v3.8b\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl v5.4s, v4.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v4.4s, v3.8h\n"
+      "sxtl v3.4s, v3.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v11.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v10.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v3.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+
+      "st1 {v0.4s, v1.4s}, [%x[output]], #32\n"
+      "st1 {v2.2s}, [%x[output]], #8\n"
+      "st1 {v2.s}[2], [%x[output]], #4\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "subs %x[rows], %x[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "x0", "x1", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9",
+        "v10", "v11", "v12", "v13", "v14", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              12>::Transform(const uint8_t* input,
+                                             const BiasAdd<uint8_t>& params,
+                                             int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "12>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr x0, %x[input_range_min]\n"
+      "dup v8.4s, w0\n"
+      "ldr x0, %x[input_range_scale]\n"
+      "dup v9.4s, w0\n"
+      "ldr x0, %x[bias_range_min]\n"
+      "dup v10.4s, w0\n"
+      "ldr x0, %x[bias_range_scale]\n"
+      "dup v11.4s, w0\n"
+      "ldr x0, %x[output_range_min]\n"
+      "dup v12.4s, w0\n"
+      "ldr x0, %x[one_over_output_range_scale]\n"
+      "dup v13.4s, w0\n"
+      "ldr x0, %x[output_range_offset]\n"
+      "dup v14.4s, w0\n"
+      "1:"
+      "mov x0, %x[count]\n"
+      "mov x1, %x[bias]\n"
+      "subs x0, x0, #12\n"
+      "beq 3f\n"
+      "2:"
+      "subs x0, x0, #16\n"
+
+      // BiasAdd::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "ld1 {v4.4s}, [x1], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v5.8h, v4.16b\n"
+      "uxtl v4.8h, v4.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v7.4s, v5.8h\n"
+      "sxtl v6.4s, v5.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v5.4s, v4.8h\n"
+      "sxtl v4.4s, v4.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "scvtf v6.4s, v6.4s\n"
+      "scvtf v7.4s, v7.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v9.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fmul v6.4s, v6.4s, v11.4s\n"
+      "fmul v7.4s, v7.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v8.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v6.4s, v6.4s, v10.4s\n"
+      "fadd v7.4s, v7.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v6.4s\n"
+      "fadd v3.4s, v3.4s, v7.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fsub v3.4s, v3.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fmul v3.4s, v3.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fadd v3.4s, v3.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.s}[2], [%x[input]], #4\n"
+      "ld1 {v3.2s}, [x1], #8\n"
+      "ld1 {v3.s}[2], [x1], #4\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v4.8h, v3.16b\n"
+      "uxtl v3.8h, v3.8b\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl v5.4s, v4.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v4.4s, v3.8h\n"
+      "sxtl v3.4s, v3.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v11.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v10.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v3.4s\n"
+      "fadd v1.4s, v1.4s, v4.4s\n"
+      "fadd v2.4s, v2.4s, v5.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s}, [%x[output]], #48\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "subs %x[rows], %x[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "x0", "x1", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9",
+        "v10", "v11", "v12", "v13", "v14", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              13>::Transform(const uint8_t* input,
+                                             const BiasAdd<uint8_t>& params,
+                                             int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "13>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr x0, %x[input_range_min]\n"
+      "dup v8.4s, w0\n"
+      "ldr x0, %x[input_range_scale]\n"
+      "dup v9.4s, w0\n"
+      "ldr x0, %x[bias_range_min]\n"
+      "dup v10.4s, w0\n"
+      "ldr x0, %x[bias_range_scale]\n"
+      "dup v11.4s, w0\n"
+      "ldr x0, %x[output_range_min]\n"
+      "dup v12.4s, w0\n"
+      "ldr x0, %x[one_over_output_range_scale]\n"
+      "dup v13.4s, w0\n"
+      "ldr x0, %x[output_range_offset]\n"
+      "dup v14.4s, w0\n"
+      "1:"
+      "mov x0, %x[count]\n"
+      "mov x1, %x[bias]\n"
+      "subs x0, x0, #13\n"
+      "beq 3f\n"
+      "2:"
+      "subs x0, x0, #16\n"
+
+      // BiasAdd::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "ld1 {v4.4s}, [x1], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v5.8h, v4.16b\n"
+      "uxtl v4.8h, v4.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v7.4s, v5.8h\n"
+      "sxtl v6.4s, v5.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v5.4s, v4.8h\n"
+      "sxtl v4.4s, v4.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "scvtf v6.4s, v6.4s\n"
+      "scvtf v7.4s, v7.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v9.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fmul v6.4s, v6.4s, v11.4s\n"
+      "fmul v7.4s, v7.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v8.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v6.4s, v6.4s, v10.4s\n"
+      "fadd v7.4s, v7.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v6.4s\n"
+      "fadd v3.4s, v3.4s, v7.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fsub v3.4s, v3.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fmul v3.4s, v3.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fadd v3.4s, v3.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.s}[2], [%x[input]], #4\n"
+      "ld1 {v0.b}[12], [%x[input]], #1\n"
+      "ld1 {v4.2s}, [x1], #8\n"
+      "ld1 {v4.s}[2], [x1], #4\n"
+      "ld1 {v4.b}[12], [x1], #1\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v5.8h, v4.16b\n"
+      "uxtl v4.8h, v4.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v7.4s, v5.8h\n"
+      "sxtl v6.4s, v5.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v5.4s, v4.8h\n"
+      "sxtl v4.4s, v4.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "scvtf v6.4s, v6.4s\n"
+      "scvtf v7.4s, v7.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v9.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fmul v6.4s, v6.4s, v11.4s\n"
+      "fmul v7.4s, v7.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v8.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v6.4s, v6.4s, v10.4s\n"
+      "fadd v7.4s, v7.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v6.4s\n"
+      "fadd v3.4s, v3.4s, v7.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fsub v3.4s, v3.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fmul v3.4s, v3.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fadd v3.4s, v3.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s}, [%x[output]], #48\n"
+      "st1 {v3.s}[0], [%x[output]], #4\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "subs %x[rows], %x[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "x0", "x1", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9",
+        "v10", "v11", "v12", "v13", "v14", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              14>::Transform(const uint8_t* input,
+                                             const BiasAdd<uint8_t>& params,
+                                             int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "14>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr x0, %x[input_range_min]\n"
+      "dup v8.4s, w0\n"
+      "ldr x0, %x[input_range_scale]\n"
+      "dup v9.4s, w0\n"
+      "ldr x0, %x[bias_range_min]\n"
+      "dup v10.4s, w0\n"
+      "ldr x0, %x[bias_range_scale]\n"
+      "dup v11.4s, w0\n"
+      "ldr x0, %x[output_range_min]\n"
+      "dup v12.4s, w0\n"
+      "ldr x0, %x[one_over_output_range_scale]\n"
+      "dup v13.4s, w0\n"
+      "ldr x0, %x[output_range_offset]\n"
+      "dup v14.4s, w0\n"
+      "1:"
+      "mov x0, %x[count]\n"
+      "mov x1, %x[bias]\n"
+      "subs x0, x0, #14\n"
+      "beq 3f\n"
+      "2:"
+      "subs x0, x0, #16\n"
+
+      // BiasAdd::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "ld1 {v4.4s}, [x1], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v5.8h, v4.16b\n"
+      "uxtl v4.8h, v4.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v7.4s, v5.8h\n"
+      "sxtl v6.4s, v5.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v5.4s, v4.8h\n"
+      "sxtl v4.4s, v4.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "scvtf v6.4s, v6.4s\n"
+      "scvtf v7.4s, v7.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v9.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fmul v6.4s, v6.4s, v11.4s\n"
+      "fmul v7.4s, v7.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v8.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v6.4s, v6.4s, v10.4s\n"
+      "fadd v7.4s, v7.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v6.4s\n"
+      "fadd v3.4s, v3.4s, v7.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fsub v3.4s, v3.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fmul v3.4s, v3.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fadd v3.4s, v3.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.s}[2], [%x[input]], #4\n"
+      "ld1 {v0.h}[6], [%x[input]], #2\n"
+      "ld1 {v4.2s}, [x1], #8\n"
+      "ld1 {v4.s}[2], [x1], #4\n"
+      "ld1 {v4.h}[6], [x1], #2\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v5.8h, v4.16b\n"
+      "uxtl v4.8h, v4.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v7.4s, v5.8h\n"
+      "sxtl v6.4s, v5.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v5.4s, v4.8h\n"
+      "sxtl v4.4s, v4.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "scvtf v6.4s, v6.4s\n"
+      "scvtf v7.4s, v7.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v9.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fmul v6.4s, v6.4s, v11.4s\n"
+      "fmul v7.4s, v7.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v8.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v6.4s, v6.4s, v10.4s\n"
+      "fadd v7.4s, v7.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v6.4s\n"
+      "fadd v3.4s, v3.4s, v7.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fsub v3.4s, v3.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fmul v3.4s, v3.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fadd v3.4s, v3.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s}, [%x[output]], #48\n"
+      "st1 {v3.2s}, [%x[output]], #8\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "subs %x[rows], %x[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "x0", "x1", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9",
+        "v10", "v11", "v12", "v13", "v14", "cc", "memory");
+}
+
+template <>
+inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
+                              15>::Transform(const uint8_t* input,
+                                             const BiasAdd<uint8_t>& params,
+                                             int32_t* output) {
+#ifdef DEBUG
+#ifdef DEBUG_METAGEMM_VERBOSE
+  std::cout << __FILE__ << "(" << __LINE__
+            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+               "15>::Transform()"
+            << std::endl
+            << std::flush;
+#endif
+#endif
+  int params_rows_copy = params.rows;
+  asm volatile(
+      "ldr x0, %x[input_range_min]\n"
+      "dup v8.4s, w0\n"
+      "ldr x0, %x[input_range_scale]\n"
+      "dup v9.4s, w0\n"
+      "ldr x0, %x[bias_range_min]\n"
+      "dup v10.4s, w0\n"
+      "ldr x0, %x[bias_range_scale]\n"
+      "dup v11.4s, w0\n"
+      "ldr x0, %x[output_range_min]\n"
+      "dup v12.4s, w0\n"
+      "ldr x0, %x[one_over_output_range_scale]\n"
+      "dup v13.4s, w0\n"
+      "ldr x0, %x[output_range_offset]\n"
+      "dup v14.4s, w0\n"
+      "1:"
+      "mov x0, %x[count]\n"
+      "mov x1, %x[bias]\n"
+      "subs x0, x0, #15\n"
+      "beq 3f\n"
+      "2:"
+      "subs x0, x0, #16\n"
+
+      // BiasAdd::Transform
+      "ld1 {v0.4s}, [%x[input]], #16\n"
+      "ld1 {v4.4s}, [x1], #16\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v5.8h, v4.16b\n"
+      "uxtl v4.8h, v4.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v7.4s, v5.8h\n"
+      "sxtl v6.4s, v5.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v5.4s, v4.8h\n"
+      "sxtl v4.4s, v4.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "scvtf v6.4s, v6.4s\n"
+      "scvtf v7.4s, v7.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v9.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fmul v6.4s, v6.4s, v11.4s\n"
+      "fmul v7.4s, v7.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v8.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v6.4s, v6.4s, v10.4s\n"
+      "fadd v7.4s, v7.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v6.4s\n"
+      "fadd v3.4s, v3.4s, v7.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fsub v3.4s, v3.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fmul v3.4s, v3.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fadd v3.4s, v3.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s, v3.4s}, [%x[output]], #64\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "bne 2b\n"
+      "3:"
+
+      // BiasAdd::Transform
+      "ld1 {v0.2s}, [%x[input]], #8\n"
+      "ld1 {v0.s}[2], [%x[input]], #4\n"
+      "ld1 {v0.h}[6], [%x[input]], #2\n"
+      "ld1 {v0.b}[14], [%x[input]], #1\n"
+      "ld1 {v4.2s}, [x1], #8\n"
+      "ld1 {v4.s}[2], [x1], #4\n"
+      "ld1 {v4.h}[6], [x1], #2\n"
+      "ld1 {v4.b}[14], [x1], #1\n"
+      "prfm pldl1keep, [%x[input], #32]\n"
+      "uxtl2 v1.8h, v0.16b\n"
+      "uxtl v0.8h, v0.8b\n"
+      "uxtl2 v5.8h, v4.16b\n"
+      "uxtl v4.8h, v4.8b\n"
+      "sxtl2 v3.4s, v1.8h\n"
+      "sxtl v2.4s, v1.4h\n"
+      "sxtl2 v7.4s, v5.8h\n"
+      "sxtl v6.4s, v5.4h\n"
+      "sxtl2 v1.4s, v0.8h\n"
+      "sxtl v0.4s, v0.4h\n"
+      "sxtl2 v5.4s, v4.8h\n"
+      "sxtl v4.4s, v4.4h\n"
+      "scvtf v0.4s, v0.4s\n"
+      "scvtf v1.4s, v1.4s\n"
+      "scvtf v2.4s, v2.4s\n"
+      "scvtf v3.4s, v3.4s\n"
+      "scvtf v4.4s, v4.4s\n"
+      "scvtf v5.4s, v5.4s\n"
+      "scvtf v6.4s, v6.4s\n"
+      "scvtf v7.4s, v7.4s\n"
+      "fmul v0.4s, v0.4s, v9.4s\n"
+      "fmul v1.4s, v1.4s, v9.4s\n"
+      "fmul v2.4s, v2.4s, v9.4s\n"
+      "fmul v3.4s, v3.4s, v9.4s\n"
+      "fmul v4.4s, v4.4s, v11.4s\n"
+      "fmul v5.4s, v5.4s, v11.4s\n"
+      "fmul v6.4s, v6.4s, v11.4s\n"
+      "fmul v7.4s, v7.4s, v11.4s\n"
+      "fadd v0.4s, v0.4s, v8.4s\n"
+      "fadd v1.4s, v1.4s, v8.4s\n"
+      "fadd v2.4s, v2.4s, v8.4s\n"
+      "fadd v3.4s, v3.4s, v8.4s\n"
+      "fadd v4.4s, v4.4s, v10.4s\n"
+      "fadd v5.4s, v5.4s, v10.4s\n"
+      "fadd v6.4s, v6.4s, v10.4s\n"
+      "fadd v7.4s, v7.4s, v10.4s\n"
+      "fadd v0.4s, v0.4s, v4.4s\n"
+      "fadd v1.4s, v1.4s, v5.4s\n"
+      "fadd v2.4s, v2.4s, v6.4s\n"
+      "fadd v3.4s, v3.4s, v7.4s\n"
+      "fsub v0.4s, v0.4s, v12.4s\n"
+      "fsub v1.4s, v1.4s, v12.4s\n"
+      "fsub v2.4s, v2.4s, v12.4s\n"
+      "fsub v3.4s, v3.4s, v12.4s\n"
+      "fmul v0.4s, v0.4s, v13.4s\n"
+      "fmul v1.4s, v1.4s, v13.4s\n"
+      "fmul v2.4s, v2.4s, v13.4s\n"
+      "fmul v3.4s, v3.4s, v13.4s\n"
+      "fadd v0.4s, v0.4s, v14.4s\n"
+      "fadd v1.4s, v1.4s, v14.4s\n"
+      "fadd v2.4s, v2.4s, v14.4s\n"
+      "fadd v3.4s, v3.4s, v14.4s\n"
+      "fcvtzs v0.4s, v0.4s\n"
+      "fcvtzs v1.4s, v1.4s\n"
+      "fcvtzs v2.4s, v2.4s\n"
+      "fcvtzs v3.4s, v3.4s\n"
+
+      "st1 {v0.4s, v1.4s, v2.4s}, [%x[output]], #48\n"
+      "st1 {v3.2s}, [%x[output]], #8\n"
+      "st1 {v3.s}[2], [%x[output]], #4\n"
+      "prfm pldl1keep, [%x[output]]\n"
+      "subs %x[rows], %x[rows], #1\n"
+      "bne 1b\n"
+      : [input] "+r"(input), [output] "+r"(output)
+      : [count] "r"(params.count), [rows] "r"(params_rows_copy),
+        [output_range_offset] "m"(params.output_range_offset),
+        [input_range_scale] "m"(params.input_range_scale),
+        [one_over_output_range_scale] "m"(params.one_over_output_range_scale),
+        [bias_range_min] "m"(params.bias_range_min),
+        [output_range_min] "m"(params.output_range_min),
+        [bias_range_scale] "m"(params.bias_range_scale),
+        [bias] "r"(params.bias), [input_range_min] "m"(params.input_range_min)
+      : "x0", "x1", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9",
+        "v10", "v11", "v12", "v13", "v14", "cc", "memory");
+}
+
+}  // namespace meta
+}  // namespace gemmlowp
+
+#else
+#warning "Meta gemm for arm64 requires: GEMMLOWP_NEON_64!"
+#endif
+
+#endif  // GEMMLOWP_META_TRANSFORM_KERNELS_ARM_64_H_


### PR DESCRIPTION
This large PR contains the template framework and a number of meta generated assembly inlines that provide optimized Arm NEON codepaths for the following cwise operations:
- Quantize
- Dequantize
- Requantize
- MinMax (used by the Relu activation)
- QuantizedBiasAdd

The transformations come with correctness tests and a simple benchmark.