### PR TITLE
Fix unused parameter warnings.

### DIFF
--- a/internal/output.h
+++ b/internal/output.h
@@ -132,7 +132,7 @@ struct OutputStageEvalImpl<
 
   OutputStageEvalImpl(const OutputStage& s) : output_stage(s) {}
 
-  OutputType Eval(InputType input, int row, int col) const {
+  OutputType Eval(InputType input, int row, int) const {
     const std::int32_t result_shift = output_stage.result_shift;
     const std::int32_t result_mult_int = output_stage.result_mult_int(row);
     const std::int32_t result_offset = output_stage.result_offset(row);
@@ -156,7 +156,7 @@ struct OutputStageEvalImpl<
 
   OutputStageEvalImpl(const OutputStage& s) : output_stage(s) {}
 
-  OutputType Eval(InputType input, int row, int col) const {
+  OutputType Eval(InputType input, int, int col) const {
     const std::int32_t result_shift = output_stage.result_shift;
     const std::int32_t result_mult_int = output_stage.result_mult_int(col);
     const std::int32_t result_offset = output_stage.result_offset(col);

--- a/public/map.h
+++ b/public/map.h
@@ -114,7 +114,7 @@ class VectorDup {
   VectorDup(const VectorDup& other) : data_(other.data_), size_(other.size_) {}
 
   int size() const { return size_; }
-  Scalar& operator()(int index) const { return data_; }
+  Scalar& operator()(int) const { return data_; }
 };
 
 }  // namespace gemmlowp


### PR DESCRIPTION
This PR proposes a fix for unused parameter compiler warnings (at least in the parts of the gemmlowp used by tiny-dnn, see here: https://github.com/tiny-dnn/tiny-dnn/issues/440).
