### PR TITLE
Remove -lpthread from Android linkopts

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -7,6 +7,13 @@ licenses(["notice"])  # Apache 2.0
 
 exports_files(["LICENSE"])
 
+config_setting(
+    name = "android",
+    values = {
+        "crosstool_top": "//external:android/crosstool",
+    },
+)
+
 load("flags", "LIB_LINKOPTS", "BIN_LINKOPTS")
 
 filegroup(

--- a/flags.bzl
+++ b/flags.bzl
@@ -1,3 +1,10 @@
-LIB_LINKOPTS = ["-lpthread"]
+# Android builds do not need to link in a separate pthread library.
+LIB_LINKOPTS = select({
+    ":android": [],
+    "//conditions:default": ["-lpthread"],
+})
 
-BIN_LINKOPTS = ["-lpthread"]
+BIN_LINKOPTS = select({
+    ":android": [],
+    "//conditions:default": ["-lpthread"],
+})


### PR DESCRIPTION
This change is necessary to depend on gemmlowp as a dependency in Bazel (rather than just importing the srcs).

This time around Bazel seems to be happy if I leave the config_setting in the BUILD file as `bazel test ...:all` passes