### PR TITLE
Rounding shifts

### DIFF
--- a/fixedpoint/fixedpoint.h
+++ b/fixedpoint/fixedpoint.h
@@ -227,7 +227,7 @@ inline std::int32_t RoundingHalfSum(std::int32_t a, std::int32_t b) {
 //
 // The mapping between IntegerType and the interval [-1, 1) is unique and
 // implied by IntegerType, which is assumed to be signed. For example,
-// for IntergerType==std::int32_t, the mapping is
+// for IntegerType==std::int32_t, the mapping is
 //   real_value = integer_value / 2^31.
 // So in this case, and leaving aside rounding and saturating, this
 // function computes ((a / 2^31) * (b / 2^31)) * 2^31, which simplifies to

--- a/fixedpoint/fixedpoint.h
+++ b/fixedpoint/fixedpoint.h
@@ -27,7 +27,7 @@ namespace gemmlowp {
 
 // Part 1: Low-level integer-arithmetic primitives.
 // The implementations here are generic implementations valid for
-// scalar types (e.g. int32_t). Architecture-specific SIMD types
+// scalar types (e.g. std::int32_t). Architecture-specific SIMD types
 // (e.g. NEON int32x4_t) may be supported by providing
 // specializations for them in separate files.
 //
@@ -191,12 +191,12 @@ IntegerType RoundingHalfSum(IntegerType a, IntegerType b) {
 }
 
 template <>
-inline int32_t RoundingHalfSum(int32_t a, int32_t b) {
-  int64_t a64 = a;
-  int64_t b64 = b;
-  int64_t sum = a64 + b64;
-  int64_t sign = sum >= 0 ? 1 : -1;
-  return static_cast<int32_t>((sum + sign) / 2);
+inline std::int32_t RoundingHalfSum(std::int32_t a, std::int32_t b) {
+  std::int64_t a64 = a;
+  std::int64_t b64 = b;
+  std::int64_t sum = a64 + b64;
+  std::int64_t sign = sum >= 0 ? 1 : -1;
+  return static_cast<std::int32_t>((sum + sign) / 2);
 }
 
 // Returns the integer that represents the product of two fixed-point
@@ -205,11 +205,11 @@ inline int32_t RoundingHalfSum(int32_t a, int32_t b) {
 // -1 * -1 to the maximum value (since 1 is not in the half-open
 // interval [-1, 1)).
 //
-// [The explanation below specializes to int32_t for example purpose.]
+// [The explanation below specializes to std::int32_t for example purpose.]
 //
 // The mapping between IntegerType and the interval [-1, 1) is unique and
 // implied by IntegerType, which is assumed to be signed. For example,
-// for IntergerType==int32_t, the mapping is
+// for IntergerType==std::int32_t, the mapping is
 //   real_value = integer_value / 2^31.
 // So in this case, and leaving aside rounding and saturating, this
 // function computes ((a / 2^31) * (b / 2^31)) * 2^31, which simplifies to
@@ -236,14 +236,14 @@ IntegerType SaturatingRoundingDoublingHighMul(IntegerType a, IntegerType b) {
 // This function implements the same computation as the ARMv7 NEON VQRDMULH
 // instruction.
 template <>
-inline int32_t SaturatingRoundingDoublingHighMul(int32_t a, int32_t b) {
-  bool overflow = a == b && a == std::numeric_limits<int32_t>::min();
-  int64_t a_64(a);
-  int64_t b_64(b);
-  int64_t ab_64 = a_64 * b_64;
-  int32_t nudge = ab_64 >= 0 ? (1 << 30) : (1 - (1 << 30));
-  int32_t ab_x2_high32 = static_cast<int32_t>((ab_64 + nudge) / (1ll << 31));
-  return overflow ? std::numeric_limits<int32_t>::max() : ab_x2_high32;
+inline std::int32_t SaturatingRoundingDoublingHighMul(std::int32_t a, std::int32_t b) {
+  bool overflow = a == b && a == std::numeric_limits<std::int32_t>::min();
+  std::int64_t a_64(a);
+  std::int64_t b_64(b);
+  std::int64_t ab_64 = a_64 * b_64;
+  std::int32_t nudge = ab_64 >= 0 ? (1 << 30) : (1 - (1 << 30));
+  std::int32_t ab_x2_high32 = static_cast<std::int32_t>((ab_64 + nudge) / (1ll << 31));
+  return overflow ? std::numeric_limits<std::int32_t>::max() : ab_x2_high32;
 }
 
 // Returns the product of a run-time integer value by a compile-time power
@@ -260,10 +260,10 @@ struct ImplSaturatingRoundingMultiplyByPOT<Exponent, IntegerType, 0> {
 };
 
 template <int Exponent>
-struct ImplSaturatingRoundingMultiplyByPOT<Exponent, int32_t, 1> {
-  static int32_t eval(int32_t x) {
-    const int64_t min = std::numeric_limits<int32_t>::min();
-    const int64_t max = std::numeric_limits<int32_t>::max();
+struct ImplSaturatingRoundingMultiplyByPOT<Exponent, std::int32_t, 1> {
+  static std::int32_t eval(std::int32_t x) {
+    const std::int64_t min = std::numeric_limits<std::int32_t>::min();
+    const std::int64_t max = std::numeric_limits<std::int32_t>::max();
     return x >= (1 << (31 - Exponent))
                ? max
                : x <= -(1 << (31 - Exponent)) ? min : x * (1 << Exponent);
@@ -271,10 +271,10 @@ struct ImplSaturatingRoundingMultiplyByPOT<Exponent, int32_t, 1> {
 };
 
 template <int Exponent>
-struct ImplSaturatingRoundingMultiplyByPOT<Exponent, int32_t, -1> {
-  static int32_t eval(int32_t x) {
-    int32_t b = (std::abs(x) & (1 << (-Exponent - 1))) >> (-Exponent - 1);
-    int32_t nudge = x >= 0 ? b : -b;
+struct ImplSaturatingRoundingMultiplyByPOT<Exponent, std::int32_t, -1> {
+  static std::int32_t eval(std::int32_t x) {
+    std::int32_t b = (std::abs(x) & (1 << (-Exponent - 1))) >> (-Exponent - 1);
+    std::int32_t nudge = x >= 0 ? b : -b;
     return x / (1 << -Exponent) + nudge;
   }
 };
@@ -290,8 +290,8 @@ template <typename tIntegerType>
 struct FixedPointRawTypeTraits {};
 
 template <>
-struct FixedPointRawTypeTraits<int32_t> {
-  typedef int32_t ScalarRawType;
+struct FixedPointRawTypeTraits<std::int32_t> {
+  typedef std::int32_t ScalarRawType;
   static const int kLanes = 1;
 };
 
@@ -398,7 +398,7 @@ class FixedPoint {
   static FixedPoint FromDouble(double x) {
     const double min_bound = static_cast<double>(ScalarRawMin());
     const double max_bound = static_cast<double>(ScalarRawMax());
-    return FromScalarRaw(static_cast<int32_t>(std::min(
+    return FromScalarRaw(static_cast<std::int32_t>(std::min(
         std::max(round(x * static_cast<double>(1ll << kFractionalBits)),
                  min_bound),
         max_bound)));

--- a/fixedpoint/fixedpoint_neon.h
+++ b/fixedpoint/fixedpoint_neon.h
@@ -143,10 +143,16 @@ inline int32x4_t SaturatingRoundingDoublingHighMul(int32x4_t a, int32x4_t b) {
   return vqrdmulhq_s32(a, b);
 }
 
+/* This attempt to use the RSHL (rounding shift) instruction failed
+ * because even though these are arithmetic shifts with rounding-to-nearest,
+ * the mid-points are always rounded upwards. This is correct for positive values
+ * and incorrect for negative values, resulting in bias. Accordingly,
+ * uncommenting this specialization causes test_fixedpoint to fail.
 template <>
 inline int32x4_t RoundingDivideByPOT(int32x4_t x, int exponent) {
   return vrshlq_s32(x, vdupq_n_s32(-exponent));
 }
+*/
 
 template <int Exponent>
 struct ImplSaturatingRoundingMultiplyByPOT<Exponent, int32x4_t, 1> {

--- a/fixedpoint/fixedpoint_neon.h
+++ b/fixedpoint/fixedpoint_neon.h
@@ -145,7 +145,8 @@ inline int32x4_t SaturatingRoundingDoublingHighMul(int32x4_t a, int32x4_t b) {
 
 /* This attempt to use the RSHL (rounding shift) instruction failed
  * because even though these are arithmetic shifts with rounding-to-nearest,
- * the mid-points are always rounded upwards. This is correct for positive values
+ * the mid-points are always rounded upwards. This is correct for positive
+values
  * and incorrect for negative values, resulting in bias. Accordingly,
  * uncommenting this specialization causes test_fixedpoint to fail.
 template <>

--- a/fixedpoint/fixedpoint_neon.h
+++ b/fixedpoint/fixedpoint_neon.h
@@ -137,6 +137,11 @@ inline int32x4_t SaturatingRoundingDoublingHighMul(int32x4_t a, int32x4_t b) {
   return vqrdmulhq_s32(a, b);
 }
 
+template <>
+inline int32x4_t RoundingDivideByPOT(int32x4_t x, int exponent) {
+  return vrshlq_s32(x, vdupq_n_s32(-exponent));
+}
+
 template <int Exponent>
 struct ImplSaturatingRoundingMultiplyByPOT<Exponent, int32x4_t, 1> {
   static int32x4_t eval(int32x4_t x) { return vqshlq_n_s32(x, Exponent); }

--- a/fixedpoint/fixedpoint_neon.h
+++ b/fixedpoint/fixedpoint_neon.h
@@ -145,10 +145,8 @@ inline int32x4_t SaturatingRoundingDoublingHighMul(int32x4_t a, int32x4_t b) {
 
 template <>
 inline int32x4_t RoundingDivideByPOT(int32x4_t x, int exponent) {
-  const int32x4_t zero = vdupq_n_s32(0);
   const int32x4_t shift_vec = vdupq_n_s32(-exponent);
-  const int32x4_t fixup =
-      vreinterpretq_s32_u32(vcltq_s32(vandq_s32(x, shift_vec), zero));
+  const int32x4_t fixup = vshrq_n_s32(vandq_s32(x, shift_vec), 31);
   const int32x4_t fixed_up_x = vqaddq_s32(x, fixup);
   return vrshlq_s32(fixed_up_x, shift_vec);
 }
@@ -161,8 +159,7 @@ struct ImplSaturatingRoundingMultiplyByPOT<Exponent, int32x4_t, 1> {
 template <int Exponent>
 struct ImplSaturatingRoundingMultiplyByPOT<Exponent, int32x4_t, -1> {
   static int32x4_t eval(int32x4_t x) {
-    const int32x4_t zero = vdupq_n_s32(0);
-    const int32x4_t fixup = vreinterpretq_s32_u32(vcltq_s32(x, zero));
+    const int32x4_t fixup = vshrq_n_s32(x, 31);
     const int32x4_t fixed_up_x = vqaddq_s32(x, fixup);
     return vrshrq_n_s32(fixed_up_x, -Exponent);
   }

--- a/fixedpoint/fixedpoint_neon.h
+++ b/fixedpoint/fixedpoint_neon.h
@@ -149,12 +149,12 @@ struct ImplSaturatingRoundingMultiplyByPOT<Exponent, int32x4_t, -1> {
 
 template <>
 struct FixedPointRawTypeTraits<int32x4_t> {
-  typedef int32_t ScalarRawType;
+  typedef std::int32_t ScalarRawType;
   static const int kLanes = 4;
 };
 
 template <>
-inline int32x4_t Dup<int32x4_t>(int32_t x) {
+inline int32x4_t Dup<int32x4_t>(std::int32_t x) {
   return vdupq_n_s32(x);
 }
 

--- a/fixedpoint/fixedpoint_neon.h
+++ b/fixedpoint/fixedpoint_neon.h
@@ -23,6 +23,12 @@
 namespace gemmlowp {
 
 template <>
+struct FixedPointRawTypeTraits<int32x4_t> {
+  typedef std::int32_t ScalarRawType;
+  static const int kLanes = 4;
+};
+
+template <>
 inline int32x4_t BitAnd(int32x4_t a, int32x4_t b) {
   return vandq_s32(a, b);
 }
@@ -150,12 +156,6 @@ struct ImplSaturatingRoundingMultiplyByPOT<Exponent, int32x4_t, 1> {
 template <int Exponent>
 struct ImplSaturatingRoundingMultiplyByPOT<Exponent, int32x4_t, -1> {
   static int32x4_t eval(int32x4_t x) { return vrshrq_n_s32(x, -Exponent); }
-};
-
-template <>
-struct FixedPointRawTypeTraits<int32x4_t> {
-  typedef std::int32_t ScalarRawType;
-  static const int kLanes = 4;
 };
 
 template <>

--- a/fixedpoint/fixedpoint_sse.h
+++ b/fixedpoint/fixedpoint_sse.h
@@ -172,7 +172,7 @@ inline __m128i SaturatingRoundingDoublingHighMul(__m128i a, __m128i b) {
   __m128i nudge;
 
   // saturation only happen if a == b == INT_MIN
-  min = _mm_set1_epi32(std::numeric_limits<int32_t>::min());
+  min = _mm_set1_epi32(std::numeric_limits<std::int32_t>::min());
   saturation_mask = BitAnd(MaskIfEqual(a, b), MaskIfEqual(a, min));
 
   // a = a0 | a1 | a2 | a3
@@ -208,10 +208,10 @@ struct ImplSaturatingRoundingMultiplyByPOT<Exponent, __m128i, 1> {
     __m128i min, max, result;
     __m128i positive_mask, negative_mask;
 
-    min = _mm_set1_epi32(std::numeric_limits<int32_t>::min());
-    max = _mm_set1_epi32(std::numeric_limits<int32_t>::max());
+    min = _mm_set1_epi32(std::numeric_limits<std::int32_t>::min());
+    max = _mm_set1_epi32(std::numeric_limits<std::int32_t>::max());
 
-    int32_t threshold = ((1 << (31 - Exponent)) - 1);
+    std::int32_t threshold = ((1 << (31 - Exponent)) - 1);
     positive_mask = MaskIfGreaterThan(x, _mm_set1_epi32(threshold));
     negative_mask = MaskIfLessThan(x, _mm_set1_epi32(-threshold));
 
@@ -235,12 +235,12 @@ struct ImplSaturatingRoundingMultiplyByPOT<Exponent, __m128i, -1> {
 
 template <>
 struct FixedPointRawTypeTraits<__m128i> {
-  typedef int32_t ScalarRawType;
+  typedef std::int32_t ScalarRawType;
   static const int kLanes = 4;
 };
 
 template <>
-inline __m128i Dup<__m128i>(int32_t x) {
+inline __m128i Dup<__m128i>(std::int32_t x) {
   return _mm_set1_epi32(x);
 }
 

--- a/fixedpoint/fixedpoint_sse.h
+++ b/fixedpoint/fixedpoint_sse.h
@@ -222,17 +222,6 @@ struct ImplSaturatingRoundingMultiplyByPOT<Exponent, __m128i, 1> {
   }
 };
 
-template <int Exponent>
-struct ImplSaturatingRoundingMultiplyByPOT<Exponent, __m128i, -1> {
-  static __m128i eval(__m128i x) {
-    __m128i nudge, result;
-    nudge = _mm_set1_epi64x(1 << (-Exponent - 1));
-    result = Add(x, nudge);
-    result = _mm_srai_epi32(x, -Exponent);
-    return result;
-  }
-};
-
 template <>
 struct FixedPointRawTypeTraits<__m128i> {
   typedef std::int32_t ScalarRawType;

--- a/internal/kernel_neon.h
+++ b/internal/kernel_neon.h
@@ -1016,8 +1016,8 @@ struct NEONKernel4Nx1Depth2 : KernelBase {
         lhs_ptr += 8;
       }
       // Load RHS cell
-      uint16_t rhs0 = rhs_ptr[0];
-      uint16_t rhs1 = rhs_ptr[1];
+      std::uint16_t rhs0 = rhs_ptr[0];
+      std::uint16_t rhs1 = rhs_ptr[1];
       rhs_ptr += 2;
       // Multiply-accumulate, level of depth 0
       for (int cell = 0; cell < Cells; cell++) {

--- a/internal/output.h
+++ b/internal/output.h
@@ -30,13 +30,15 @@ namespace gemmlowp {
 
 // A Fragment is a small fixed-size matrix typically stored in one or
 // a few architecture-specific SIMD vectors. Besides plain old scalar types
-// such as std::int32_t, Fragment types are what can be used as input/output data
+// such as std::int32_t, Fragment types are what can be used as input/output
+// data
 // types for output pipeline stages.
 //
 // More details:
 //
 // In the generic scalar code in this file, we have only implemented
-// evaluation of output stages for scalar inputs (e.g. plain std::int32_t values).
+// evaluation of output stages for scalar inputs (e.g. plain std::int32_t
+// values).
 // Other files (e.g. output_neon.h) are to provide SIMD paths by implementing
 // evaluation of output stages for SIMD vector types. However, this raises
 // the question of how the different values ("lanes") in a SIMD vector

--- a/internal/output.h
+++ b/internal/output.h
@@ -30,13 +30,13 @@ namespace gemmlowp {
 
 // A Fragment is a small fixed-size matrix typically stored in one or
 // a few architecture-specific SIMD vectors. Besides plain old scalar types
-// such as int32_t, Fragment types are what can be used as input/output data
+// such as std::int32_t, Fragment types are what can be used as input/output data
 // types for output pipeline stages.
 //
 // More details:
 //
 // In the generic scalar code in this file, we have only implemented
-// evaluation of output stages for scalar inputs (e.g. plain int32_t values).
+// evaluation of output stages for scalar inputs (e.g. plain std::int32_t values).
 // Other files (e.g. output_neon.h) are to provide SIMD paths by implementing
 // evaluation of output stages for SIMD vector types. However, this raises
 // the question of how the different values ("lanes") in a SIMD vector

--- a/internal/output.h
+++ b/internal/output.h
@@ -31,14 +31,14 @@ namespace gemmlowp {
 // A Fragment is a small fixed-size matrix typically stored in one or
 // a few architecture-specific SIMD vectors. Besides plain old scalar types
 // such as std::int32_t, Fragment types are what can be used as input/output
-// data
-// types for output pipeline stages.
+// data types for output pipeline stages.
 //
 // More details:
 //
 // In the generic scalar code in this file, we have only implemented
 // evaluation of output stages for scalar inputs (e.g. plain std::int32_t
 // values).
+//
 // Other files (e.g. output_neon.h) are to provide SIMD paths by implementing
 // evaluation of output stages for SIMD vector types. However, this raises
 // the question of how the different values ("lanes") in a SIMD vector

--- a/internal/output_sse.h
+++ b/internal/output_sse.h
@@ -28,7 +28,7 @@ typedef struct _int32x16x1_t { __m128i val[4]; } int32x16x1_t;
 typedef Fragment<__m128i, 4, 1, MapOrder::ColMajor> SSE4FragmentInt32x4x1;
 typedef Fragment<int32x16x1_t, 16, 1, MapOrder::ColMajor>
     SSE4FragmentInt32x16x1;
-typedef Fragment<uint32_t, 4, 1, MapOrder::ColMajor> SSE4FragmentUint8x4x1;
+typedef Fragment<std::uint32_t, 4, 1, MapOrder::ColMajor> SSE4FragmentUint8x4x1;
 typedef Fragment<__m128i, 16, 1, MapOrder::ColMajor> SSE4FragmentUint8x16x1;
 
 template <typename OutputStageType>

--- a/internal/pack.h
+++ b/internal/pack.h
@@ -237,7 +237,7 @@ class ScalarRoundingOffsetGenerator<RoundingMode::ProbabilisticXorshift> {
 // expensive % operations.
 template <>
 class ScalarRoundingOffsetGenerator<RoundingMode::ProbabilisticAddmod> {
-  static const uint8_t AddConst = 97;
+  static const std::uint8_t AddConst = 97;
 
  public:
   ScalarRoundingOffsetGenerator() { x_ = 1; }  // Start must be non-zero

--- a/internal/pack_neon.h
+++ b/internal/pack_neon.h
@@ -46,7 +46,7 @@ template <>
 class NEONRoundingOffsetGenerator<RoundingMode::ProbabilisticXorshift> {
  public:
   NEONRoundingOffsetGenerator() {
-    uint8_t s = 128;
+    std::uint8_t s = 128;
     std::uint8_t a[16];
     for (int i = 0; i < 16; i++) {
       a[i] = s;
@@ -81,7 +81,7 @@ template <>
 class NEONRoundingOffsetGenerator<RoundingMode::ProbabilisticAddmod> {
  public:
   NEONRoundingOffsetGenerator() {
-    uint8_t s = 128;
+    std::uint8_t s = 128;
     std::uint8_t a[16];
     // The initial offset is set by offsetting each lane to one
     // more iteration of the sequence (s0...s15)  Then, upon iteration,

--- a/internal/pack_sse.h
+++ b/internal/pack_sse.h
@@ -27,9 +27,9 @@ namespace gemmlowp {
 // This is in-place requantization, where the input is
 // not modified if 8bit integers are used. SSE does not
 // have less than 8bit kernels currently. Altought SSE registers
-// hold 16 uint8_t elements, only first 8 uint8_t elements are
-// requantized. The packing only use first 8 uint8_t elements
-// of the SSE registers. Therefore, requantizing all 16 uint8_t
+// hold 16 std::uint8_t elements, only first 8 std::uint8_t elements are
+// requantized. The packing only use first 8 std::uint8_t elements
+// of the SSE registers. Therefore, requantizing all 16 std::uint8_t
 // elements will be wasteful computation.
 template <typename QuantizationParams>
 void SSERequantize(

--- a/internal/single_thread_gemm.h
+++ b/internal/single_thread_gemm.h
@@ -46,10 +46,10 @@ class SingleThreadGemmContext {
   Allocator allocator_;
 };
 
-typedef VectorMap<const int32_t, VectorShape::Col> OffsetColMap;
-typedef VectorMap<const int32_t, VectorShape::Row> OffsetRowMap;
-typedef VectorDup<const int32_t, VectorShape::Col> OffsetColDup;
-typedef VectorDup<const int32_t, VectorShape::Row> OffsetRowDup;
+typedef VectorMap<const std::int32_t, VectorShape::Col> OffsetColMap;
+typedef VectorMap<const std::int32_t, VectorShape::Row> OffsetRowMap;
+typedef VectorDup<const std::int32_t, VectorShape::Col> OffsetColDup;
+typedef VectorDup<const std::int32_t, VectorShape::Row> OffsetRowDup;
 
 template <typename KernelFormat, typename InputScalar, typename OutputScalar,
           typename BitDepthParams, MapOrder LhsOrder, MapOrder RhsOrder,

--- a/internal/unpack_sse.h
+++ b/internal/unpack_sse.h
@@ -84,7 +84,7 @@ struct UnpackResultImpl<
     const int kRhsBits = BitDepthParams::RhsBitDepth::kBits;
     const std::int32_t kLhsMax = (1 << kLhsBits) - 1;
     const std::int32_t kRhsMax = (1 << kRhsBits) - 1;
-    __m128i depth_xmm = _mm_set1_epi32((int32_t)depth);
+    __m128i depth_xmm = _mm_set1_epi32((std::int32_t)depth);
 
     OutputPipelineExecutor<OutputPipelineType, SSE4FragmentInt32x4x1>
         int32x4x1_output_pipeline_executor(output_pipeline);

--- a/meta/base.h
+++ b/meta/base.h
@@ -64,7 +64,7 @@ struct GemmParams {
   const InType* lhs;
   const InType* rhs;
   OutType* result;
-  uint8_t* scratch;
+  std::uint8_t* scratch;
 
   // Specialized parameters.
 
@@ -114,7 +114,7 @@ struct Transform1DParams {
 
   const InType* input;
   OutType* output;
-  uint8_t* scratch;
+  std::uint8_t* scratch;
 
   Kernel kernel;
 };

--- a/meta/legacy_single_thread_gemm.h
+++ b/meta/legacy_single_thread_gemm.h
@@ -37,7 +37,7 @@ void gemm_q8_strided(std::uint8_t* scratch, const std::uint8_t* lhs,
   std::cout << "Legacy::GemmQ8." << std::endl;
 #endif
 #endif
-  typedef GemmParams<uint8_t, uint8_t, RowMajorWithSum, RowMajorWithSum,
+  typedef GemmParams<std::uint8_t, std::uint8_t, RowMajorWithSum, RowMajorWithSum,
                      QuantizedStaticPreprocessed, RowMajor>
       Params;
   Params params;
@@ -81,7 +81,7 @@ void gemv_q8(std::uint8_t* scratch, const std::uint8_t* lhs,
   std::cout << "Legacy::GemvQ8." << std::endl;
 #endif
 #endif
-  typedef GemmParams<uint8_t, uint8_t, RowMajorWithSum, RowMajorWithSum,
+  typedef GemmParams<std::uint8_t, std::uint8_t, RowMajorWithSum, RowMajorWithSum,
                      QuantizedStaticPreprocessed, RowMajor>
       Params;
   Params params;
@@ -129,7 +129,7 @@ void gemm_i32_strided(std::uint8_t* scratch, const std::uint8_t* lhs,
   std::cout << "Legacy::GemmI32." << std::endl;
 #endif
 #endif
-  typedef GemmParams<uint8_t, int32_t, RowMajorWithSum, RowMajorWithSum,
+  typedef GemmParams<std::uint8_t, std::int32_t, RowMajorWithSum, RowMajorWithSum,
                      QuantizedStaticPreprocessedAsInt32, RowMajor>
       Params;
   Params params;
@@ -168,7 +168,7 @@ void gemv_i32(std::uint8_t* scratch, const std::uint8_t* lhs,
   std::cout << "Legacy::GemvI32." << std::endl;
 #endif
 #endif
-  typedef GemmParams<uint8_t, int32_t, RowMajorWithSum, RowMajorWithSum,
+  typedef GemmParams<std::uint8_t, std::int32_t, RowMajorWithSum, RowMajorWithSum,
                      QuantizedStaticPreprocessedAsInt32, RowMajor>
       Params;
   Params params;
@@ -212,7 +212,7 @@ void gemm_f_strided(std::uint8_t* scratch, const std::uint8_t* lhs,
   std::cout << "Legacy::GemmF." << std::endl;
 #endif
 #endif
-  typedef GemmParams<uint8_t, float, RowMajorWithSum, RowMajorWithSum,
+  typedef GemmParams<std::uint8_t, float, RowMajorWithSum, RowMajorWithSum,
                      QuantizedStaticPreprocessedAsFloat, RowMajor>
       Params;
   Params params;
@@ -252,7 +252,7 @@ void gemv_f(std::uint8_t* scratch, const std::uint8_t* lhs,
   std::cout << "Legacy::GemvF." << std::endl;
 #endif
 #endif
-  typedef GemmParams<uint8_t, float, RowMajorWithSum, RowMajorWithSum,
+  typedef GemmParams<std::uint8_t, float, RowMajorWithSum, RowMajorWithSum,
                      QuantizedStaticPreprocessedAsFloat, RowMajor>
       Params;
   Params params;

--- a/meta/multi_thread_gemm.h
+++ b/meta/multi_thread_gemm.h
@@ -26,8 +26,8 @@ const std::int32_t kMinGemmTaskSize = 16000;
 const std::int32_t kMinGemmTaskDimension = 4;
 
 template <typename Executor, typename Params>
-uint8_t* PrepareGemmTask(const Params& params, int kernel_m, int kernel_n,
-                         int kernel_k, uint8_t* scratch, int m_start, int m,
+std::uint8_t* PrepareGemmTask(const Params& params, int kernel_m, int kernel_n,
+                         int kernel_k, std::uint8_t* scratch, int m_start, int m,
                          int n_start, int n, std::vector<Params>* tasks) {
   tasks->push_back(params);
   Params& task = tasks->back();
@@ -71,7 +71,7 @@ bool PrepareGemmTasks(MultiThreadingContext* context, const Params& params,
     return false;
   }
 
-  uint8_t* scratch = params.scratch;
+  std::uint8_t* scratch = params.scratch;
 
   if (max_tasks_m > max_tasks_n) {
     const int m_chunk = params.m / real_tasks;

--- a/meta/quantized_mul_kernels_arm_32.h
+++ b/meta/quantized_mul_kernels_arm_32.h
@@ -25,15 +25,15 @@ namespace meta {
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 1,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 1,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 1, 1, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -99,15 +99,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 1,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 2,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 2,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 1, 2, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -177,15 +177,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 2,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 3,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 3,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 1, 3, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -261,15 +261,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 3,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 4,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 4,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 1, 4, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -349,15 +349,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 4,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 5,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 5,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 1, 5, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -450,15 +450,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 5,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 6,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 6,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 1, 6, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -555,15 +555,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 6,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 7,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 7,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 1, 7, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -666,15 +666,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 7,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 8,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 8,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 1, 8, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -781,15 +781,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 8,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 1,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 1,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 2, 1, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -870,15 +870,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 1,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 2,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 2,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 2, 2, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -968,15 +968,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 2,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 3,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 3,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 2, 3, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -1079,15 +1079,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 3,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 4,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 4,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 2, 4, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -1198,15 +1198,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 4,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 1,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 1,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 3, 1, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -1303,15 +1303,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 1,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 2,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 2,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 3, 2, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -1421,15 +1421,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 2,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 3,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 3,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 3, 3, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -1560,15 +1560,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 3,
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 1,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 1,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 1, "
                "8>::Multiply()"
             << std::endl
@@ -1624,15 +1624,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 2,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 2,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 2, "
                "8>::Multiply()"
             << std::endl
@@ -1692,15 +1692,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 3,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 3,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 3, "
                "8>::Multiply()"
             << std::endl
@@ -1766,15 +1766,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 4,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 4,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 4, "
                "8>::Multiply()"
             << std::endl
@@ -1844,15 +1844,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 5,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 5,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 5, "
                "8>::Multiply()"
             << std::endl
@@ -1931,15 +1931,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 6,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 6,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 6, "
                "8>::Multiply()"
             << std::endl
@@ -2021,15 +2021,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 7,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 7,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 7, "
                "8>::Multiply()"
             << std::endl
@@ -2117,15 +2117,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 8,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 8,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 8, "
                "8>::Multiply()"
             << std::endl
@@ -2218,15 +2218,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 1,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 1,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 1, "
                "8>::Multiply()"
             << std::endl
@@ -2292,15 +2292,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 2,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 2,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 2, "
                "8>::Multiply()"
             << std::endl
@@ -2375,15 +2375,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 3,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 3,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 3, "
                "8>::Multiply()"
             << std::endl
@@ -2471,15 +2471,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 4,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 4,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 4, "
                "8>::Multiply()"
             << std::endl
@@ -2575,15 +2575,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 1,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 1,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 1, "
                "8>::Multiply()"
             << std::endl
@@ -2659,15 +2659,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 2,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 2,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 2, "
                "8>::Multiply()"
             << std::endl
@@ -2757,15 +2757,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 3,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 3,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 3, "
                "8>::Multiply()"
             << std::endl
@@ -2876,15 +2876,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 1,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 1,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 1, "
                "8>::Multiply()"
             << std::endl
@@ -2944,15 +2944,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 2,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 2,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 2, "
                "8>::Multiply()"
             << std::endl
@@ -3016,15 +3016,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 3,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 3,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 3, "
                "8>::Multiply()"
             << std::endl
@@ -3094,15 +3094,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 4,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 4,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 4, "
                "8>::Multiply()"
             << std::endl
@@ -3176,15 +3176,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 5,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 5,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 5, "
                "8>::Multiply()"
             << std::endl
@@ -3269,15 +3269,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 6,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 6,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 6, "
                "8>::Multiply()"
             << std::endl
@@ -3365,15 +3365,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 7,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 7,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 7, "
                "8>::Multiply()"
             << std::endl
@@ -3467,15 +3467,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 8,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 8,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 8, "
                "8>::Multiply()"
             << std::endl
@@ -3574,15 +3574,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 1,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 1,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 1, "
                "8>::Multiply()"
             << std::endl
@@ -3654,15 +3654,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 2,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 2,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 2, "
                "8>::Multiply()"
             << std::endl
@@ -3743,15 +3743,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 3,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 3,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 3, "
                "8>::Multiply()"
             << std::endl
@@ -3845,15 +3845,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 4,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 4,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 4, "
                "8>::Multiply()"
             << std::endl
@@ -3955,15 +3955,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 1,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 1,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 1, "
                "8>::Multiply()"
             << std::endl
@@ -4047,15 +4047,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 2,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 2,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 2, "
                "8>::Multiply()"
             << std::endl
@@ -4153,15 +4153,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 3,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 3,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 3, "
                "8>::Multiply()"
             << std::endl

--- a/meta/quantized_mul_kernels_arm_64.h
+++ b/meta/quantized_mul_kernels_arm_64.h
@@ -25,15 +25,15 @@ namespace meta {
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 1,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 1,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 1, 1, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -98,15 +98,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 1,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 2,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 2,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 1, 2, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -174,15 +174,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 2,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 3,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 3,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 1, 3, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -256,15 +256,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 3,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 4,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 4,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 1, 4, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -340,15 +340,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 4,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 5,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 5,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 1, 5, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -437,15 +437,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 5,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 6,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 6,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 1, 6, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -537,15 +537,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 6,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 7,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 7,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 1, 7, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -642,15 +642,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 7,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 8,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 8,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 1, 8, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -749,15 +749,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 1, 8,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 1,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 1,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 2, 1, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -838,15 +838,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 1,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 2,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 2,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 2, 2, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -933,15 +933,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 2,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 3,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 3,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 2, 3, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -1038,15 +1038,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 3,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 4,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 4,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 2, 4, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -1149,15 +1149,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 2, 4,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 1,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 1,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 3, 1, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -1253,15 +1253,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 1,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 2,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 2,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 3, 2, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -1366,15 +1366,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 2,
 
 template <>
 inline void
-MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 3,
-          8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+MulKernel<std::uint8_t, std::uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 3,
+          8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                        const FusedKernelParams<QuantizedStaticPreprocessed,
                                                RowMajor>& params,
-                       uint8_t* result) {
+                       std::uint8_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedRowMajor<uint8_t, uint8_t, "
+            << ") QuantizedStaticPreprocessedRowMajor<std::uint8_t, std::uint8_t, "
                "QuantizedStaticPreprocessed, RowMajor, 3, 3, 8>::Multiply()"
             << std::endl
             << std::flush;
@@ -1498,15 +1498,15 @@ MulKernel<uint8_t, uint8_t, QuantizedStaticPreprocessed, RowMajor, 3, 3,
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 1,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 1,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 1, "
                "8>::Multiply()"
             << std::endl
@@ -1561,15 +1561,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 2,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 2,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 2, "
                "8>::Multiply()"
             << std::endl
@@ -1627,15 +1627,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 3,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 3,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 3, "
                "8>::Multiply()"
             << std::endl
@@ -1699,15 +1699,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 4,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 4,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 4, "
                "8>::Multiply()"
             << std::endl
@@ -1773,15 +1773,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 5,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 5,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 5, "
                "8>::Multiply()"
             << std::endl
@@ -1856,15 +1856,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 6,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 6,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 6, "
                "8>::Multiply()"
             << std::endl
@@ -1942,15 +1942,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 7,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 7,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 7, "
                "8>::Multiply()"
             << std::endl
@@ -2033,15 +2033,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 8,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 8,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 1, 8, "
                "8>::Multiply()"
             << std::endl
@@ -2126,15 +2126,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 1,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 1,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 1, "
                "8>::Multiply()"
             << std::endl
@@ -2199,15 +2199,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 2,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 2,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 2, "
                "8>::Multiply()"
             << std::endl
@@ -2279,15 +2279,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 3,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 3,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 3, "
                "8>::Multiply()"
             << std::endl
@@ -2369,15 +2369,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 4,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 4,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 2, 4, "
                "8>::Multiply()"
             << std::endl
@@ -2465,15 +2465,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 1,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 1,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 1, "
                "8>::Multiply()"
             << std::endl
@@ -2549,15 +2549,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 2,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 2,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 2, "
                "8>::Multiply()"
             << std::endl
@@ -2642,15 +2642,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 3,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, std::int32_t, QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 3,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsInt32,
                                          RowMajor>& params,
-                 int32_t* result) {
+                 std::int32_t* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsInt32RowMajor<uint8_t, int32_t, "
+            << ") QuantizedStaticPreprocessedAsInt32RowMajor<std::uint8_t, std::int32_t, "
                "QuantizedStaticPreprocessedAsInt32, RowMajor, 3, 3, "
                "8>::Multiply()"
             << std::endl
@@ -2754,15 +2754,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 1,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 1,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 1, "
                "8>::Multiply()"
             << std::endl
@@ -2821,15 +2821,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 2,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 2,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 2, "
                "8>::Multiply()"
             << std::endl
@@ -2891,15 +2891,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 3,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 3,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 3, "
                "8>::Multiply()"
             << std::endl
@@ -2967,15 +2967,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 4,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 4,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 4, "
                "8>::Multiply()"
             << std::endl
@@ -3045,15 +3045,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 5,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 5,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 5, "
                "8>::Multiply()"
             << std::endl
@@ -3134,15 +3134,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 6,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 6,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 6, "
                "8>::Multiply()"
             << std::endl
@@ -3226,15 +3226,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 7,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 7,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 7, "
                "8>::Multiply()"
             << std::endl
@@ -3323,15 +3323,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 8,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 8,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 1, 8, "
                "8>::Multiply()"
             << std::endl
@@ -3422,15 +3422,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 1,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 1,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 1, "
                "8>::Multiply()"
             << std::endl
@@ -3501,15 +3501,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 2,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 2,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 2, "
                "8>::Multiply()"
             << std::endl
@@ -3587,15 +3587,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 3,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 3,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 3, "
                "8>::Multiply()"
             << std::endl
@@ -3683,15 +3683,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 4,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 4,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 2, 4, "
                "8>::Multiply()"
             << std::endl
@@ -3785,15 +3785,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 1,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 1,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 1, "
                "8>::Multiply()"
             << std::endl
@@ -3877,15 +3877,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 2,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 2,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 2, "
                "8>::Multiply()"
             << std::endl
@@ -3978,15 +3978,15 @@ inline void MulKernel<
 
 template <>
 inline void MulKernel<
-    uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 3,
-    8>::Multiply(const uint8_t* lhs, const uint8_t* rhs,
+    std::uint8_t, float, QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 3,
+    8>::Multiply(const std::uint8_t* lhs, const std::uint8_t* rhs,
                  const FusedKernelParams<QuantizedStaticPreprocessedAsFloat,
                                          RowMajor>& params,
                  float* result) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") QuantizedStaticPreprocessedAsFloatRowMajor<uint8_t, float, "
+            << ") QuantizedStaticPreprocessedAsFloatRowMajor<std::uint8_t, float, "
                "QuantizedStaticPreprocessedAsFloat, RowMajor, 3, 3, "
                "8>::Multiply()"
             << std::endl

--- a/meta/single_thread_gemm.h
+++ b/meta/single_thread_gemm.h
@@ -111,18 +111,18 @@ class GemmExecutorPackRHS {
 
     // Scratch memory for packed LHS & RHS chunks.
 
-    uint8_t* packed_lhs = params.scratch;
-    uint8_t* packed_rhs =
+    std::uint8_t* packed_lhs = params.scratch;
+    std::uint8_t* packed_rhs =
         params.scratch + LeftStreamF::Scratch(params.left_stream);
 
     // Pack full RHS first.
 
-    uint8_t* packed_rhs_chunk = packed_rhs;
+    std::uint8_t* packed_rhs_chunk = packed_rhs;
     const int packed_rhs_chunk_size =
         RightStreamF::PackedStride(params.right_stream);
 
     {
-      const uint8_t* rhs_chunk = reinterpret_cast<const uint8_t*>(params.rhs);
+      const std::uint8_t* rhs_chunk = reinterpret_cast<const std::uint8_t*>(params.rhs);
       const int rhs_chunk_size =
           RightStreamF::UnpackedStride(params.right_stream);
 
@@ -142,9 +142,9 @@ class GemmExecutorPackRHS {
 
     // Multiply RHS by LHS one LHS chunk at a time.
 
-    const uint8_t* lhs_chunk = reinterpret_cast<const uint8_t*>(params.lhs);
-    uint8_t* result_strip = reinterpret_cast<uint8_t*>(params.result);
-    uint8_t* result_chunk = result_strip;
+    const std::uint8_t* lhs_chunk = reinterpret_cast<const std::uint8_t*>(params.lhs);
+    std::uint8_t* result_strip = reinterpret_cast<std::uint8_t*>(params.result);
+    std::uint8_t* result_chunk = result_strip;
 
     {
       const int lhs_chunk_size =
@@ -296,18 +296,18 @@ class GemmExecutorPackLHS {
     int rhs_chunks = params.n / n;
 
     // Scratch memory for packed LHS & RHS chunks.
-    uint8_t* packed_rhs = params.scratch;
-    uint8_t* packed_lhs =
+    std::uint8_t* packed_rhs = params.scratch;
+    std::uint8_t* packed_lhs =
         params.scratch + RightStreamF::Scratch(params.right_stream);
 
     // Pack full LHS first.
 
-    uint8_t* packed_lhs_chunk = packed_lhs;
+    std::uint8_t* packed_lhs_chunk = packed_lhs;
     const int packed_lhs_chunk_size =
         LeftStreamF::PackedStride(params.left_stream);
 
     {
-      const uint8_t* lhs_chunk = reinterpret_cast<const uint8_t*>(params.lhs);
+      const std::uint8_t* lhs_chunk = reinterpret_cast<const std::uint8_t*>(params.lhs);
       const int lhs_chunk_size =
           LeftStreamF::UnpackedStride(params.left_stream);
 
@@ -327,9 +327,9 @@ class GemmExecutorPackLHS {
 
     // Multiply RHS by LHS one RHS chunk at a time.
 
-    const uint8_t* rhs_chunk = reinterpret_cast<const uint8_t*>(params.rhs);
-    uint8_t* result_strip = reinterpret_cast<uint8_t*>(params.result);
-    uint8_t* result_chunk = result_strip;
+    const std::uint8_t* rhs_chunk = reinterpret_cast<const std::uint8_t*>(params.rhs);
+    std::uint8_t* result_strip = reinterpret_cast<std::uint8_t*>(params.result);
+    std::uint8_t* result_chunk = result_strip;
 
     {
       const int rhs_chunk_size =

--- a/meta/streams.h
+++ b/meta/streams.h
@@ -50,13 +50,13 @@ class StreamUtil<InType, RowMajor> {
   static const InType* Offset(const RowMajor& params, const InType* source,
                               int offset_stride, int offset_advance) {
     return reinterpret_cast<const InType*>(
-        reinterpret_cast<const uint8_t*>(source) +
+        reinterpret_cast<const std::uint8_t*>(source) +
         offset_stride * params.stride + offset_advance * sizeof(InType));
   }
 
   static InType* Offset(const RowMajor& params, InType* source,
                         int offset_stride, int offset_advance) {
-    return reinterpret_cast<InType*>(reinterpret_cast<uint8_t*>(source) +
+    return reinterpret_cast<InType*>(reinterpret_cast<std::uint8_t*>(source) +
                                      offset_stride * params.stride +
                                      offset_advance * sizeof(InType));
   }
@@ -73,13 +73,13 @@ class StreamUtil<InType, RowMajorWithSum> {
                               const InType* source, int offset_stride,
                               int offset_advance) {
     return reinterpret_cast<const InType*>(
-        reinterpret_cast<const uint8_t*>(source) +
+        reinterpret_cast<const std::uint8_t*>(source) +
         offset_stride * params.stride + offset_advance * sizeof(InType));
   }
 
   static InType* Offset(const RowMajorWithSum& params, InType* source,
                         int offset_stride, int offset_advance) {
-    return reinterpret_cast<InType*>(reinterpret_cast<uint8_t*>(source) +
+    return reinterpret_cast<InType*>(reinterpret_cast<std::uint8_t*>(source) +
                                      offset_stride * params.stride +
                                      offset_advance * sizeof(InType));
   }
@@ -98,13 +98,13 @@ class StreamUtil<InType, ColumnMajorWithSum> {
                               const InType* source, int offset_stride,
                               int offset_advance) {
     return reinterpret_cast<const InType*>(
-        reinterpret_cast<const uint8_t*>(source) +
+        reinterpret_cast<const std::uint8_t*>(source) +
         params.stride * offset_advance + offset_stride * sizeof(InType));
   }
 
   static const InType* Offset(const ColumnMajorWithSum& params, InType* source,
                               int offset_stride, int offset_advance) {
-    return reinterpret_cast<InType*>(reinterpret_cast<uint8_t*>(source) +
+    return reinterpret_cast<InType*>(reinterpret_cast<std::uint8_t*>(source) +
                                      params.stride * offset_advance +
                                      offset_stride * sizeof(InType));
   }

--- a/meta/streams_arm_32.h
+++ b/meta/streams_arm_32.h
@@ -24,12 +24,12 @@ namespace gemmlowp {
 namespace meta {
 
 template <>
-inline void Stream<uint8_t, 1, 8, 0, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 0, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 1, 8, 0, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 1, 8, 0, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -65,12 +65,12 @@ inline void Stream<uint8_t, 1, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 1, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 1, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 1, 8, 1, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 1, 8, 1, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -115,12 +115,12 @@ inline void Stream<uint8_t, 1, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 2, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 2, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 1, 8, 2, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 1, 8, 2, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -165,12 +165,12 @@ inline void Stream<uint8_t, 1, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 3, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 3, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 1, 8, 3, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 1, 8, 3, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -216,12 +216,12 @@ inline void Stream<uint8_t, 1, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 4, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 4, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 1, 8, 4, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 1, 8, 4, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -266,12 +266,12 @@ inline void Stream<uint8_t, 1, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 5, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 5, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 1, 8, 5, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 1, 8, 5, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -317,12 +317,12 @@ inline void Stream<uint8_t, 1, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 6, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 6, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 1, 8, 6, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 1, 8, 6, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -368,12 +368,12 @@ inline void Stream<uint8_t, 1, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 7, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 7, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 1, 8, 7, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 1, 8, 7, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -420,12 +420,12 @@ inline void Stream<uint8_t, 1, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 0, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 0, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 2, 8, 0, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 2, 8, 0, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -468,12 +468,12 @@ inline void Stream<uint8_t, 2, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 1, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 1, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 2, 8, 1, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 2, 8, 1, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -528,12 +528,12 @@ inline void Stream<uint8_t, 2, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 2, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 2, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 2, 8, 2, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 2, 8, 2, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -588,12 +588,12 @@ inline void Stream<uint8_t, 2, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 3, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 3, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 2, 8, 3, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 2, 8, 3, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -650,12 +650,12 @@ inline void Stream<uint8_t, 2, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 4, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 4, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 2, 8, 4, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 2, 8, 4, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -710,12 +710,12 @@ inline void Stream<uint8_t, 2, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 5, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 5, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 2, 8, 5, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 2, 8, 5, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -772,12 +772,12 @@ inline void Stream<uint8_t, 2, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 6, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 6, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 2, 8, 6, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 2, 8, 6, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -834,12 +834,12 @@ inline void Stream<uint8_t, 2, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 7, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 7, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 2, 8, 7, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 2, 8, 7, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -898,12 +898,12 @@ inline void Stream<uint8_t, 2, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 0, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 0, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 3, 8, 0, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 3, 8, 0, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -953,12 +953,12 @@ inline void Stream<uint8_t, 3, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 1, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 1, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 3, 8, 1, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 3, 8, 1, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1023,12 +1023,12 @@ inline void Stream<uint8_t, 3, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 2, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 2, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 3, 8, 2, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 3, 8, 2, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1093,12 +1093,12 @@ inline void Stream<uint8_t, 3, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 3, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 3, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 3, 8, 3, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 3, 8, 3, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1166,12 +1166,12 @@ inline void Stream<uint8_t, 3, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 4, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 4, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 3, 8, 4, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 3, 8, 4, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1236,12 +1236,12 @@ inline void Stream<uint8_t, 3, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 5, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 5, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 3, 8, 5, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 3, 8, 5, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1309,12 +1309,12 @@ inline void Stream<uint8_t, 3, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 6, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 6, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 3, 8, 6, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 3, 8, 6, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1382,12 +1382,12 @@ inline void Stream<uint8_t, 3, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 7, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 7, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 3, 8, 7, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 3, 8, 7, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1458,12 +1458,12 @@ inline void Stream<uint8_t, 3, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 0, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 0, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 4, 8, 0, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 4, 8, 0, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1519,12 +1519,12 @@ inline void Stream<uint8_t, 4, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 1, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 1, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 4, 8, 1, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 4, 8, 1, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1598,12 +1598,12 @@ inline void Stream<uint8_t, 4, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 2, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 2, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 4, 8, 2, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 4, 8, 2, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1677,12 +1677,12 @@ inline void Stream<uint8_t, 4, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 3, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 3, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 4, 8, 3, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 4, 8, 3, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1760,12 +1760,12 @@ inline void Stream<uint8_t, 4, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 4, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 4, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 4, 8, 4, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 4, 8, 4, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1839,12 +1839,12 @@ inline void Stream<uint8_t, 4, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 5, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 5, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 4, 8, 5, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 4, 8, 5, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1922,12 +1922,12 @@ inline void Stream<uint8_t, 4, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 6, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 6, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 4, 8, 6, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 4, 8, 6, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -2005,12 +2005,12 @@ inline void Stream<uint8_t, 4, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 7, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 7, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 4, 8, 7, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 4, 8, 7, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -2092,12 +2092,12 @@ inline void Stream<uint8_t, 4, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 0, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 0, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 5, 8, 0, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 5, 8, 0, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -2163,12 +2163,12 @@ inline void Stream<uint8_t, 5, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 1, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 1, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 5, 8, 1, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 5, 8, 1, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -2256,12 +2256,12 @@ inline void Stream<uint8_t, 5, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 2, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 2, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 5, 8, 2, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 5, 8, 2, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -2349,12 +2349,12 @@ inline void Stream<uint8_t, 5, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 3, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 3, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 5, 8, 3, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 5, 8, 3, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -2447,12 +2447,12 @@ inline void Stream<uint8_t, 5, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 4, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 4, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 5, 8, 4, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 5, 8, 4, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -2540,12 +2540,12 @@ inline void Stream<uint8_t, 5, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 5, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 5, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 5, 8, 5, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 5, 8, 5, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -2638,12 +2638,12 @@ inline void Stream<uint8_t, 5, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 6, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 6, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 5, 8, 6, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 5, 8, 6, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -2736,12 +2736,12 @@ inline void Stream<uint8_t, 5, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 7, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 7, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 5, 8, 7, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 5, 8, 7, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -2839,12 +2839,12 @@ inline void Stream<uint8_t, 5, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 0, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 0, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 6, 8, 0, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 6, 8, 0, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -2917,12 +2917,12 @@ inline void Stream<uint8_t, 6, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 1, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 1, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 6, 8, 1, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 6, 8, 1, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -3020,12 +3020,12 @@ inline void Stream<uint8_t, 6, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 2, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 2, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 6, 8, 2, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 6, 8, 2, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -3123,12 +3123,12 @@ inline void Stream<uint8_t, 6, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 3, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 3, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 6, 8, 3, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 6, 8, 3, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -3232,12 +3232,12 @@ inline void Stream<uint8_t, 6, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 4, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 4, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 6, 8, 4, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 6, 8, 4, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -3335,12 +3335,12 @@ inline void Stream<uint8_t, 6, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 5, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 5, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 6, 8, 5, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 6, 8, 5, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -3444,12 +3444,12 @@ inline void Stream<uint8_t, 6, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 6, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 6, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 6, 8, 6, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 6, 8, 6, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -3553,12 +3553,12 @@ inline void Stream<uint8_t, 6, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 7, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 7, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 6, 8, 7, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 6, 8, 7, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -3668,12 +3668,12 @@ inline void Stream<uint8_t, 6, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 0, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 0, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 7, 8, 0, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 7, 8, 0, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -3753,12 +3753,12 @@ inline void Stream<uint8_t, 7, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 1, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 1, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 7, 8, 1, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 7, 8, 1, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -3866,12 +3866,12 @@ inline void Stream<uint8_t, 7, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 2, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 2, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 7, 8, 2, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 7, 8, 2, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -3979,12 +3979,12 @@ inline void Stream<uint8_t, 7, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 3, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 3, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 7, 8, 3, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 7, 8, 3, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -4099,12 +4099,12 @@ inline void Stream<uint8_t, 7, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 4, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 4, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 7, 8, 4, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 7, 8, 4, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -4212,12 +4212,12 @@ inline void Stream<uint8_t, 7, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 5, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 5, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 7, 8, 5, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 7, 8, 5, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -4332,12 +4332,12 @@ inline void Stream<uint8_t, 7, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 6, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 6, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 7, 8, 6, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 7, 8, 6, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -4452,12 +4452,12 @@ inline void Stream<uint8_t, 7, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 7, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 7, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 7, 8, 7, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 7, 8, 7, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -4579,12 +4579,12 @@ inline void Stream<uint8_t, 7, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 0, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 0, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 8, 8, 0, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 8, 8, 0, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -4671,12 +4671,12 @@ inline void Stream<uint8_t, 8, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 1, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 1, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 8, 8, 1, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 8, 8, 1, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -4794,12 +4794,12 @@ inline void Stream<uint8_t, 8, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 2, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 2, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 8, 8, 2, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 8, 8, 2, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -4917,12 +4917,12 @@ inline void Stream<uint8_t, 8, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 3, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 3, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 8, 8, 3, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 8, 8, 3, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -5048,12 +5048,12 @@ inline void Stream<uint8_t, 8, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 4, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 4, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 8, 8, 4, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 8, 8, 4, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -5171,12 +5171,12 @@ inline void Stream<uint8_t, 8, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 5, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 5, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 8, 8, 5, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 8, 8, 5, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -5302,12 +5302,12 @@ inline void Stream<uint8_t, 8, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 6, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 6, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 8, 8, 6, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 8, 8, 6, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -5433,12 +5433,12 @@ inline void Stream<uint8_t, 8, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 7, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 7, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 8, 8, 7, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 8, 8, 7, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -5572,13 +5572,13 @@ inline void Stream<uint8_t, 8, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 0, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 0, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 1, 8, 0, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 1, 8, 0, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -5623,13 +5623,13 @@ inline void Stream<uint8_t, 1, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 1, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 1, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 1, 8, 1, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 1, 8, 1, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -5684,13 +5684,13 @@ inline void Stream<uint8_t, 1, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 2, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 2, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 1, 8, 2, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 1, 8, 2, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -5746,13 +5746,13 @@ inline void Stream<uint8_t, 1, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 3, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 3, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 1, 8, 3, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 1, 8, 3, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -5809,13 +5809,13 @@ inline void Stream<uint8_t, 1, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 4, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 4, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 1, 8, 4, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 1, 8, 4, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -5873,13 +5873,13 @@ inline void Stream<uint8_t, 1, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 5, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 5, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 1, 8, 5, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 1, 8, 5, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -5938,13 +5938,13 @@ inline void Stream<uint8_t, 1, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 6, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 6, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 1, 8, 6, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 1, 8, 6, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6004,13 +6004,13 @@ inline void Stream<uint8_t, 1, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 7, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 7, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 1, 8, 7, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 1, 8, 7, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6071,13 +6071,13 @@ inline void Stream<uint8_t, 1, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 0, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 0, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 2, 8, 0, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 2, 8, 0, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6127,13 +6127,13 @@ inline void Stream<uint8_t, 2, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 1, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 1, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 2, 8, 1, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 2, 8, 1, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6196,13 +6196,13 @@ inline void Stream<uint8_t, 2, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 2, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 2, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 2, 8, 2, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 2, 8, 2, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6266,13 +6266,13 @@ inline void Stream<uint8_t, 2, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 3, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 3, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 2, 8, 3, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 2, 8, 3, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6337,13 +6337,13 @@ inline void Stream<uint8_t, 2, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 4, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 4, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 2, 8, 4, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 2, 8, 4, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6409,13 +6409,13 @@ inline void Stream<uint8_t, 2, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 5, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 5, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 2, 8, 5, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 2, 8, 5, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6482,13 +6482,13 @@ inline void Stream<uint8_t, 2, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 6, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 6, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 2, 8, 6, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 2, 8, 6, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6556,13 +6556,13 @@ inline void Stream<uint8_t, 2, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 7, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 7, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 2, 8, 7, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 2, 8, 7, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6631,13 +6631,13 @@ inline void Stream<uint8_t, 2, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 0, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 0, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 3, 8, 0, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 3, 8, 0, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6691,13 +6691,13 @@ inline void Stream<uint8_t, 3, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 1, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 1, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 3, 8, 1, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 3, 8, 1, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6764,13 +6764,13 @@ inline void Stream<uint8_t, 3, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 2, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 2, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 3, 8, 2, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 3, 8, 2, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6838,13 +6838,13 @@ inline void Stream<uint8_t, 3, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 3, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 3, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 3, 8, 3, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 3, 8, 3, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6913,13 +6913,13 @@ inline void Stream<uint8_t, 3, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 4, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 4, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 3, 8, 4, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 3, 8, 4, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6989,13 +6989,13 @@ inline void Stream<uint8_t, 3, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 5, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 5, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 3, 8, 5, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 3, 8, 5, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -7066,13 +7066,13 @@ inline void Stream<uint8_t, 3, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 6, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 6, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 3, 8, 6, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 3, 8, 6, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -7144,13 +7144,13 @@ inline void Stream<uint8_t, 3, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 7, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 7, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 3, 8, 7, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 3, 8, 7, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -7223,13 +7223,13 @@ inline void Stream<uint8_t, 3, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 0, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 0, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 4, 8, 0, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 4, 8, 0, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -7292,13 +7292,13 @@ inline void Stream<uint8_t, 4, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 1, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 1, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 4, 8, 1, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 4, 8, 1, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -7381,13 +7381,13 @@ inline void Stream<uint8_t, 4, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 2, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 2, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 4, 8, 2, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 4, 8, 2, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -7471,13 +7471,13 @@ inline void Stream<uint8_t, 4, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 3, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 3, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 4, 8, 3, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 4, 8, 3, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -7562,13 +7562,13 @@ inline void Stream<uint8_t, 4, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 4, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 4, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 4, 8, 4, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 4, 8, 4, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -7654,13 +7654,13 @@ inline void Stream<uint8_t, 4, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 5, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 5, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 4, 8, 5, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 4, 8, 5, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -7747,13 +7747,13 @@ inline void Stream<uint8_t, 4, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 6, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 6, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 4, 8, 6, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 4, 8, 6, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -7841,13 +7841,13 @@ inline void Stream<uint8_t, 4, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 7, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 7, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 4, 8, 7, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 4, 8, 7, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -7936,13 +7936,13 @@ inline void Stream<uint8_t, 4, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 0, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 0, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 5, 8, 0, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 5, 8, 0, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -8022,13 +8022,13 @@ inline void Stream<uint8_t, 5, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 1, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 1, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 5, 8, 1, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 5, 8, 1, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -8132,13 +8132,13 @@ inline void Stream<uint8_t, 5, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 2, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 2, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 5, 8, 2, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 5, 8, 2, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -8244,13 +8244,13 @@ inline void Stream<uint8_t, 5, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 3, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 3, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 5, 8, 3, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 5, 8, 3, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -8358,13 +8358,13 @@ inline void Stream<uint8_t, 5, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 4, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 4, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 5, 8, 4, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 5, 8, 4, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -8474,13 +8474,13 @@ inline void Stream<uint8_t, 5, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 5, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 5, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 5, 8, 5, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 5, 8, 5, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -8592,13 +8592,13 @@ inline void Stream<uint8_t, 5, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 6, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 6, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 5, 8, 6, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 5, 8, 6, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -8712,13 +8712,13 @@ inline void Stream<uint8_t, 5, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 7, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 7, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 5, 8, 7, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 5, 8, 7, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -8834,13 +8834,13 @@ inline void Stream<uint8_t, 5, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 0, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 0, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 6, 8, 0, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 6, 8, 0, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -8925,13 +8925,13 @@ inline void Stream<uint8_t, 6, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 1, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 1, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 6, 8, 1, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 6, 8, 1, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -9043,13 +9043,13 @@ inline void Stream<uint8_t, 6, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 2, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 2, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 6, 8, 2, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 6, 8, 2, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -9163,13 +9163,13 @@ inline void Stream<uint8_t, 6, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 3, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 3, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 6, 8, 3, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 6, 8, 3, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -9285,13 +9285,13 @@ inline void Stream<uint8_t, 6, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 4, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 4, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 6, 8, 4, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 6, 8, 4, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -9409,13 +9409,13 @@ inline void Stream<uint8_t, 6, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 5, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 5, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 6, 8, 5, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 6, 8, 5, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -9535,13 +9535,13 @@ inline void Stream<uint8_t, 6, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 6, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 6, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 6, 8, 6, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 6, 8, 6, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -9663,13 +9663,13 @@ inline void Stream<uint8_t, 6, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 7, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 7, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 6, 8, 7, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 6, 8, 7, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -9793,13 +9793,13 @@ inline void Stream<uint8_t, 6, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 0, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 0, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 7, 8, 0, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 7, 8, 0, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -9889,13 +9889,13 @@ inline void Stream<uint8_t, 7, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 1, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 1, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 7, 8, 1, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 7, 8, 1, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -10013,13 +10013,13 @@ inline void Stream<uint8_t, 7, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 2, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 2, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 7, 8, 2, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 7, 8, 2, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -10139,13 +10139,13 @@ inline void Stream<uint8_t, 7, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 3, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 3, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 7, 8, 3, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 7, 8, 3, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -10267,13 +10267,13 @@ inline void Stream<uint8_t, 7, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 4, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 4, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 7, 8, 4, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 7, 8, 4, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -10397,13 +10397,13 @@ inline void Stream<uint8_t, 7, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 5, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 5, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 7, 8, 5, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 7, 8, 5, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -10529,13 +10529,13 @@ inline void Stream<uint8_t, 7, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 6, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 6, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 7, 8, 6, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 7, 8, 6, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -10663,13 +10663,13 @@ inline void Stream<uint8_t, 7, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 7, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 7, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 7, 8, 7, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 7, 8, 7, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -10799,13 +10799,13 @@ inline void Stream<uint8_t, 7, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 0, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 0, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 8, 8, 0, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 8, 8, 0, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -10898,13 +10898,13 @@ inline void Stream<uint8_t, 8, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 1, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 1, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 8, 8, 1, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 8, 8, 1, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -11034,13 +11034,13 @@ inline void Stream<uint8_t, 8, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 2, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 2, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 8, 8, 2, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 8, 8, 2, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -11171,13 +11171,13 @@ inline void Stream<uint8_t, 8, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 3, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 3, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 8, 8, 3, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 8, 8, 3, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -11309,13 +11309,13 @@ inline void Stream<uint8_t, 8, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 4, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 4, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 8, 8, 4, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 8, 8, 4, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -11448,13 +11448,13 @@ inline void Stream<uint8_t, 8, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 5, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 5, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 8, 8, 5, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 8, 8, 5, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -11588,13 +11588,13 @@ inline void Stream<uint8_t, 8, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 6, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 6, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 8, 8, 6, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 8, 8, 6, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -11729,13 +11729,13 @@ inline void Stream<uint8_t, 8, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 7, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 7, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 8, 8, 7, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 8, 8, 7, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif

--- a/meta/streams_arm_64.h
+++ b/meta/streams_arm_64.h
@@ -24,12 +24,12 @@ namespace gemmlowp {
 namespace meta {
 
 template <>
-inline void Stream<uint8_t, 1, 8, 0, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 0, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 1, 8, 0, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 1, 8, 0, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -65,12 +65,12 @@ inline void Stream<uint8_t, 1, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 1, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 1, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 1, 8, 1, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 1, 8, 1, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -115,12 +115,12 @@ inline void Stream<uint8_t, 1, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 2, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 2, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 1, 8, 2, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 1, 8, 2, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -165,12 +165,12 @@ inline void Stream<uint8_t, 1, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 3, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 3, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 1, 8, 3, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 1, 8, 3, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -216,12 +216,12 @@ inline void Stream<uint8_t, 1, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 4, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 4, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 1, 8, 4, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 1, 8, 4, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -266,12 +266,12 @@ inline void Stream<uint8_t, 1, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 5, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 5, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 1, 8, 5, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 1, 8, 5, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -317,12 +317,12 @@ inline void Stream<uint8_t, 1, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 6, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 6, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 1, 8, 6, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 1, 8, 6, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -368,12 +368,12 @@ inline void Stream<uint8_t, 1, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 7, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 7, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 1, 8, 7, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 1, 8, 7, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -420,12 +420,12 @@ inline void Stream<uint8_t, 1, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 0, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 0, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 2, 8, 0, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 2, 8, 0, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -466,12 +466,12 @@ inline void Stream<uint8_t, 2, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 1, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 1, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 2, 8, 1, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 2, 8, 1, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -524,12 +524,12 @@ inline void Stream<uint8_t, 2, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 2, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 2, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 2, 8, 2, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 2, 8, 2, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -582,12 +582,12 @@ inline void Stream<uint8_t, 2, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 3, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 3, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 2, 8, 3, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 2, 8, 3, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -642,12 +642,12 @@ inline void Stream<uint8_t, 2, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 4, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 4, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 2, 8, 4, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 2, 8, 4, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -700,12 +700,12 @@ inline void Stream<uint8_t, 2, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 5, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 5, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 2, 8, 5, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 2, 8, 5, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -760,12 +760,12 @@ inline void Stream<uint8_t, 2, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 6, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 6, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 2, 8, 6, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 2, 8, 6, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -820,12 +820,12 @@ inline void Stream<uint8_t, 2, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 7, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 7, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 2, 8, 7, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 2, 8, 7, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -882,12 +882,12 @@ inline void Stream<uint8_t, 2, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 0, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 0, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 3, 8, 0, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 3, 8, 0, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -934,12 +934,12 @@ inline void Stream<uint8_t, 3, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 1, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 1, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 3, 8, 1, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 3, 8, 1, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1001,12 +1001,12 @@ inline void Stream<uint8_t, 3, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 2, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 2, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 3, 8, 2, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 3, 8, 2, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1068,12 +1068,12 @@ inline void Stream<uint8_t, 3, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 3, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 3, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 3, 8, 3, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 3, 8, 3, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1138,12 +1138,12 @@ inline void Stream<uint8_t, 3, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 4, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 4, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 3, 8, 4, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 3, 8, 4, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1205,12 +1205,12 @@ inline void Stream<uint8_t, 3, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 5, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 5, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 3, 8, 5, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 3, 8, 5, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1275,12 +1275,12 @@ inline void Stream<uint8_t, 3, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 6, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 6, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 3, 8, 6, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 3, 8, 6, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1345,12 +1345,12 @@ inline void Stream<uint8_t, 3, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 7, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 7, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 3, 8, 7, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 3, 8, 7, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1418,12 +1418,12 @@ inline void Stream<uint8_t, 3, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 0, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 0, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 4, 8, 0, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 4, 8, 0, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1476,12 +1476,12 @@ inline void Stream<uint8_t, 4, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 1, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 1, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 4, 8, 1, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 4, 8, 1, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1552,12 +1552,12 @@ inline void Stream<uint8_t, 4, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 2, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 2, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 4, 8, 2, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 4, 8, 2, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1628,12 +1628,12 @@ inline void Stream<uint8_t, 4, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 3, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 3, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 4, 8, 3, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 4, 8, 3, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1708,12 +1708,12 @@ inline void Stream<uint8_t, 4, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 4, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 4, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 4, 8, 4, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 4, 8, 4, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1784,12 +1784,12 @@ inline void Stream<uint8_t, 4, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 5, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 5, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 4, 8, 5, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 4, 8, 5, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1864,12 +1864,12 @@ inline void Stream<uint8_t, 4, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 6, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 6, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 4, 8, 6, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 4, 8, 6, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -1944,12 +1944,12 @@ inline void Stream<uint8_t, 4, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 7, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 7, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 4, 8, 7, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 4, 8, 7, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -2028,12 +2028,12 @@ inline void Stream<uint8_t, 4, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 0, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 0, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 5, 8, 0, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 5, 8, 0, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -2096,12 +2096,12 @@ inline void Stream<uint8_t, 5, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 1, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 1, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 5, 8, 1, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 5, 8, 1, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -2186,12 +2186,12 @@ inline void Stream<uint8_t, 5, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 2, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 2, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 5, 8, 2, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 5, 8, 2, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -2276,12 +2276,12 @@ inline void Stream<uint8_t, 5, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 3, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 3, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 5, 8, 3, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 5, 8, 3, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -2371,12 +2371,12 @@ inline void Stream<uint8_t, 5, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 4, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 4, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 5, 8, 4, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 5, 8, 4, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -2461,12 +2461,12 @@ inline void Stream<uint8_t, 5, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 5, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 5, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 5, 8, 5, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 5, 8, 5, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -2556,12 +2556,12 @@ inline void Stream<uint8_t, 5, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 6, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 6, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 5, 8, 6, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 5, 8, 6, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -2651,12 +2651,12 @@ inline void Stream<uint8_t, 5, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 7, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 7, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 5, 8, 7, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 5, 8, 7, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -2751,12 +2751,12 @@ inline void Stream<uint8_t, 5, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 0, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 0, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 6, 8, 0, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 6, 8, 0, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -2824,12 +2824,12 @@ inline void Stream<uint8_t, 6, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 1, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 1, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 6, 8, 1, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 6, 8, 1, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -2922,12 +2922,12 @@ inline void Stream<uint8_t, 6, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 2, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 2, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 6, 8, 2, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 6, 8, 2, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -3020,12 +3020,12 @@ inline void Stream<uint8_t, 6, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 3, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 3, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 6, 8, 3, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 6, 8, 3, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -3124,12 +3124,12 @@ inline void Stream<uint8_t, 6, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 4, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 4, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 6, 8, 4, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 6, 8, 4, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -3222,12 +3222,12 @@ inline void Stream<uint8_t, 6, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 5, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 5, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 6, 8, 5, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 6, 8, 5, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -3326,12 +3326,12 @@ inline void Stream<uint8_t, 6, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 6, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 6, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 6, 8, 6, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 6, 8, 6, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -3430,12 +3430,12 @@ inline void Stream<uint8_t, 6, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 7, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 7, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 6, 8, 7, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 6, 8, 7, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -3540,12 +3540,12 @@ inline void Stream<uint8_t, 6, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 0, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 0, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 7, 8, 0, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 7, 8, 0, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -3619,12 +3619,12 @@ inline void Stream<uint8_t, 7, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 1, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 1, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 7, 8, 1, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 7, 8, 1, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -3726,12 +3726,12 @@ inline void Stream<uint8_t, 7, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 2, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 2, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 7, 8, 2, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 7, 8, 2, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -3833,12 +3833,12 @@ inline void Stream<uint8_t, 7, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 3, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 3, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 7, 8, 3, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 7, 8, 3, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -3947,12 +3947,12 @@ inline void Stream<uint8_t, 7, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 4, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 4, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 7, 8, 4, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 7, 8, 4, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -4054,12 +4054,12 @@ inline void Stream<uint8_t, 7, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 5, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 5, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 7, 8, 5, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 7, 8, 5, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -4168,12 +4168,12 @@ inline void Stream<uint8_t, 7, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 6, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 6, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 7, 8, 6, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 7, 8, 6, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -4282,12 +4282,12 @@ inline void Stream<uint8_t, 7, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 7, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 7, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 7, 8, 7, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 7, 8, 7, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -4403,12 +4403,12 @@ inline void Stream<uint8_t, 7, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 0, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 0, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 8, 8, 0, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 8, 8, 0, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -4488,12 +4488,12 @@ inline void Stream<uint8_t, 8, 8, 0, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 1, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 1, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 8, 8, 1, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 8, 8, 1, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -4604,12 +4604,12 @@ inline void Stream<uint8_t, 8, 8, 1, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 2, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 2, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 8, 8, 2, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 8, 8, 2, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -4720,12 +4720,12 @@ inline void Stream<uint8_t, 8, 8, 2, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 3, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 3, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 8, 8, 3, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 8, 8, 3, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -4844,12 +4844,12 @@ inline void Stream<uint8_t, 8, 8, 3, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 4, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 4, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 8, 8, 4, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 8, 8, 4, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -4960,12 +4960,12 @@ inline void Stream<uint8_t, 8, 8, 4, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 5, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 5, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 8, 8, 5, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 8, 8, 5, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -5084,12 +5084,12 @@ inline void Stream<uint8_t, 8, 8, 5, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 6, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 6, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 8, 8, 6, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 8, 8, 6, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -5208,12 +5208,12 @@ inline void Stream<uint8_t, 8, 8, 6, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 7, RowMajorWithSum>::Pack(
-    const uint8_t* in, const RowMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 7, RowMajorWithSum>::Pack(
+    const std::uint8_t* in, const RowMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") RowMajorWithSum<uint8_t, 8, 8, 7, RowMajorWithSum>::Pack()"
+            << ") RowMajorWithSum<std::uint8_t, 8, 8, 7, RowMajorWithSum>::Pack()"
             << std::endl
             << std::flush;
 #endif
@@ -5340,13 +5340,13 @@ inline void Stream<uint8_t, 8, 8, 7, RowMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 0, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 0, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 1, 8, 0, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 1, 8, 0, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -5391,13 +5391,13 @@ inline void Stream<uint8_t, 1, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 1, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 1, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 1, 8, 1, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 1, 8, 1, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -5452,13 +5452,13 @@ inline void Stream<uint8_t, 1, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 2, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 2, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 1, 8, 2, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 1, 8, 2, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -5514,13 +5514,13 @@ inline void Stream<uint8_t, 1, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 3, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 3, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 1, 8, 3, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 1, 8, 3, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -5577,13 +5577,13 @@ inline void Stream<uint8_t, 1, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 4, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 4, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 1, 8, 4, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 1, 8, 4, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -5641,13 +5641,13 @@ inline void Stream<uint8_t, 1, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 5, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 5, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 1, 8, 5, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 1, 8, 5, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -5706,13 +5706,13 @@ inline void Stream<uint8_t, 1, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 6, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 6, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 1, 8, 6, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 1, 8, 6, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -5772,13 +5772,13 @@ inline void Stream<uint8_t, 1, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 1, 8, 7, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 1, 8, 7, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 1, 8, 7, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 1, 8, 7, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -5839,13 +5839,13 @@ inline void Stream<uint8_t, 1, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 0, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 0, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 2, 8, 0, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 2, 8, 0, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -5895,13 +5895,13 @@ inline void Stream<uint8_t, 2, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 1, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 1, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 2, 8, 1, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 2, 8, 1, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -5965,13 +5965,13 @@ inline void Stream<uint8_t, 2, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 2, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 2, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 2, 8, 2, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 2, 8, 2, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6036,13 +6036,13 @@ inline void Stream<uint8_t, 2, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 3, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 3, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 2, 8, 3, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 2, 8, 3, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6108,13 +6108,13 @@ inline void Stream<uint8_t, 2, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 4, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 4, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 2, 8, 4, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 2, 8, 4, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6181,13 +6181,13 @@ inline void Stream<uint8_t, 2, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 5, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 5, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 2, 8, 5, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 2, 8, 5, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6255,13 +6255,13 @@ inline void Stream<uint8_t, 2, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 6, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 6, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 2, 8, 6, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 2, 8, 6, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6330,13 +6330,13 @@ inline void Stream<uint8_t, 2, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 2, 8, 7, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 2, 8, 7, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 2, 8, 7, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 2, 8, 7, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6406,13 +6406,13 @@ inline void Stream<uint8_t, 2, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 0, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 0, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 3, 8, 0, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 3, 8, 0, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6464,13 +6464,13 @@ inline void Stream<uint8_t, 3, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 1, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 1, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 3, 8, 1, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 3, 8, 1, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6536,13 +6536,13 @@ inline void Stream<uint8_t, 3, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 2, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 2, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 3, 8, 2, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 3, 8, 2, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6609,13 +6609,13 @@ inline void Stream<uint8_t, 3, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 3, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 3, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 3, 8, 3, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 3, 8, 3, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6683,13 +6683,13 @@ inline void Stream<uint8_t, 3, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 4, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 4, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 3, 8, 4, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 3, 8, 4, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6758,13 +6758,13 @@ inline void Stream<uint8_t, 3, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 5, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 5, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 3, 8, 5, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 3, 8, 5, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6834,13 +6834,13 @@ inline void Stream<uint8_t, 3, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 6, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 6, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 3, 8, 6, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 3, 8, 6, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6911,13 +6911,13 @@ inline void Stream<uint8_t, 3, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 3, 8, 7, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 3, 8, 7, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 3, 8, 7, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 3, 8, 7, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -6989,13 +6989,13 @@ inline void Stream<uint8_t, 3, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 0, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 0, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 4, 8, 0, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 4, 8, 0, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -7059,13 +7059,13 @@ inline void Stream<uint8_t, 4, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 1, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 1, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 4, 8, 1, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 4, 8, 1, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -7153,13 +7153,13 @@ inline void Stream<uint8_t, 4, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 2, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 2, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 4, 8, 2, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 4, 8, 2, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -7248,13 +7248,13 @@ inline void Stream<uint8_t, 4, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 3, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 3, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 4, 8, 3, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 4, 8, 3, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -7344,13 +7344,13 @@ inline void Stream<uint8_t, 4, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 4, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 4, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 4, 8, 4, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 4, 8, 4, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -7441,13 +7441,13 @@ inline void Stream<uint8_t, 4, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 5, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 5, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 4, 8, 5, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 4, 8, 5, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -7539,13 +7539,13 @@ inline void Stream<uint8_t, 4, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 6, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 6, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 4, 8, 6, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 4, 8, 6, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -7638,13 +7638,13 @@ inline void Stream<uint8_t, 4, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 4, 8, 7, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 4, 8, 7, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 4, 8, 7, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 4, 8, 7, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -7738,13 +7738,13 @@ inline void Stream<uint8_t, 4, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 0, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 0, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 5, 8, 0, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 5, 8, 0, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -7825,13 +7825,13 @@ inline void Stream<uint8_t, 5, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 1, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 1, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 5, 8, 1, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 5, 8, 1, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -7940,13 +7940,13 @@ inline void Stream<uint8_t, 5, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 2, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 2, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 5, 8, 2, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 5, 8, 2, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -8057,13 +8057,13 @@ inline void Stream<uint8_t, 5, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 3, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 3, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 5, 8, 3, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 5, 8, 3, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -8176,13 +8176,13 @@ inline void Stream<uint8_t, 5, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 4, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 4, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 5, 8, 4, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 5, 8, 4, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -8297,13 +8297,13 @@ inline void Stream<uint8_t, 5, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 5, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 5, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 5, 8, 5, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 5, 8, 5, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -8420,13 +8420,13 @@ inline void Stream<uint8_t, 5, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 6, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 6, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 5, 8, 6, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 5, 8, 6, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -8545,13 +8545,13 @@ inline void Stream<uint8_t, 5, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 5, 8, 7, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 5, 8, 7, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 5, 8, 7, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 5, 8, 7, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -8672,13 +8672,13 @@ inline void Stream<uint8_t, 5, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 0, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 0, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 6, 8, 0, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 6, 8, 0, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -8764,13 +8764,13 @@ inline void Stream<uint8_t, 6, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 1, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 1, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 6, 8, 1, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 6, 8, 1, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -8888,13 +8888,13 @@ inline void Stream<uint8_t, 6, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 2, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 2, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 6, 8, 2, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 6, 8, 2, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -9014,13 +9014,13 @@ inline void Stream<uint8_t, 6, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 3, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 3, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 6, 8, 3, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 6, 8, 3, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -9142,13 +9142,13 @@ inline void Stream<uint8_t, 6, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 4, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 4, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 6, 8, 4, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 6, 8, 4, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -9272,13 +9272,13 @@ inline void Stream<uint8_t, 6, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 5, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 5, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 6, 8, 5, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 6, 8, 5, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -9404,13 +9404,13 @@ inline void Stream<uint8_t, 6, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 6, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 6, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 6, 8, 6, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 6, 8, 6, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -9538,13 +9538,13 @@ inline void Stream<uint8_t, 6, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 6, 8, 7, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 6, 8, 7, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 6, 8, 7, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 6, 8, 7, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -9674,13 +9674,13 @@ inline void Stream<uint8_t, 6, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 0, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 0, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 7, 8, 0, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 7, 8, 0, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -9768,13 +9768,13 @@ inline void Stream<uint8_t, 7, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 1, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 1, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 7, 8, 1, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 7, 8, 1, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -9894,13 +9894,13 @@ inline void Stream<uint8_t, 7, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 2, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 2, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 7, 8, 2, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 7, 8, 2, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -10022,13 +10022,13 @@ inline void Stream<uint8_t, 7, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 3, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 3, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 7, 8, 3, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 7, 8, 3, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -10152,13 +10152,13 @@ inline void Stream<uint8_t, 7, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 4, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 4, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 7, 8, 4, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 7, 8, 4, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -10284,13 +10284,13 @@ inline void Stream<uint8_t, 7, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 5, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 5, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 7, 8, 5, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 7, 8, 5, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -10418,13 +10418,13 @@ inline void Stream<uint8_t, 7, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 6, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 6, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 7, 8, 6, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 7, 8, 6, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -10554,13 +10554,13 @@ inline void Stream<uint8_t, 7, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 7, 8, 7, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 7, 8, 7, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 7, 8, 7, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 7, 8, 7, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -10692,13 +10692,13 @@ inline void Stream<uint8_t, 7, 8, 7, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 0, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 0, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 8, 8, 0, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 8, 8, 0, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -10797,13 +10797,13 @@ inline void Stream<uint8_t, 8, 8, 0, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 1, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 1, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 8, 8, 1, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 8, 8, 1, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -10951,13 +10951,13 @@ inline void Stream<uint8_t, 8, 8, 1, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 2, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 2, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 8, 8, 2, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 8, 8, 2, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -11106,13 +11106,13 @@ inline void Stream<uint8_t, 8, 8, 2, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 3, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 3, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 8, 8, 3, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 8, 8, 3, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -11262,13 +11262,13 @@ inline void Stream<uint8_t, 8, 8, 3, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 4, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 4, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 8, 8, 4, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 8, 8, 4, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -11419,13 +11419,13 @@ inline void Stream<uint8_t, 8, 8, 4, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 5, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 5, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 8, 8, 5, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 8, 8, 5, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -11577,13 +11577,13 @@ inline void Stream<uint8_t, 8, 8, 5, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 6, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 6, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 8, 8, 6, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 8, 8, 6, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif
@@ -11736,13 +11736,13 @@ inline void Stream<uint8_t, 8, 8, 6, ColumnMajorWithSum>::Pack(
 }
 
 template <>
-inline void Stream<uint8_t, 8, 8, 7, ColumnMajorWithSum>::Pack(
-    const uint8_t* in, const ColumnMajorWithSum& params, uint8_t* out) {
+inline void Stream<std::uint8_t, 8, 8, 7, ColumnMajorWithSum>::Pack(
+    const std::uint8_t* in, const ColumnMajorWithSum& params, std::uint8_t* out) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout
       << __FILE__ << "(" << __LINE__
-      << ") ColumnMajorWithSum<uint8_t, 8, 8, 7, ColumnMajorWithSum>::Pack()"
+      << ") ColumnMajorWithSum<std::uint8_t, 8, 8, 7, ColumnMajorWithSum>::Pack()"
       << std::endl
       << std::flush;
 #endif

--- a/meta/test_gemm_correctness.cc
+++ b/meta/test_gemm_correctness.cc
@@ -42,27 +42,27 @@ using namespace gemmlowp::meta;
 
 // Input, output & kernel setups.
 
-typedef GemmParams<uint8_t, uint8_t, RowMajorWithSum, ColumnMajorWithSum,
+typedef GemmParams<std::uint8_t, std::uint8_t, RowMajorWithSum, ColumnMajorWithSum,
                    QuantizedStaticPreprocessed, RowMajor>
     ParamsColumnMajor;
 
-typedef GemmParams<uint8_t, uint8_t, RowMajorWithSum, RowMajorWithSum,
+typedef GemmParams<std::uint8_t, std::uint8_t, RowMajorWithSum, RowMajorWithSum,
                    QuantizedStaticPreprocessed, RowMajor>
     ParamsRowMajor;
 
-typedef GemmParams<uint8_t, float, RowMajorWithSum, ColumnMajorWithSum,
+typedef GemmParams<std::uint8_t, float, RowMajorWithSum, ColumnMajorWithSum,
                    QuantizedStaticPreprocessedAsFloat, RowMajor>
     ParamsColumnMajorAsFloat;
 
-typedef GemmParams<uint8_t, float, RowMajorWithSum, RowMajorWithSum,
+typedef GemmParams<std::uint8_t, float, RowMajorWithSum, RowMajorWithSum,
                    QuantizedStaticPreprocessedAsFloat, RowMajor>
     ParamsRowMajorAsFloat;
 
-typedef GemmParams<uint8_t, int32_t, RowMajorWithSum, ColumnMajorWithSum,
+typedef GemmParams<std::uint8_t, std::int32_t, RowMajorWithSum, ColumnMajorWithSum,
                    QuantizedStaticPreprocessedAsInt32, RowMajor>
     ParamsColumnMajorAsInt32;
 
-typedef GemmParams<uint8_t, int32_t, RowMajorWithSum, RowMajorWithSum,
+typedef GemmParams<std::uint8_t, std::int32_t, RowMajorWithSum, RowMajorWithSum,
                    QuantizedStaticPreprocessedAsInt32, RowMajor>
     ParamsRowMajorAsInt32;
 
@@ -79,7 +79,7 @@ typedef GemmExecutorPackRHSCacheFriendly<> Executor;
 
 void prepare_test_data(std::uint8_t* data, std::int32_t rows, std::int32_t cols,
                        std::int32_t seed, std::int32_t seed_2) {
-  int32_t value = seed;
+  std::int32_t value = seed;
   for (int i = 0; i < rows * cols; ++i) {
     data[i] = static_cast<std::uint8_t>(value);
     value = ((value * seed_2) + seed) % 256;
@@ -93,7 +93,7 @@ void clear(int rows, int cols, CLEAR_TYPE* data) {
   }
 }
 
-bool check_row_row(uint8_t* lhs, uint8_t* rhs, uint8_t* results, int rows,
+bool check_row_row(std::uint8_t* lhs, std::uint8_t* rhs, std::uint8_t* results, int rows,
                    int cols, int depth) {
   int wrong = 0;
   int rounding = (1 << (SHIFT - 1));
@@ -128,7 +128,7 @@ bool check_row_row(uint8_t* lhs, uint8_t* rhs, uint8_t* results, int rows,
   return wrong == 0;
 }
 
-bool check_row_col(uint8_t* lhs, uint8_t* rhs, uint8_t* results, int rows,
+bool check_row_col(std::uint8_t* lhs, std::uint8_t* rhs, std::uint8_t* results, int rows,
                    int cols, int depth) {
   int wrong = 0;
   int rounding = (1 << (SHIFT - 1));
@@ -158,7 +158,7 @@ bool check_row_col(uint8_t* lhs, uint8_t* rhs, uint8_t* results, int rows,
   return wrong == 0;
 }
 
-bool check_row_row_f(uint8_t* lhs, uint8_t* rhs, float* results, int rows,
+bool check_row_row_f(std::uint8_t* lhs, std::uint8_t* rhs, float* results, int rows,
                      int cols, int depth) {
   int wrong = 0;
   for (int i = 0; i < rows; ++i) {
@@ -178,7 +178,7 @@ bool check_row_row_f(uint8_t* lhs, uint8_t* rhs, float* results, int rows,
   return wrong == 0;
 }
 
-bool check_row_col_f(uint8_t* lhs, uint8_t* rhs, float* results, int rows,
+bool check_row_col_f(std::uint8_t* lhs, std::uint8_t* rhs, float* results, int rows,
                      int cols, int depth) {
   int wrong = 0;
   for (int i = 0; i < rows; ++i) {
@@ -198,7 +198,7 @@ bool check_row_col_f(uint8_t* lhs, uint8_t* rhs, float* results, int rows,
   return wrong == 0;
 }
 
-bool check_row_row_i32(uint8_t* lhs, uint8_t* rhs, int32_t* results, int rows,
+bool check_row_row_i32(std::uint8_t* lhs, std::uint8_t* rhs, std::int32_t* results, int rows,
                        int cols, int depth) {
   int wrong = 0;
   for (int i = 0; i < rows; ++i) {
@@ -217,7 +217,7 @@ bool check_row_row_i32(uint8_t* lhs, uint8_t* rhs, int32_t* results, int rows,
   return wrong == 0;
 }
 
-bool check_row_col_i32(uint8_t* lhs, uint8_t* rhs, int32_t* results, int rows,
+bool check_row_col_i32(std::uint8_t* lhs, std::uint8_t* rhs, std::int32_t* results, int rows,
                        int cols, int depth) {
   int wrong = 0;
   for (int i = 0; i < rows; ++i) {
@@ -323,7 +323,7 @@ void setup_row_row_i32(int m, int n, int k, ParamsRowMajorAsInt32* params) {
   params->right_stream.count = k;
   params->right_stream.stride = k;
   params->fused_kernel.kernel.count = k;
-  params->fused_kernel.output_stream.stride = n * sizeof(int32_t);
+  params->fused_kernel.output_stream.stride = n * sizeof(std::int32_t);
 }
 
 void setup_row_col_i32(int m, int n, int k, ParamsColumnMajorAsInt32* params) {
@@ -336,7 +336,7 @@ void setup_row_col_i32(int m, int n, int k, ParamsColumnMajorAsInt32* params) {
   params->right_stream.count = k;
   params->right_stream.stride = n;
   params->fused_kernel.kernel.count = k;
-  params->fused_kernel.output_stream.stride = n * sizeof(int32_t);
+  params->fused_kernel.output_stream.stride = n * sizeof(std::int32_t);
 }
 
 int main() {
@@ -347,12 +347,12 @@ int main() {
   ParamsRowMajorAsInt32 params_row_i32;
   ParamsColumnMajorAsInt32 params_col_i32;
 
-  std::unique_ptr<uint8_t> lhs(new uint8_t[1024 * 1024]);
-  std::unique_ptr<uint8_t> rhs(new uint8_t[1024 * 1024]);
-  std::unique_ptr<uint8_t> result(new uint8_t[1024 * 1024]);
+  std::unique_ptr<std::uint8_t> lhs(new std::uint8_t[1024 * 1024]);
+  std::unique_ptr<std::uint8_t> rhs(new std::uint8_t[1024 * 1024]);
+  std::unique_ptr<std::uint8_t> result(new std::uint8_t[1024 * 1024]);
   std::unique_ptr<float> result_f(new float[1024 * 1024]);
-  std::unique_ptr<int32_t> result_i32(new int32_t[1024 * 1024]);
-  std::unique_ptr<uint8_t> scratch(new uint8_t[4048 * 1024]);
+  std::unique_ptr<std::int32_t> result_i32(new std::int32_t[1024 * 1024]);
+  std::unique_ptr<std::uint8_t> scratch(new std::uint8_t[4048 * 1024]);
 
   setup_params(lhs.get(), rhs.get(), result.get(), scratch.get(), &params_row);
   setup_params(lhs.get(), rhs.get(), result.get(), scratch.get(), &params_col);

--- a/meta/test_streams_correctness.cc
+++ b/meta/test_streams_correctness.cc
@@ -33,7 +33,7 @@
 
 using namespace gemmlowp::meta;
 
-void prepare_row_major_data(int rows, int elements, int stride, uint8_t* data) {
+void prepare_row_major_data(int rows, int elements, int stride, std::uint8_t* data) {
   for (int i = 0; i < rows * stride; ++i) {
     data[i] = 255;
   }
@@ -45,7 +45,7 @@ void prepare_row_major_data(int rows, int elements, int stride, uint8_t* data) {
 }
 
 void prepare_column_major_data(int columns, int elements, int stride,
-                               uint8_t* data) {
+                               std::uint8_t* data) {
   for (int i = 0; i < elements * stride; ++i) {
     data[i] = 255;
   }
@@ -56,7 +56,7 @@ void prepare_column_major_data(int columns, int elements, int stride,
   }
 }
 
-void print_out(uint8_t* result, int rows, int elements) {
+void print_out(std::uint8_t* result, int rows, int elements) {
   int size = rows * ((elements + 7) / 8) * 8;
   for (int i = 0; i < size; ++i) {
     std::cout << static_cast<int>(result[i]) << " ";
@@ -64,7 +64,7 @@ void print_out(uint8_t* result, int rows, int elements) {
   std::cout << std::endl << std::flush;
 }
 
-bool check(uint8_t* result, int rows, int elements) {
+bool check(std::uint8_t* result, int rows, int elements) {
   int chunks = elements / 8;
   int leftover = elements % 8;
   for (int i = 0; i < chunks; ++i) {
@@ -92,7 +92,7 @@ bool check(uint8_t* result, int rows, int elements) {
   int expected_sum =
       ((elements * (elements - 1)) / 2) * MUL_OFFSET + ADD_OFFSET;
   int sums_offset = rows * ((elements + 7) / 8) * 8;
-  int32_t* sums = reinterpret_cast<int32_t*>(result + sums_offset);
+  std::int32_t* sums = reinterpret_cast<std::int32_t*>(result + sums_offset);
   for (int i = 0; i < rows; ++i) {
     if (sums[i] != expected_sum) {
       return false;
@@ -103,7 +103,7 @@ bool check(uint8_t* result, int rows, int elements) {
 }
 
 template <int lanes, int leftover>
-void test_2(uint8_t* in, uint8_t* out) {
+void test_2(std::uint8_t* in, std::uint8_t* out) {
   for (int elements = 8; elements < 64; elements += 8) {
     int all_elements = elements + leftover;
     for (int stride = all_elements; stride < all_elements + 4; ++stride) {
@@ -114,7 +114,7 @@ void test_2(uint8_t* in, uint8_t* out) {
       params.additive_sum_offset = ADD_OFFSET;
 
       prepare_row_major_data(lanes, all_elements, stride, in);
-      Stream<uint8_t, lanes, 8, leftover, RowMajorWithSum>::Pack(in, params,
+      Stream<std::uint8_t, lanes, 8, leftover, RowMajorWithSum>::Pack(in, params,
                                                                  out);
       if (check(out, lanes, all_elements)) {
         //        std::cout << "Row: " << lanes << "x8x" << leftover << " : "
@@ -136,7 +136,7 @@ void test_2(uint8_t* in, uint8_t* out) {
       params.additive_sum_offset = ADD_OFFSET;
 
       prepare_column_major_data(lanes, all_elements, stride, in);
-      Stream<uint8_t, lanes, 8, leftover, ColumnMajorWithSum>::Pack(in, params,
+      Stream<std::uint8_t, lanes, 8, leftover, ColumnMajorWithSum>::Pack(in, params,
                                                                     out);
       if (check(out, lanes, all_elements)) {
         //        std::cout << "Column: " << lanes << "x8x" << leftover << " : "
@@ -153,7 +153,7 @@ void test_2(uint8_t* in, uint8_t* out) {
 }
 
 template <int lanes>
-void test(uint8_t* in, uint8_t* out) {
+void test(std::uint8_t* in, std::uint8_t* out) {
   test_2<lanes, 0>(in, out);
   test_2<lanes, 1>(in, out);
   test_2<lanes, 2>(in, out);
@@ -165,8 +165,8 @@ void test(uint8_t* in, uint8_t* out) {
 }
 
 int main() {
-  std::unique_ptr<uint8_t> in(new uint8_t[128 * 1024]);
-  std::unique_ptr<uint8_t> out(new uint8_t[128 * 1024]);
+  std::unique_ptr<std::uint8_t> in(new std::uint8_t[128 * 1024]);
+  std::unique_ptr<std::uint8_t> out(new std::uint8_t[128 * 1024]);
 
   test<1>(in.get(), out.get());
   test<2>(in.get(), out.get());

--- a/meta/test_transform_benchmark.cc
+++ b/meta/test_transform_benchmark.cc
@@ -66,7 +66,7 @@ void run_benchmark(const std::string& name, int repetitions, int elements,
   double wall_time = time() - start;
   double ops = static_cast<double>(elements) * repetitions;
   std::cout << "Avg: " << (wall_time / repetitions) << std::endl;
-  std::cout << "Perf: " << static_cast<int64_t>(ops / wall_time) << "/s."
+  std::cout << "Perf: " << static_cast<std::int64_t>(ops / wall_time) << "/s."
             << std::endl;
 
   std::cout << "Warmup single." << std::endl;
@@ -86,7 +86,7 @@ void run_benchmark(const std::string& name, int repetitions, int elements,
   wall_time = time() - start;
   ops = static_cast<double>(elements) * repetitions;
   std::cout << "Avg: " << (wall_time / repetitions) << std::endl;
-  std::cout << "Perf: " << static_cast<int64_t>(ops / wall_time) << "/s."
+  std::cout << "Perf: " << static_cast<std::int64_t>(ops / wall_time) << "/s."
             << std::endl;
 }
 
@@ -94,56 +94,56 @@ int main() {
   const int repetitions = 500;
   const int elements = 4 * 1024 * 1024;
 
-  std::unique_ptr<int32_t[]> int32_array(new int32_t[elements]);
-  std::unique_ptr<uint8_t[]> uint8_array(new uint8_t[elements]);
+  std::unique_ptr<std::int32_t[]> int32_array(new std::int32_t[elements]);
+  std::unique_ptr<std::uint8_t[]> uint8_array(new std::uint8_t[elements]);
   std::unique_ptr<float[]> float_array(new float[elements]);
 
   typedef SimpleContext<gemmlowp::WorkersPool> Context;
   Context context(4, new gemmlowp::WorkersPool());
 
-  typedef Transform1DParams<int32_t, uint8_t, Requantize> RequantizeParams;
+  typedef Transform1DParams<std::int32_t, std::uint8_t, Requantize> RequantizeParams;
   RequantizeParams requantize_params;
   requantize_params.input = int32_array.get();
   requantize_params.output = uint8_array.get();
   requantize_params.kernel.count = elements;
   requantize_params.kernel.input_range_min = -100.0f;
   requantize_params.kernel.input_range_scale =
-      200.0f / ((static_cast<int64_t>(1) << 32) - 1);
+      200.0f / ((static_cast<std::int64_t>(1) << 32) - 1);
   requantize_params.kernel.input_range_offset =
-      static_cast<float>(std::numeric_limits<int32_t>::lowest());
+      static_cast<float>(std::numeric_limits<std::int32_t>::lowest());
   requantize_params.kernel.output_range_min = -200.0f;
   requantize_params.kernel.one_over_output_range_scale =
-      static_cast<float>((static_cast<int64_t>(1) << 8) - 1) / 500.0f;
+      static_cast<float>((static_cast<std::int64_t>(1) << 8) - 1) / 500.0f;
   requantize_params.kernel.output_range_offset =
-      static_cast<float>(std::numeric_limits<uint8_t>::lowest());
+      static_cast<float>(std::numeric_limits<std::uint8_t>::lowest());
 
   run_benchmark("Requantize", repetitions, elements, &context,
                 requantize_params);
 
-  typedef Transform1DParams<uint8_t, float, Dequantize> DequantizeParams;
+  typedef Transform1DParams<std::uint8_t, float, Dequantize> DequantizeParams;
   DequantizeParams dequantize_params;
   dequantize_params.input = uint8_array.get();
   dequantize_params.output = float_array.get();
   dequantize_params.kernel.count = elements;
   dequantize_params.kernel.range_min = -100.0f;
   dequantize_params.kernel.range_scale =
-      static_cast<float>((static_cast<int64_t>(1) << 8) - 1) / 200.0f;
+      static_cast<float>((static_cast<std::int64_t>(1) << 8) - 1) / 200.0f;
   dequantize_params.kernel.range_offset =
-      static_cast<float>(std::numeric_limits<uint8_t>::lowest());
+      static_cast<float>(std::numeric_limits<std::uint8_t>::lowest());
 
   run_benchmark("Dequantize", repetitions, elements, &context,
                 dequantize_params);
 
-  typedef Transform1DParams<float, uint8_t, Quantize> QuantizeParams;
+  typedef Transform1DParams<float, std::uint8_t, Quantize> QuantizeParams;
   QuantizeParams quantize_params;
   quantize_params.input = float_array.get();
   quantize_params.output = uint8_array.get();
   quantize_params.kernel.count = elements;
   quantize_params.kernel.range_min = -100.0f;
   quantize_params.kernel.range_scale =
-      200.0f / ((static_cast<int64_t>(1) << 8) - 1);
+      200.0f / ((static_cast<std::int64_t>(1) << 8) - 1);
   quantize_params.kernel.range_offset =
-      static_cast<float>(std::numeric_limits<uint8_t>::lowest());
+      static_cast<float>(std::numeric_limits<std::uint8_t>::lowest());
 
   run_benchmark("Quantize", repetitions, elements, &context, quantize_params);
 

--- a/meta/transform_kernels_arm_32.h
+++ b/meta/transform_kernels_arm_32.h
@@ -24,12 +24,12 @@ namespace gemmlowp {
 namespace meta {
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 0>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 0>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 0>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 0>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -99,12 +99,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 0>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 1>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 1>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 1>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 1>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -196,12 +196,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 1>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 2>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 2>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 2>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 2>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -293,12 +293,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 2>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 3>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 3>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 3>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 3>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -392,12 +392,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 3>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 4>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 4>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 4>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 4>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -489,12 +489,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 4>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 5>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 5>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 5>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 5>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -595,12 +595,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 5>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 6>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 6>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 6>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 6>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -700,12 +700,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 6>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 7>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 7>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 7>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 7>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -807,12 +807,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 7>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 8>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 8>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 8>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 8>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -911,12 +911,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 8>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 9>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 9>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 9>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 9>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -1025,12 +1025,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 9>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 10>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 10>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 10>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 10>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -1139,12 +1139,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 10>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 11>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 11>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 11>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 11>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -1255,12 +1255,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 11>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 12>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 12>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 12>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 12>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -1369,12 +1369,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 12>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 13>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 13>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 13>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 13>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -1492,12 +1492,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 13>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 14>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 14>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 14>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 14>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -1614,12 +1614,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 14>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 15>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 15>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 15>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 15>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -1738,12 +1738,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 15>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 0>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 0>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 0>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 0>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -1799,12 +1799,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 0>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 1>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 1>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 1>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 1>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -1880,12 +1880,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 1>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 2>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 2>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 2>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 2>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -1961,12 +1961,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 2>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 3>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 3>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 3>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 3>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2044,12 +2044,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 3>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 4>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 4>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 4>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 4>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2125,12 +2125,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 4>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 5>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 5>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 5>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 5>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2213,12 +2213,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 5>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 6>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 6>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 6>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 6>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2300,12 +2300,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 6>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 7>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 7>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 7>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 7>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2389,12 +2389,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 7>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 8>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 8>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 8>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 8>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2475,12 +2475,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 8>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 9>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 9>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 9>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 9>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2569,12 +2569,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 9>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 10>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 10>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 10>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 10>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2663,12 +2663,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 10>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 11>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 11>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 11>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 11>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2759,12 +2759,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 11>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 12>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 12>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 12>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 12>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2853,12 +2853,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 12>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 13>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 13>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 13>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 13>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2954,12 +2954,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 13>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 14>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 14>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 14>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 14>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3054,12 +3054,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 14>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 15>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 15>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 15>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 15>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3156,12 +3156,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 15>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 0>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 0>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 0>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 0>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3217,12 +3217,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 0>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 1>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 1>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 1>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 1>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3298,12 +3298,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 1>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 2>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 2>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 2>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 2>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3379,12 +3379,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 2>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 3>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 3>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 3>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 3>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3462,12 +3462,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 3>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 4>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 4>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 4>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 4>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3543,12 +3543,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 4>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 5>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 5>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 5>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 5>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3631,12 +3631,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 5>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 6>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 6>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 6>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 6>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3718,12 +3718,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 6>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 7>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 7>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 7>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 7>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3807,12 +3807,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 7>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 8>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 8>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 8>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 8>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3893,12 +3893,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 8>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 9>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 9>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 9>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 9>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3987,12 +3987,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 9>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 10>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 10>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 10>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 10>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -4081,12 +4081,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 10>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 11>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 11>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 11>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 11>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -4177,12 +4177,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 11>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 12>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 12>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 12>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 12>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -4271,12 +4271,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 12>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 13>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 13>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 13>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 13>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -4372,12 +4372,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 13>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 14>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 14>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 14>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 14>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -4472,12 +4472,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 14>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 15>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 15>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 15>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 15>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -4574,14 +4574,14 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 15>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              0>::Transform(const uint8_t* input,
-                                            const MinMax<uint8_t>& params,
-                                            uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              0>::Transform(const std::uint8_t* input,
+                                            const MinMax<std::uint8_t>& params,
+                                            std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "0>::Transform()"
             << std::endl
             << std::flush;
@@ -4614,14 +4614,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              1>::Transform(const uint8_t* input,
-                                            const MinMax<uint8_t>& params,
-                                            uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              1>::Transform(const std::uint8_t* input,
+                                            const MinMax<std::uint8_t>& params,
+                                            std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "1>::Transform()"
             << std::endl
             << std::flush;
@@ -4670,14 +4670,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              2>::Transform(const uint8_t* input,
-                                            const MinMax<uint8_t>& params,
-                                            uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              2>::Transform(const std::uint8_t* input,
+                                            const MinMax<std::uint8_t>& params,
+                                            std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "2>::Transform()"
             << std::endl
             << std::flush;
@@ -4726,14 +4726,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              3>::Transform(const uint8_t* input,
-                                            const MinMax<uint8_t>& params,
-                                            uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              3>::Transform(const std::uint8_t* input,
+                                            const MinMax<std::uint8_t>& params,
+                                            std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "3>::Transform()"
             << std::endl
             << std::flush;
@@ -4784,14 +4784,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              4>::Transform(const uint8_t* input,
-                                            const MinMax<uint8_t>& params,
-                                            uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              4>::Transform(const std::uint8_t* input,
+                                            const MinMax<std::uint8_t>& params,
+                                            std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "4>::Transform()"
             << std::endl
             << std::flush;
@@ -4840,14 +4840,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              5>::Transform(const uint8_t* input,
-                                            const MinMax<uint8_t>& params,
-                                            uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              5>::Transform(const std::uint8_t* input,
+                                            const MinMax<std::uint8_t>& params,
+                                            std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "5>::Transform()"
             << std::endl
             << std::flush;
@@ -4898,14 +4898,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              6>::Transform(const uint8_t* input,
-                                            const MinMax<uint8_t>& params,
-                                            uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              6>::Transform(const std::uint8_t* input,
+                                            const MinMax<std::uint8_t>& params,
+                                            std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "6>::Transform()"
             << std::endl
             << std::flush;
@@ -4956,14 +4956,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              7>::Transform(const uint8_t* input,
-                                            const MinMax<uint8_t>& params,
-                                            uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              7>::Transform(const std::uint8_t* input,
+                                            const MinMax<std::uint8_t>& params,
+                                            std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "7>::Transform()"
             << std::endl
             << std::flush;
@@ -5016,14 +5016,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              8>::Transform(const uint8_t* input,
-                                            const MinMax<uint8_t>& params,
-                                            uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              8>::Transform(const std::uint8_t* input,
+                                            const MinMax<std::uint8_t>& params,
+                                            std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "8>::Transform()"
             << std::endl
             << std::flush;
@@ -5072,14 +5072,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              9>::Transform(const uint8_t* input,
-                                            const MinMax<uint8_t>& params,
-                                            uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              9>::Transform(const std::uint8_t* input,
+                                            const MinMax<std::uint8_t>& params,
+                                            std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "9>::Transform()"
             << std::endl
             << std::flush;
@@ -5130,14 +5130,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              10>::Transform(const uint8_t* input,
-                                             const MinMax<uint8_t>& params,
-                                             uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              10>::Transform(const std::uint8_t* input,
+                                             const MinMax<std::uint8_t>& params,
+                                             std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "10>::Transform()"
             << std::endl
             << std::flush;
@@ -5188,14 +5188,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              11>::Transform(const uint8_t* input,
-                                             const MinMax<uint8_t>& params,
-                                             uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              11>::Transform(const std::uint8_t* input,
+                                             const MinMax<std::uint8_t>& params,
+                                             std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "11>::Transform()"
             << std::endl
             << std::flush;
@@ -5248,14 +5248,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              12>::Transform(const uint8_t* input,
-                                             const MinMax<uint8_t>& params,
-                                             uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              12>::Transform(const std::uint8_t* input,
+                                             const MinMax<std::uint8_t>& params,
+                                             std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "12>::Transform()"
             << std::endl
             << std::flush;
@@ -5306,14 +5306,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              13>::Transform(const uint8_t* input,
-                                             const MinMax<uint8_t>& params,
-                                             uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              13>::Transform(const std::uint8_t* input,
+                                             const MinMax<std::uint8_t>& params,
+                                             std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "13>::Transform()"
             << std::endl
             << std::flush;
@@ -5366,14 +5366,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              14>::Transform(const uint8_t* input,
-                                             const MinMax<uint8_t>& params,
-                                             uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              14>::Transform(const std::uint8_t* input,
+                                             const MinMax<std::uint8_t>& params,
+                                             std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "14>::Transform()"
             << std::endl
             << std::flush;
@@ -5426,14 +5426,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              15>::Transform(const uint8_t* input,
-                                             const MinMax<uint8_t>& params,
-                                             uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              15>::Transform(const std::uint8_t* input,
+                                             const MinMax<std::uint8_t>& params,
+                                             std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "15>::Transform()"
             << std::endl
             << std::flush;
@@ -5488,14 +5488,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              0>::Transform(const uint8_t* input,
-                                            const BiasAdd<uint8_t>& params,
-                                            int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              0>::Transform(const std::uint8_t* input,
+                                            const BiasAdd<std::uint8_t>& params,
+                                            std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "0>::Transform()"
             << std::endl
             << std::flush;
@@ -5606,14 +5606,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              1>::Transform(const uint8_t* input,
-                                            const BiasAdd<uint8_t>& params,
-                                            int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              1>::Transform(const std::uint8_t* input,
+                                            const BiasAdd<std::uint8_t>& params,
+                                            std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "1>::Transform()"
             << std::endl
             << std::flush;
@@ -5750,14 +5750,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              2>::Transform(const uint8_t* input,
-                                            const BiasAdd<uint8_t>& params,
-                                            int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              2>::Transform(const std::uint8_t* input,
+                                            const BiasAdd<std::uint8_t>& params,
+                                            std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "2>::Transform()"
             << std::endl
             << std::flush;
@@ -5894,14 +5894,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              3>::Transform(const uint8_t* input,
-                                            const BiasAdd<uint8_t>& params,
-                                            int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              3>::Transform(const std::uint8_t* input,
+                                            const BiasAdd<std::uint8_t>& params,
+                                            std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "3>::Transform()"
             << std::endl
             << std::flush;
@@ -6041,14 +6041,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              4>::Transform(const uint8_t* input,
-                                            const BiasAdd<uint8_t>& params,
-                                            int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              4>::Transform(const std::uint8_t* input,
+                                            const BiasAdd<std::uint8_t>& params,
+                                            std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "4>::Transform()"
             << std::endl
             << std::flush;
@@ -6185,14 +6185,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              5>::Transform(const uint8_t* input,
-                                            const BiasAdd<uint8_t>& params,
-                                            int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              5>::Transform(const std::uint8_t* input,
+                                            const BiasAdd<std::uint8_t>& params,
+                                            std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "5>::Transform()"
             << std::endl
             << std::flush;
@@ -6345,14 +6345,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              6>::Transform(const uint8_t* input,
-                                            const BiasAdd<uint8_t>& params,
-                                            int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              6>::Transform(const std::uint8_t* input,
+                                            const BiasAdd<std::uint8_t>& params,
+                                            std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "6>::Transform()"
             << std::endl
             << std::flush;
@@ -6504,14 +6504,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              7>::Transform(const uint8_t* input,
-                                            const BiasAdd<uint8_t>& params,
-                                            int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              7>::Transform(const std::uint8_t* input,
+                                            const BiasAdd<std::uint8_t>& params,
+                                            std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "7>::Transform()"
             << std::endl
             << std::flush;
@@ -6666,14 +6666,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              8>::Transform(const uint8_t* input,
-                                            const BiasAdd<uint8_t>& params,
-                                            int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              8>::Transform(const std::uint8_t* input,
+                                            const BiasAdd<std::uint8_t>& params,
+                                            std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "8>::Transform()"
             << std::endl
             << std::flush;
@@ -6823,14 +6823,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              9>::Transform(const uint8_t* input,
-                                            const BiasAdd<uint8_t>& params,
-                                            int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              9>::Transform(const std::uint8_t* input,
+                                            const BiasAdd<std::uint8_t>& params,
+                                            std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "9>::Transform()"
             << std::endl
             << std::flush;
@@ -6998,14 +6998,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              10>::Transform(const uint8_t* input,
-                                             const BiasAdd<uint8_t>& params,
-                                             int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              10>::Transform(const std::uint8_t* input,
+                                             const BiasAdd<std::uint8_t>& params,
+                                             std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "10>::Transform()"
             << std::endl
             << std::flush;
@@ -7173,14 +7173,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              11>::Transform(const uint8_t* input,
-                                             const BiasAdd<uint8_t>& params,
-                                             int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              11>::Transform(const std::uint8_t* input,
+                                             const BiasAdd<std::uint8_t>& params,
+                                             std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "11>::Transform()"
             << std::endl
             << std::flush;
@@ -7351,14 +7351,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              12>::Transform(const uint8_t* input,
-                                             const BiasAdd<uint8_t>& params,
-                                             int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              12>::Transform(const std::uint8_t* input,
+                                             const BiasAdd<std::uint8_t>& params,
+                                             std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "12>::Transform()"
             << std::endl
             << std::flush;
@@ -7526,14 +7526,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              13>::Transform(const uint8_t* input,
-                                             const BiasAdd<uint8_t>& params,
-                                             int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              13>::Transform(const std::uint8_t* input,
+                                             const BiasAdd<std::uint8_t>& params,
+                                             std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "13>::Transform()"
             << std::endl
             << std::flush;
@@ -7717,14 +7717,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              14>::Transform(const uint8_t* input,
-                                             const BiasAdd<uint8_t>& params,
-                                             int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              14>::Transform(const std::uint8_t* input,
+                                             const BiasAdd<std::uint8_t>& params,
+                                             std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "14>::Transform()"
             << std::endl
             << std::flush;
@@ -7907,14 +7907,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              15>::Transform(const uint8_t* input,
-                                             const BiasAdd<uint8_t>& params,
-                                             int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              15>::Transform(const std::uint8_t* input,
+                                             const BiasAdd<std::uint8_t>& params,
+                                             std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "15>::Transform()"
             << std::endl
             << std::flush;

--- a/meta/transform_kernels_arm_64.h
+++ b/meta/transform_kernels_arm_64.h
@@ -24,12 +24,12 @@ namespace gemmlowp {
 namespace meta {
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 0>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 0>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 0>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 0>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -97,12 +97,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 0>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 1>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 1>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 1>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 1>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -192,12 +192,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 1>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 2>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 2>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 2>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 2>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -287,12 +287,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 2>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 3>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 3>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 3>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 3>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -384,12 +384,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 3>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 4>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 4>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 4>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 4>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -479,12 +479,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 4>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 5>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 5>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 5>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 5>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -583,12 +583,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 5>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 6>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 6>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 6>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 6>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -687,12 +687,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 6>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 7>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 7>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 7>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 7>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -793,12 +793,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 7>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 8>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 8>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 8>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 8>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -895,12 +895,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 8>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 9>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 9>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 9>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 9>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -1007,12 +1007,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 9>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 10>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 10>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 10>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 10>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -1119,12 +1119,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 10>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 11>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 11>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 11>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 11>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -1233,12 +1233,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 11>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 12>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 12>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 12>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 12>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -1344,12 +1344,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 12>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 13>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 13>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 13>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 13>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -1464,12 +1464,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 13>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 14>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 14>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 14>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 14>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -1584,12 +1584,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 14>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 15>::Transform(
-    const int32_t* input, const Requantize& params, uint8_t* output) {
+inline void Transform1DKernel<std::int32_t, std::uint8_t, Requantize, 16, 15>::Transform(
+    const std::int32_t* input, const Requantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Requantize<int32_t, uint8_t, Requantize, 16, 15>::Transform()"
+            << ") Requantize<std::int32_t, std::uint8_t, Requantize, 16, 15>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -1706,12 +1706,12 @@ inline void Transform1DKernel<int32_t, uint8_t, Requantize, 16, 15>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 0>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 0>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 0>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 0>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -1765,12 +1765,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 0>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 1>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 1>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 1>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 1>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -1844,12 +1844,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 1>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 2>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 2>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 2>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 2>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -1923,12 +1923,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 2>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 3>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 3>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 3>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 3>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2004,12 +2004,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 3>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 4>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 4>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 4>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 4>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2083,12 +2083,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 4>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 5>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 5>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 5>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 5>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2169,12 +2169,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 5>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 6>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 6>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 6>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 6>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2255,12 +2255,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 6>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 7>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 7>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 7>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 7>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2343,12 +2343,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 7>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 8>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 8>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 8>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 8>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2427,12 +2427,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 8>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 9>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 9>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 9>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 9>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2519,12 +2519,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 9>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 10>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 10>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 10>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 10>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2611,12 +2611,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 10>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 11>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 11>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 11>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 11>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2705,12 +2705,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 11>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 12>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 12>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 12>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 12>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2796,12 +2796,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 12>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 13>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 13>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 13>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 13>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2894,12 +2894,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 13>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 14>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 14>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 14>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 14>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -2992,12 +2992,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 14>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<float, uint8_t, Quantize, 16, 15>::Transform(
-    const float* input, const Quantize& params, uint8_t* output) {
+inline void Transform1DKernel<float, std::uint8_t, Quantize, 16, 15>::Transform(
+    const float* input, const Quantize& params, std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Quantize<float, uint8_t, Quantize, 16, 15>::Transform()"
+            << ") Quantize<float, std::uint8_t, Quantize, 16, 15>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3092,12 +3092,12 @@ inline void Transform1DKernel<float, uint8_t, Quantize, 16, 15>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 0>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 0>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 0>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 0>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3151,12 +3151,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 0>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 1>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 1>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 1>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 1>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3230,12 +3230,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 1>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 2>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 2>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 2>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 2>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3309,12 +3309,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 2>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 3>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 3>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 3>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 3>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3390,12 +3390,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 3>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 4>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 4>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 4>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 4>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3469,12 +3469,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 4>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 5>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 5>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 5>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 5>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3555,12 +3555,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 5>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 6>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 6>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 6>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 6>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3641,12 +3641,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 6>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 7>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 7>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 7>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 7>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3729,12 +3729,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 7>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 8>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 8>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 8>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 8>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3813,12 +3813,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 8>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 9>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 9>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 9>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 9>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3905,12 +3905,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 9>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 10>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 10>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 10>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 10>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -3997,12 +3997,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 10>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 11>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 11>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 11>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 11>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -4091,12 +4091,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 11>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 12>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 12>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 12>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 12>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -4182,12 +4182,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 12>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 13>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 13>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 13>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 13>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -4280,12 +4280,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 13>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 14>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 14>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 14>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 14>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -4378,12 +4378,12 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 14>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 15>::Transform(
-    const uint8_t* input, const Dequantize& params, float* output) {
+inline void Transform1DKernel<std::uint8_t, float, Dequantize, 16, 15>::Transform(
+    const std::uint8_t* input, const Dequantize& params, float* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") Dequantize<uint8_t, float, Dequantize, 16, 15>::Transform()"
+            << ") Dequantize<std::uint8_t, float, Dequantize, 16, 15>::Transform()"
             << std::endl
             << std::flush;
 #endif
@@ -4478,14 +4478,14 @@ inline void Transform1DKernel<uint8_t, float, Dequantize, 16, 15>::Transform(
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              0>::Transform(const uint8_t* input,
-                                            const MinMax<uint8_t>& params,
-                                            uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              0>::Transform(const std::uint8_t* input,
+                                            const MinMax<std::uint8_t>& params,
+                                            std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "0>::Transform()"
             << std::endl
             << std::flush;
@@ -4518,14 +4518,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              1>::Transform(const uint8_t* input,
-                                            const MinMax<uint8_t>& params,
-                                            uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              1>::Transform(const std::uint8_t* input,
+                                            const MinMax<std::uint8_t>& params,
+                                            std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "1>::Transform()"
             << std::endl
             << std::flush;
@@ -4574,14 +4574,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              2>::Transform(const uint8_t* input,
-                                            const MinMax<uint8_t>& params,
-                                            uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              2>::Transform(const std::uint8_t* input,
+                                            const MinMax<std::uint8_t>& params,
+                                            std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "2>::Transform()"
             << std::endl
             << std::flush;
@@ -4630,14 +4630,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              3>::Transform(const uint8_t* input,
-                                            const MinMax<uint8_t>& params,
-                                            uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              3>::Transform(const std::uint8_t* input,
+                                            const MinMax<std::uint8_t>& params,
+                                            std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "3>::Transform()"
             << std::endl
             << std::flush;
@@ -4688,14 +4688,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              4>::Transform(const uint8_t* input,
-                                            const MinMax<uint8_t>& params,
-                                            uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              4>::Transform(const std::uint8_t* input,
+                                            const MinMax<std::uint8_t>& params,
+                                            std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "4>::Transform()"
             << std::endl
             << std::flush;
@@ -4744,14 +4744,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              5>::Transform(const uint8_t* input,
-                                            const MinMax<uint8_t>& params,
-                                            uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              5>::Transform(const std::uint8_t* input,
+                                            const MinMax<std::uint8_t>& params,
+                                            std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "5>::Transform()"
             << std::endl
             << std::flush;
@@ -4802,14 +4802,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              6>::Transform(const uint8_t* input,
-                                            const MinMax<uint8_t>& params,
-                                            uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              6>::Transform(const std::uint8_t* input,
+                                            const MinMax<std::uint8_t>& params,
+                                            std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "6>::Transform()"
             << std::endl
             << std::flush;
@@ -4860,14 +4860,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              7>::Transform(const uint8_t* input,
-                                            const MinMax<uint8_t>& params,
-                                            uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              7>::Transform(const std::uint8_t* input,
+                                            const MinMax<std::uint8_t>& params,
+                                            std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "7>::Transform()"
             << std::endl
             << std::flush;
@@ -4920,14 +4920,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              8>::Transform(const uint8_t* input,
-                                            const MinMax<uint8_t>& params,
-                                            uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              8>::Transform(const std::uint8_t* input,
+                                            const MinMax<std::uint8_t>& params,
+                                            std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "8>::Transform()"
             << std::endl
             << std::flush;
@@ -4976,14 +4976,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              9>::Transform(const uint8_t* input,
-                                            const MinMax<uint8_t>& params,
-                                            uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              9>::Transform(const std::uint8_t* input,
+                                            const MinMax<std::uint8_t>& params,
+                                            std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "9>::Transform()"
             << std::endl
             << std::flush;
@@ -5034,14 +5034,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              10>::Transform(const uint8_t* input,
-                                             const MinMax<uint8_t>& params,
-                                             uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              10>::Transform(const std::uint8_t* input,
+                                             const MinMax<std::uint8_t>& params,
+                                             std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "10>::Transform()"
             << std::endl
             << std::flush;
@@ -5092,14 +5092,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              11>::Transform(const uint8_t* input,
-                                             const MinMax<uint8_t>& params,
-                                             uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              11>::Transform(const std::uint8_t* input,
+                                             const MinMax<std::uint8_t>& params,
+                                             std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "11>::Transform()"
             << std::endl
             << std::flush;
@@ -5152,14 +5152,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              12>::Transform(const uint8_t* input,
-                                             const MinMax<uint8_t>& params,
-                                             uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              12>::Transform(const std::uint8_t* input,
+                                             const MinMax<std::uint8_t>& params,
+                                             std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "12>::Transform()"
             << std::endl
             << std::flush;
@@ -5210,14 +5210,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              13>::Transform(const uint8_t* input,
-                                             const MinMax<uint8_t>& params,
-                                             uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              13>::Transform(const std::uint8_t* input,
+                                             const MinMax<std::uint8_t>& params,
+                                             std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "13>::Transform()"
             << std::endl
             << std::flush;
@@ -5270,14 +5270,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              14>::Transform(const uint8_t* input,
-                                             const MinMax<uint8_t>& params,
-                                             uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              14>::Transform(const std::uint8_t* input,
+                                             const MinMax<std::uint8_t>& params,
+                                             std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "14>::Transform()"
             << std::endl
             << std::flush;
@@ -5330,14 +5330,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
-                              15>::Transform(const uint8_t* input,
-                                             const MinMax<uint8_t>& params,
-                                             uint8_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16,
+                              15>::Transform(const std::uint8_t* input,
+                                             const MinMax<std::uint8_t>& params,
+                                             std::uint8_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") MinMax<uint8_t><uint8_t, uint8_t, MinMax<uint8_t>, 16, "
+            << ") MinMax<std::uint8_t><std::uint8_t, std::uint8_t, MinMax<std::uint8_t>, 16, "
                "15>::Transform()"
             << std::endl
             << std::flush;
@@ -5392,14 +5392,14 @@ inline void Transform1DKernel<uint8_t, uint8_t, MinMax<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              0>::Transform(const uint8_t* input,
-                                            const BiasAdd<uint8_t>& params,
-                                            int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              0>::Transform(const std::uint8_t* input,
+                                            const BiasAdd<std::uint8_t>& params,
+                                            std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "0>::Transform()"
             << std::endl
             << std::flush;
@@ -5507,14 +5507,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              1>::Transform(const uint8_t* input,
-                                            const BiasAdd<uint8_t>& params,
-                                            int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              1>::Transform(const std::uint8_t* input,
+                                            const BiasAdd<std::uint8_t>& params,
+                                            std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "1>::Transform()"
             << std::endl
             << std::flush;
@@ -5648,14 +5648,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              2>::Transform(const uint8_t* input,
-                                            const BiasAdd<uint8_t>& params,
-                                            int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              2>::Transform(const std::uint8_t* input,
+                                            const BiasAdd<std::uint8_t>& params,
+                                            std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "2>::Transform()"
             << std::endl
             << std::flush;
@@ -5789,14 +5789,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              3>::Transform(const uint8_t* input,
-                                            const BiasAdd<uint8_t>& params,
-                                            int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              3>::Transform(const std::uint8_t* input,
+                                            const BiasAdd<std::uint8_t>& params,
+                                            std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "3>::Transform()"
             << std::endl
             << std::flush;
@@ -5933,14 +5933,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              4>::Transform(const uint8_t* input,
-                                            const BiasAdd<uint8_t>& params,
-                                            int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              4>::Transform(const std::uint8_t* input,
+                                            const BiasAdd<std::uint8_t>& params,
+                                            std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "4>::Transform()"
             << std::endl
             << std::flush;
@@ -6074,14 +6074,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              5>::Transform(const uint8_t* input,
-                                            const BiasAdd<uint8_t>& params,
-                                            int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              5>::Transform(const std::uint8_t* input,
+                                            const BiasAdd<std::uint8_t>& params,
+                                            std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "5>::Transform()"
             << std::endl
             << std::flush;
@@ -6231,14 +6231,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              6>::Transform(const uint8_t* input,
-                                            const BiasAdd<uint8_t>& params,
-                                            int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              6>::Transform(const std::uint8_t* input,
+                                            const BiasAdd<std::uint8_t>& params,
+                                            std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "6>::Transform()"
             << std::endl
             << std::flush;
@@ -6388,14 +6388,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              7>::Transform(const uint8_t* input,
-                                            const BiasAdd<uint8_t>& params,
-                                            int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              7>::Transform(const std::uint8_t* input,
+                                            const BiasAdd<std::uint8_t>& params,
+                                            std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "7>::Transform()"
             << std::endl
             << std::flush;
@@ -6548,14 +6548,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              8>::Transform(const uint8_t* input,
-                                            const BiasAdd<uint8_t>& params,
-                                            int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              8>::Transform(const std::uint8_t* input,
+                                            const BiasAdd<std::uint8_t>& params,
+                                            std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "8>::Transform()"
             << std::endl
             << std::flush;
@@ -6702,14 +6702,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              9>::Transform(const uint8_t* input,
-                                            const BiasAdd<uint8_t>& params,
-                                            int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              9>::Transform(const std::uint8_t* input,
+                                            const BiasAdd<std::uint8_t>& params,
+                                            std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "9>::Transform()"
             << std::endl
             << std::flush;
@@ -6874,14 +6874,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              10>::Transform(const uint8_t* input,
-                                             const BiasAdd<uint8_t>& params,
-                                             int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              10>::Transform(const std::uint8_t* input,
+                                             const BiasAdd<std::uint8_t>& params,
+                                             std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "10>::Transform()"
             << std::endl
             << std::flush;
@@ -7046,14 +7046,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              11>::Transform(const uint8_t* input,
-                                             const BiasAdd<uint8_t>& params,
-                                             int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              11>::Transform(const std::uint8_t* input,
+                                             const BiasAdd<std::uint8_t>& params,
+                                             std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "11>::Transform()"
             << std::endl
             << std::flush;
@@ -7221,14 +7221,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              12>::Transform(const uint8_t* input,
-                                             const BiasAdd<uint8_t>& params,
-                                             int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              12>::Transform(const std::uint8_t* input,
+                                             const BiasAdd<std::uint8_t>& params,
+                                             std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "12>::Transform()"
             << std::endl
             << std::flush;
@@ -7392,14 +7392,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              13>::Transform(const uint8_t* input,
-                                             const BiasAdd<uint8_t>& params,
-                                             int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              13>::Transform(const std::uint8_t* input,
+                                             const BiasAdd<std::uint8_t>& params,
+                                             std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "13>::Transform()"
             << std::endl
             << std::flush;
@@ -7579,14 +7579,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              14>::Transform(const uint8_t* input,
-                                             const BiasAdd<uint8_t>& params,
-                                             int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              14>::Transform(const std::uint8_t* input,
+                                             const BiasAdd<std::uint8_t>& params,
+                                             std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "14>::Transform()"
             << std::endl
             << std::flush;
@@ -7766,14 +7766,14 @@ inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
 }
 
 template <>
-inline void Transform1DKernel<uint8_t, int32_t, BiasAdd<uint8_t>, 16,
-                              15>::Transform(const uint8_t* input,
-                                             const BiasAdd<uint8_t>& params,
-                                             int32_t* output) {
+inline void Transform1DKernel<std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16,
+                              15>::Transform(const std::uint8_t* input,
+                                             const BiasAdd<std::uint8_t>& params,
+                                             std::int32_t* output) {
 #ifdef DEBUG
 #ifdef DEBUG_METAGEMM_VERBOSE
   std::cout << __FILE__ << "(" << __LINE__
-            << ") BiasAdd<uint8_t><uint8_t, int32_t, BiasAdd<uint8_t>, 16, "
+            << ") BiasAdd<std::uint8_t><std::uint8_t, std::int32_t, BiasAdd<std::uint8_t>, 16, "
                "15>::Transform()"
             << std::endl
             << std::flush;

--- a/standalone/neon-gemm-kernel-benchmark.cc
+++ b/standalone/neon-gemm-kernel-benchmark.cc
@@ -2701,11 +2701,11 @@ double benchmark() {
   CacheLineAlignedBuffer<OperandType> rhs(Kernel::Format::Rhs::kWidth * depth);
   CacheLineAlignedBuffer<AccumulatorType> accum(Kernel::Format::Lhs::kWidth * Kernel::Format::Rhs::kWidth);
 
-  uint64_t iters_at_a_time = 1;
+  std::uint64_t iters_at_a_time = 1;
 
-  for (uint64_t iters_at_a_time = 1; ; iters_at_a_time *= 2) {
+  for (std::uint64_t iters_at_a_time = 1; ; iters_at_a_time *= 2) {
     const double t_start = current_time_in_seconds();
-    for (uint64_t i = 0; i < iters_at_a_time; i++) {
+    for (std::uint64_t i = 0; i < iters_at_a_time; i++) {
       Kernel::Run(lhs.data(), rhs.data(), accum.data(), depth);
     }
     const double t_end = current_time_in_seconds();

--- a/test/benchmark.cc
+++ b/test/benchmark.cc
@@ -38,9 +38,9 @@
 #endif
 
 #if defined(__SSE4_2__) && !defined(GEMMLOWP_SSE4)
-#warning "Building without SSE4.2 support on SSE4.2 enabled machine, check your compiler setup!"
+#warning \
+    "Building without SSE4.2 support on SSE4.2 enabled machine, check your compiler setup!"
 #endif
-
 
 namespace gemmlowp {
 

--- a/test/correctness_meta_gemm.cc
+++ b/test/correctness_meta_gemm.cc
@@ -261,8 +261,9 @@ void test_i32(std::uint8_t* scratch, std::uint8_t* lhs, std::uint8_t* rhs,
 }
 
 void q_suite(int mi, int ni, int ki, int mx, int nx, int kx, int md, int nd,
-             int kd, std::uint8_t* scratch, std::uint8_t* left, std::uint8_t* right,
-             std::uint8_t* result, gemmlowp::WorkersPool* pool, int t) {
+             int kd, std::uint8_t* scratch, std::uint8_t* left,
+             std::uint8_t* right, std::uint8_t* result,
+             gemmlowp::WorkersPool* pool, int t) {
   for (int m = mi; m < mx; m += md) {
     for (int n = ni; n < nx; n += nd) {
       for (int k = ki; k < kx; k += kd) {
@@ -274,8 +275,9 @@ void q_suite(int mi, int ni, int ki, int mx, int nx, int kx, int md, int nd,
 }
 
 void f_suite(int mi, int ni, int ki, int mx, int nx, int kx, int md, int nd,
-             int kd, std::uint8_t* scratch, std::uint8_t* left, std::uint8_t* right,
-             float* result, gemmlowp::WorkersPool* pool, int t) {
+             int kd, std::uint8_t* scratch, std::uint8_t* left,
+             std::uint8_t* right, float* result, gemmlowp::WorkersPool* pool,
+             int t) {
   for (int m = mi; m < mx; m += md) {
     for (int n = ni; n < nx; n += nd) {
       for (int k = ki; k < kx; k += kd) {
@@ -287,8 +289,9 @@ void f_suite(int mi, int ni, int ki, int mx, int nx, int kx, int md, int nd,
 }
 
 void i32_suite(int mi, int ni, int ki, int mx, int nx, int kx, int md, int nd,
-               int kd, std::uint8_t* scratch, std::uint8_t* left, std::uint8_t* right,
-               std::int32_t* result, gemmlowp::WorkersPool* pool, int t) {
+               int kd, std::uint8_t* scratch, std::uint8_t* left,
+               std::uint8_t* right, std::int32_t* result,
+               gemmlowp::WorkersPool* pool, int t) {
   for (int m = mi; m < mx; m += md) {
     for (int n = ni; n < nx; n += nd) {
       for (int k = ki; k < kx; k += kd) {

--- a/test/correctness_meta_gemm.cc
+++ b/test/correctness_meta_gemm.cc
@@ -46,7 +46,7 @@ double time() {
 
 void prepare_test_data(std::uint8_t* data, std::int32_t rows, std::int32_t cols,
                        std::int32_t seed, std::int32_t seed_2) {
-  int32_t value = seed;
+  std::int32_t value = seed;
   for (int i = 0; i < rows; ++i) {
     for (int j = 0; j < cols; ++j) {
       data[i * cols + j] = static_cast<std::uint8_t>(value);
@@ -183,7 +183,7 @@ void check_result_i32(std::uint8_t* left, std::uint8_t* right,
             (static_cast<std::int32_t>(left[depth * i + k]) + lhs_offset) *
             (static_cast<std::int32_t>(right[depth * j + k]) + rhs_offset);
       }
-      int32_t actual = result[i * cols + j];
+      std::int32_t actual = result[i * cols + j];
       if (actual == expected) {
         if (!quiet) {
           if (verbose) {
@@ -261,8 +261,8 @@ void test_i32(std::uint8_t* scratch, std::uint8_t* lhs, std::uint8_t* rhs,
 }
 
 void q_suite(int mi, int ni, int ki, int mx, int nx, int kx, int md, int nd,
-             int kd, uint8_t* scratch, uint8_t* left, uint8_t* right,
-             uint8_t* result, gemmlowp::WorkersPool* pool, int t) {
+             int kd, std::uint8_t* scratch, std::uint8_t* left, std::uint8_t* right,
+             std::uint8_t* result, gemmlowp::WorkersPool* pool, int t) {
   for (int m = mi; m < mx; m += md) {
     for (int n = ni; n < nx; n += nd) {
       for (int k = ki; k < kx; k += kd) {
@@ -274,7 +274,7 @@ void q_suite(int mi, int ni, int ki, int mx, int nx, int kx, int md, int nd,
 }
 
 void f_suite(int mi, int ni, int ki, int mx, int nx, int kx, int md, int nd,
-             int kd, uint8_t* scratch, uint8_t* left, uint8_t* right,
+             int kd, std::uint8_t* scratch, std::uint8_t* left, std::uint8_t* right,
              float* result, gemmlowp::WorkersPool* pool, int t) {
   for (int m = mi; m < mx; m += md) {
     for (int n = ni; n < nx; n += nd) {
@@ -287,8 +287,8 @@ void f_suite(int mi, int ni, int ki, int mx, int nx, int kx, int md, int nd,
 }
 
 void i32_suite(int mi, int ni, int ki, int mx, int nx, int kx, int md, int nd,
-               int kd, uint8_t* scratch, uint8_t* left, uint8_t* right,
-               int32_t* result, gemmlowp::WorkersPool* pool, int t) {
+               int kd, std::uint8_t* scratch, std::uint8_t* left, std::uint8_t* right,
+               std::int32_t* result, gemmlowp::WorkersPool* pool, int t) {
   for (int m = mi; m < mx; m += md) {
     for (int n = ni; n < nx; n += nd) {
       for (int k = ki; k < kx; k += kd) {

--- a/test/test.cc
+++ b/test/test.cc
@@ -35,10 +35,10 @@ namespace gemmlowp {
 
 void ReferenceEightBitIntGemm(bool transpose_a, bool transpose_b,
                               bool transpose_c, int m, int n, int k,
-                              const uint8_t* a, int32_t a_offset, int lda,
-                              const uint8_t* b, int32_t b_offset, int ldb,
-                              uint8_t* c, int32_t c_offset, int32_t c_mult_int,
-                              int32_t c_shift, int ldc) {
+                              const std::uint8_t* a, std::int32_t a_offset, int lda,
+                              const std::uint8_t* b, std::int32_t b_offset, int ldb,
+                              std::uint8_t* c, std::int32_t c_offset, std::int32_t c_mult_int,
+                              std::int32_t c_shift, int ldc) {
   assert((c_shift >= 0) && (c_shift <= 32));
 
   assert(a != nullptr);
@@ -78,18 +78,18 @@ void ReferenceEightBitIntGemm(bool transpose_a, bool transpose_b,
 
   for (j = 0; j < n; j++) {
     for (i = 0; i < m; i++) {
-      int32_t total = 0;
+      std::int32_t total = 0;
       for (l = 0; l < k; l++) {
         const int a_index = i * a_i_stride + l * a_l_stride;
-        const uint8_t a_as_byte = a[a_index];
-        const int32_t a_as_int = static_cast<int32_t>(a_as_byte) + a_offset;
+        const std::uint8_t a_as_byte = a[a_index];
+        const std::int32_t a_as_int = static_cast<std::int32_t>(a_as_byte) + a_offset;
         const int b_index = j * b_j_stride + l * b_l_stride;
-        const uint8_t b_as_byte = b[b_index];
-        const int32_t b_as_int = static_cast<int32_t>(b_as_byte) + b_offset;
-        const int32_t mult_as_int = a_as_int * b_as_int;
+        const std::uint8_t b_as_byte = b[b_index];
+        const std::int32_t b_as_int = static_cast<std::int32_t>(b_as_byte) + b_offset;
+        const std::int32_t mult_as_int = a_as_int * b_as_int;
         total += mult_as_int;
       }
-      int32_t output =
+      std::int32_t output =
           (((total + c_offset) * c_mult_int) + kRoundingTerm) >> c_shift;
       if (output > 255) {
         output = 255;
@@ -98,7 +98,7 @@ void ReferenceEightBitIntGemm(bool transpose_a, bool transpose_b,
         output = 0;
       }
       const int c_index = i * c_i_stride + j * c_j_stride;
-      c[c_index] = static_cast<uint8_t>(output);
+      c[c_index] = static_cast<std::uint8_t>(output);
     }
   }
 }
@@ -181,7 +181,7 @@ struct PublicGemmWrapper {
                    MatrixMap<Scalar, ResultOrder>* result, int lhs_offset,
                    int rhs_offset, int result_offset, int result_mult_int,
                    int result_shift) {
-    gemmlowp::Gemm<uint8_t, BitDepthParams, LhsOrder, RhsOrder, ResultOrder>(
+    gemmlowp::Gemm<std::uint8_t, BitDepthParams, LhsOrder, RhsOrder, ResultOrder>(
         context, lhs, rhs, result, lhs_offset, rhs_offset, result_offset,
         result_mult_int, result_shift);
   }
@@ -267,15 +267,15 @@ struct ResultStats {
   std::vector<int> count_diff_by_pot_slice;
 };
 
-void GetResultStats(const uint8_t* actual, const uint8_t* expected,
+void GetResultStats(const std::uint8_t* actual, const std::uint8_t* expected,
                     size_t count, ResultStats* stats) {
-  std::vector<uint8_t> results;
-  std::vector<int16_t> signed_diffs;
-  std::vector<uint8_t> unsigned_diffs;
-  int64_t signed_diffs_sum = 0;
+  std::vector<std::uint8_t> results;
+  std::vector<std::int16_t> signed_diffs;
+  std::vector<std::uint8_t> unsigned_diffs;
+  std::int64_t signed_diffs_sum = 0;
   for (size_t i = 0; i < count; i++) {
     results.push_back(actual[i]);
-    int16_t signed_diff = actual[i] - expected[i];
+    std::int16_t signed_diff = actual[i] - expected[i];
     signed_diffs.push_back(signed_diff);
     unsigned_diffs.push_back(std::abs(signed_diff));
     signed_diffs_sum += signed_diff;
@@ -712,7 +712,7 @@ void TestWithSmallDataPerChannelQuantization() {
   const int k = 12;
 
   // 12 x 2, columnwise.
-  const uint8_t a_data[] = {0,  0,  0,  0,  0,  0,  0, 0, 0, 255, 255, 255,
+  const std::uint8_t a_data[] = {0,  0,  0,  0,  0,  0,  0, 0, 0, 255, 255, 255,
                             64, 64, 64, 64, 64, 64, 0, 0, 0, 255, 255, 255};
   const int lda = k;
   int a_offset[] = {0, -64};
@@ -720,7 +720,7 @@ void TestWithSmallDataPerChannelQuantization() {
   const OffsetColMap lhs_offset(a_offset, m);
 
   // 12 x 9, columnwise.
-  const uint8_t b_data[] = {
+  const std::uint8_t b_data[] = {
       0,   0,   0,   0,   0,   0,   0,   0,   0,   255, 255, 255, 0,   0,
       0,   0,   0,   0,   255, 255, 255, 0,   0,   0,   0,   0,   0,   127,
       127, 127, 0,   0,   0,   127, 127, 127, 0,   0,   0,   255, 255, 255,
@@ -735,7 +735,7 @@ void TestWithSmallDataPerChannelQuantization() {
   const OffsetRowDup rhs_offset(b_offset, rhs.cols());
 
   // 2 x 9, columnwise.
-  const uint8_t expected_c_data[] = {255, 255, 0,   0,   127, 159,
+  const std::uint8_t expected_c_data[] = {255, 255, 0,   0,   127, 159,
                                      0,   64,  0,   64,  127, 159,
                                      127, 127, 127, 127, 127, 127};
   const int ldc = m;
@@ -744,7 +744,7 @@ void TestWithSmallDataPerChannelQuantization() {
   const int c_shift = 21;
 
   const int c_count = m * n;
-  std::unique_ptr<uint8_t[]> output_data(new uint8_t[c_count]);
+  std::unique_ptr<std::uint8_t[]> output_data(new std::uint8_t[c_count]);
   MatrixMap<std::uint8_t, MapOrder::ColMajor> result(output_data.get(), m, n,
                                                      ldc);
   const OffsetColMap result_offset(c_offset, m);
@@ -754,7 +754,7 @@ void TestWithSmallDataPerChannelQuantization() {
   GemmContext gemm_context;
   auto output_pipeline = MakeStandardOutputPipeline<VectorShape::Col>(
       result_offset, result_mult_int, result_shift);
-  GemmWithOutputPipelinePC<uint8_t, uint8_t, DefaultL8R8BitDepthParams>(
+  GemmWithOutputPipelinePC<std::uint8_t, std::uint8_t, DefaultL8R8BitDepthParams>(
       &gemm_context, lhs, rhs, &result, lhs_offset, rhs_offset,
       output_pipeline);
 
@@ -780,7 +780,7 @@ void TestWithLargeDataPerChannelQuantization() {
   const int k = 27;
 
   // 27 x 22, column-wise.
-  const uint8_t a_data[] = {
+  const std::uint8_t a_data[] = {
       0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   255, 255, 255,
       0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   127, 127, 127, 255, 255, 255, 127, 127, 127,
@@ -829,7 +829,7 @@ void TestWithLargeDataPerChannelQuantization() {
   const OffsetColMap lhs_offset(a_offset, m);
 
   // 27 x 25, column-wise.
-  const uint8_t b_data[] = {
+  const std::uint8_t b_data[] = {
       127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127, 119, 119,
       119, 119, 119, 119, 127, 127, 127, 119, 119, 119, 119, 119, 119, 127,
       127, 127, 127, 127, 127, 127, 127, 127, 119, 119, 119, 119, 119, 119,
@@ -885,7 +885,7 @@ void TestWithLargeDataPerChannelQuantization() {
   const OffsetRowDup rhs_offset(b_offset, rhs.cols());
 
   // 22 x 25, column-wise.
-  const uint8_t expected_c_data[] = {
+  const std::uint8_t expected_c_data[] = {
       7,   37,  37,  67,  67,  39,  79,  7,   7,   7,   7,   7,   7,   7,   7,
       7,   7,   7,   7,   7,   7,   7,   7,   7,   37,  87,  67,  23,  91,  7,
       7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
@@ -940,7 +940,7 @@ void TestWithLargeDataPerChannelQuantization() {
   const int c_shift = 21;
 
   const int c_count = m * n;
-  std::unique_ptr<uint8_t[]> output_data(new uint8_t[c_count]);
+  std::unique_ptr<std::uint8_t[]> output_data(new std::uint8_t[c_count]);
   MatrixMap<std::uint8_t, MapOrder::ColMajor> result(output_data.get(), m, n,
                                                      ldc);
   const OffsetColMap result_offset(c_offset, m);
@@ -950,7 +950,7 @@ void TestWithLargeDataPerChannelQuantization() {
   GemmContext gemm_context;
   auto output_pipeline = MakeStandardOutputPipeline<VectorShape::Col>(
       result_offset, result_mult_int, result_shift);
-  GemmWithOutputPipelinePC<uint8_t, uint8_t, DefaultL8R8BitDepthParams>(
+  GemmWithOutputPipelinePC<std::uint8_t, std::uint8_t, DefaultL8R8BitDepthParams>(
       &gemm_context, lhs, rhs, &result, lhs_offset, rhs_offset,
       output_pipeline);
 
@@ -985,28 +985,28 @@ void TestMultithreadedPerChannelQuantization() {
   const int k = 160;
 
   // LHS, m x k.
-  const std::array<int32_t, 4> lhs_offsets_terse{{
+  const std::array<std::int32_t, 4> lhs_offsets_terse{{
       0, -51, -85, -109,
   }};
   assert(lhs_offsets_terse.size() * 16 == m);
-  const std::array<uint8_t, 4> lhs_first_el{{
+  const std::array<std::uint8_t, 4> lhs_first_el{{
       128, 153, 170, 182,
   }};
   assert(lhs_first_el.size() * 16 == m);
 
   // lhs_first_el at (i, 0) and 255 at (i, 1), other values are all -offset.
-  std::vector<uint8_t> a_data(m * k, 0);
+  std::vector<std::uint8_t> a_data(m * k, 0);
   for (int i = 0; i < m; ++i) {
     a_data[i * k] = lhs_first_el[i / 16];
     a_data[i * k + 1] = 255;
     for (int j = 2; j < k; ++j) {
-      a_data[i * k + j] = uint8_t(-lhs_offsets_terse[i / 16]);
+      a_data[i * k + j] = std::uint8_t(-lhs_offsets_terse[i / 16]);
     }
   }
 
   const int lda = k;
   // Given values at [i / 16].
-  std::vector<int32_t> a_offset(m, 0);
+  std::vector<std::int32_t> a_offset(m, 0);
   for (int i = 0; i < m; ++i) {
     a_offset[i] = lhs_offsets_terse[i / 16];
   }
@@ -1016,35 +1016,35 @@ void TestMultithreadedPerChannelQuantization() {
 
   // RHS, k x n.
   // All zeros, except 128 at (0, 0) and 255 at (1, 0).
-  std::vector<uint8_t> b_data(k * n, 0);
+  std::vector<std::uint8_t> b_data(k * n, 0);
   b_data[0] = 128;
   b_data[1] = 255;
 
   const int ldb = k;
-  int32_t b_offset = 0;
+  std::int32_t b_offset = 0;
   MatrixMap<const std::uint8_t, MapOrder::ColMajor> rhs(&b_data[0], k, n, ldb);
   const OffsetRowDup rhs_offset(b_offset, rhs.cols());
 
   // Result, m x n.
   // All zeros, except given values at (i / 16, 0).
-  const std::array<uint8_t, 4> expected_c_terse{{
+  const std::array<std::uint8_t, 4> expected_c_terse{{
       142, 159, 182, 213,
   }};
   assert(expected_c_terse.size() * 16 == m);
-  std::vector<uint8_t> expected_c_data(m * n, 0);
+  std::vector<std::uint8_t> expected_c_data(m * n, 0);
   for (int i = 0; i < m; ++i) {
     expected_c_data[i] = expected_c_terse[i / 16];
   }
 
   const int ldc = m;
   // All zeros.
-  std::vector<int32_t> c_offset(m, 0);
+  std::vector<std::int32_t> c_offset(m, 0);
   // Given values at [i / 16].
-  const std::array<int32_t, 4> c_mult_int_terse{{
+  const std::array<std::int32_t, 4> c_mult_int_terse{{
       3655, 5140, 7049, 9595,
   }};
   assert(c_mult_int_terse.size() * 16 == m);
-  std::vector<int32_t> c_mult_int(m);
+  std::vector<std::int32_t> c_mult_int(m);
   for (int i = 0; i < m; ++i) {
     c_mult_int[i] = c_mult_int_terse[i / 16];
   }
@@ -1052,7 +1052,7 @@ void TestMultithreadedPerChannelQuantization() {
   const int c_shift = 21;
 
   const int c_count = m * n;
-  std::unique_ptr<uint8_t[]> output_data(new uint8_t[c_count]);
+  std::unique_ptr<std::uint8_t[]> output_data(new std::uint8_t[c_count]);
   MatrixMap<std::uint8_t, MapOrder::ColMajor> result(output_data.get(), m, n,
                                                      ldc);
   const OffsetColMap result_offset(&c_offset[0], m);
@@ -1062,7 +1062,7 @@ void TestMultithreadedPerChannelQuantization() {
   GemmContext gemm_context;
   auto output_pipeline = MakeStandardOutputPipeline<VectorShape::Col>(
       result_offset, result_mult_int, result_shift);
-  GemmWithOutputPipelinePC<uint8_t, uint8_t, DefaultL8R8BitDepthParams>(
+  GemmWithOutputPipelinePC<std::uint8_t, std::uint8_t, DefaultL8R8BitDepthParams>(
       &gemm_context, lhs, rhs, &result, lhs_offset, rhs_offset,
       output_pipeline);
 
@@ -1086,11 +1086,11 @@ void TestWithSmallData() {
   // |  7 | 10 | 13 | 16 |
   // |  8 | 11 | 14 | 17 |
   // |  9 | 12 | 15 | 18 |
-  const uint8_t a_data[] = {7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18};
+  const std::uint8_t a_data[] = {7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18};
   // Matrix B (RHS) is:
   // |  1 |  3 |  5 |
   // |  2 |  4 |  6 |
-  const uint8_t b_data[] = {1, 2, 3, 4, 5, 6};
+  const std::uint8_t b_data[] = {1, 2, 3, 4, 5, 6};
   // Here are the results we expect, from hand calculations:
   // (1 * 7) + (3 * 8) + (5 * 9) = 76
   // (2 * 7) + (4 * 8) + (6 * 9) = 100
@@ -1103,10 +1103,10 @@ void TestWithSmallData() {
   // That means matrix C should be:
   // |  76 | 103 | 130 | 157 |
   // | 100 | 136 | 172 | 208 |
-  const uint8_t expected_data[] = {76, 100, 103, 136, 130, 172, 157, 208};
+  const std::uint8_t expected_data[] = {76, 100, 103, 136, 130, 172, 157, 208};
 
   const int c_count = m * n;
-  std::unique_ptr<uint8_t[]> output_data(new uint8_t[c_count]);
+  std::unique_ptr<std::uint8_t[]> output_data(new std::uint8_t[c_count]);
 
   const bool is_a_transposed = true;
   const bool is_b_transposed = true;
@@ -1141,7 +1141,7 @@ void TestWithSmallData() {
 // captured from an actual neural network run.
 void TestWithRealData(eight_bit_int_gemm::BitDepthSetting BitDepth,
                       int tolerance_median, int tolerance_max) {
-  std::unique_ptr<uint8_t[]> output_data(new uint8_t[test_data::c_count]);
+  std::unique_ptr<std::uint8_t[]> output_data(new std::uint8_t[test_data::c_count]);
   gemmlowp::eight_bit_int_gemm::EightBitIntGemm(
       test_data::is_a_transposed, test_data::is_b_transposed,
       test_data::is_c_transposed, test_data::m, test_data::n, test_data::k,
@@ -1479,9 +1479,9 @@ void TestExhaustively() {
       std::uint8_t, DefaultL8R8BitDepthParams>>(&context);
 
   // Test the public GEMM interfaces
-  test_gemm<PublicGemmWrapper<uint8_t, DefaultL8R8BitDepthParams>>(&context);
+  test_gemm<PublicGemmWrapper<std::uint8_t, DefaultL8R8BitDepthParams>>(&context);
 
-  test_gemm<EightBitIntGemmWrapper<uint8_t,
+  test_gemm<EightBitIntGemmWrapper<std::uint8_t,
                                    eight_bit_int_gemm::BitDepthSetting::A8B8>>(
       &context);
 
@@ -1495,9 +1495,9 @@ void TestExhaustively() {
       std::uint8_t, DefaultL8R8BitDepthParams>>(&context);
 
   // Test GEMV cases (public interfaces)
-  test_gemv<PublicGemmWrapper<uint8_t, DefaultL8R8BitDepthParams>>(&context);
+  test_gemv<PublicGemmWrapper<std::uint8_t, DefaultL8R8BitDepthParams>>(&context);
 
-  test_gemv<EightBitIntGemmWrapper<uint8_t,
+  test_gemv<EightBitIntGemmWrapper<std::uint8_t,
                                    eight_bit_int_gemm::BitDepthSetting::A8B8>>(
       &context);
 

--- a/test/test_fixedpoint.cc
+++ b/test/test_fixedpoint.cc
@@ -20,6 +20,23 @@
 
 using namespace gemmlowp;
 
+void test_RoundingDivideByPOT(std::int32_t x) {
+  double d = x;
+  for (int s = 0; s < 32; s++) {
+    const std::int32_t actual = RoundingDivideByPOT(x, s);
+    const std::int32_t expected = std::round(d);
+    Check(actual == expected);
+    d /= 2;
+  }
+}
+
+void test_RoundingDivideByPOT(const std::vector<std::int32_t>& testvals_int32) {
+  for (auto a : testvals_int32) {
+    test_RoundingDivideByPOT(a);
+  }
+}
+
+
 template <int tIntegerBits>
 void test_convert(FixedPoint<std::int32_t, tIntegerBits> x) {
   typedef FixedPoint<std::int32_t, tIntegerBits> F;
@@ -294,6 +311,8 @@ int main() {
   }
 
   std::sort(testvals_int32.begin(), testvals_int32.end());
+
+  test_RoundingDivideByPOT(testvals_int32);
 
   for (auto a : testvals_int32) {
     FixedPoint<std::int32_t, 4> x;

--- a/test/test_fixedpoint.cc
+++ b/test/test_fixedpoint.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// test_fixedpoint.cc: unit tests covering the fixedpoint/ directory.
+
 #define GEMMLOWP_ENABLE_FIXEDPOINT_CONSTANTS_CHECKS
 
 #include <algorithm>

--- a/test/test_fixedpoint.cc
+++ b/test/test_fixedpoint.cc
@@ -15,27 +15,287 @@
 #define GEMMLOWP_ENABLE_FIXEDPOINT_CONSTANTS_CHECKS
 
 #include "test.h"
+#include <cmath>
+#include <random>
+#include <vector>
+#include <algorithm>
 
 #include "../fixedpoint/fixedpoint.h"
 
-using namespace gemmlowp;
+namespace gemmlowp {
 
-void test_RoundingDivideByPOT(std::int32_t x) {
-  double d = x;
-  for (int s = 0; s < 32; s++) {
-    const std::int32_t actual = RoundingDivideByPOT(x, s);
-    const std::int32_t expected = std::round(d);
-    Check(actual == expected);
-    d /= 2;
+namespace {
+
+// Explanation of SimdVector type and associated functions
+// (LoadSimdVector, StoreSimdVector):
+// The fixedpoint stuff being tested here is generic in an underlying
+// integer type which may be either scalar (int32_t) or SIMD (e.g.
+// NEON int32x4_t). We want to write uniform tests that can test
+// both the scalar and SIMD paths. We achieve this by having this
+// generic SimdVector abstraction, local to this test.
+
+#ifdef GEMMLOWP_NEON
+using SimdVector = int32x4_t;
+constexpr std::size_t SimdVectorSize = 4;
+SimdVector LoadSimdVector(const std::int32_t* src) {
+  return vld1q_s32(src);
+}
+void StoreSimdVector(std::int32_t* dst, SimdVector v) {
+  vst1q_s32(dst, v);
+}
+#elif defined(GEMMLOWP_SSE4)
+using SimdVector = __m128i;
+constexpr std::size_t SimdVectorSize = 4;
+SimdVector LoadSimdVector(const std::int32_t* src) {
+  return _mm_loadu_si128(
+            reinterpret_cast<const __m128i*>(src));
+}
+void StoreSimdVector(std::int32_t* dst, SimdVector v) {
+  _mm_storeu_si128(
+            reinterpret_cast<__m128i*>(dst), v);
+}
+#else
+using SimdVector = std::int32_t;
+constexpr std::size_t SimdVectorSize = 1;
+SimdVector LoadSimdVector(const std::int32_t* src) {
+  return *src;
+}
+void StoreSimdVector(std::int32_t* dst, SimdVector v) {
+  *dst = v;
+}
+#endif
+
+// Explanation of UnaryOpBase, its *Op subclasses below, and TestUnaryOp:
+// Most (though not all) of the fixedpoint functionality being tested
+// consists of functions taking one fixedpoint value and returning one
+// fixedpoint value, e.g. "exp" or "tanh". We call them "unary operators".
+// We factor a lot of testing boilerplate into a common TestUnaryOp function
+// taking a "unary op" object that fully describes the function to be tested.
+// These objects inherit UnaryOpBase mostly as a means to share some default
+// values for some properties.
+//
+// An important design element here is that the fixed-point values are passed
+// around as raw integers (e.g. int32_t or SIMD types such as int32x4_t), not
+// as higher-level FixedPoint objects. The motivation for this design is 1) to
+// avoid having to templatize everything in the tIntegerBits parameter of
+// class FixedPoint, and 2) to allow directly testing low-level functions
+// operating on raw types (e.g. RoundingDivideByPOT) without needlessly requiring
+// wrapping raw values in FixedPoint objects.
+class UnaryOpBase {
+public:
+  // Min bound of the input range of this op. For example, an op only handling
+  // nonnegative values would return 0.
+  std::int32_t MinInput() const {
+    return std::numeric_limits<std::int32_t>::min();
+  }
+  // Max bound of the input range of this op. For example, an op only handling
+  // nonpositive values would return 0.
+  std::int32_t MaxInput() const {
+    return std::numeric_limits<std::int32_t>::max();
+  }
+  // Tolerated difference between actual and reference int32 values.
+  // Note that the corresponding real-numbers tolerance depends on the number
+  // of integer bits of the fixed-point representation of the results of this op.
+  // For example, for an op returning fixed-point values with 0 integer bits,
+  // the correspondence between real-number values and raw values is
+  // real_number = (2^31) * raw_value.
+  std::int32_t Tolerance() const {
+    return 0;
+  }
+};
+
+
+// Op wrapping RoundingDivideByPOT
+class RoundingDivideByPOTOp final : public UnaryOpBase {
+public:
+  RoundingDivideByPOTOp(int exponent) : exponent_(exponent) {}
+  std::int32_t ReferenceOp(std::int32_t x) const {
+    const double d = static_cast<double>(x) / (1ll << exponent_);
+    return static_cast<std::int32_t>(std::round(d));
+  }
+  template <typename tRawType>
+  tRawType Op(tRawType x) const {
+    return RoundingDivideByPOT(x, exponent_);
+  }
+private:
+  const int exponent_;
+};
+
+// Op wrapping exp_on_interval_between_negative_one_quarter_and_0_excl
+class ExpOnIntervalBetweenNegativeOneQuarterAnd0ExclOp final : public UnaryOpBase {
+public:
+  std::int32_t MinInput() const {
+    return -(1 << 29);
+  }
+  std::int32_t MaxInput() const {
+    return 0;
+  }
+  std::int32_t Tolerance() const {
+    return 500;
+  }
+  std::int32_t ReferenceOp(std::int32_t x) const {
+    using F = FixedPoint<std::int32_t, 0>;
+    const double d = ToDouble(F::FromRaw(x));
+    const double e = std::exp(d);
+    return F::FromDouble(e).raw();
+  }
+  template <typename tRawType>
+  tRawType Op(tRawType x) const {
+    using F = FixedPoint<tRawType, 0>;
+    const F f = F::FromRaw(x);
+    const F e = exp_on_interval_between_negative_one_quarter_and_0_excl(f);
+    return e.raw();
+  }
+};
+
+// Op wrapping exp_on_negative_values
+template <int tIntegerBits>
+class ExpOnNegativeValuesOp final : public UnaryOpBase {
+public:
+  std::int32_t MaxInput() const {
+    return 0;
+  }
+  std::int32_t Tolerance() const {
+    return 500;
+  }
+  std::int32_t ReferenceOp(std::int32_t x) const {
+    using F = FixedPoint<std::int32_t, tIntegerBits>;
+    using F0 = FixedPoint<std::int32_t, 0>;
+    const double d = ToDouble(F::FromRaw(x));
+    const double e = std::exp(d);
+    return F0::FromDouble(e).raw();
+  }
+  template <typename tRawType>
+  tRawType Op(tRawType x) const {
+    using F = FixedPoint<tRawType, tIntegerBits>;
+    const F f = F::FromRaw(x);
+    return exp_on_negative_values(f).raw();
+  }
+};
+
+// Op wrapping one_minus_x_over_one_plus_x_for_x_in_0_1
+class OneMinusXOverOnePlusXForXIn01Op final : public UnaryOpBase {
+public:
+  std::int32_t MinInput() const {
+    return 0;
+  }
+  std::int32_t Tolerance() const {
+    return 12;
+  }
+  std::int32_t ReferenceOp(std::int32_t x) const {
+    using F = FixedPoint<std::int32_t, 0>;
+    const double d = ToDouble(F::FromRaw(x));
+    const double e = (1 - d) / (1 + d);
+    return F::FromDouble(e).raw();
+  }
+  template <typename tRawType>
+  tRawType Op(tRawType x) const {
+    using F = FixedPoint<tRawType, 0>;
+    const F f = F::FromRaw(x);
+    return one_minus_x_over_one_plus_x_for_x_in_0_1(f).raw();
+  }
+};
+
+// Op wrapping tanh
+template <int tIntegerBits>
+class TanhOp final : public UnaryOpBase {
+public:
+  std::int32_t Tolerance() const {
+    return 310;
+  }
+  std::int32_t ReferenceOp(std::int32_t x) const {
+    using F = FixedPoint<std::int32_t, tIntegerBits>;
+    using F0 = FixedPoint<std::int32_t, 0>;
+    const double d = ToDouble(F::FromRaw(x));
+    const double e = std::tanh(d);
+    return F0::FromDouble(e).raw();
+  }
+  template <typename tRawType>
+  tRawType Op(tRawType x) const {
+    using F = FixedPoint<tRawType, tIntegerBits>;
+    const F f = F::FromRaw(x);
+    return tanh(f).raw();
+  }
+};
+
+// Op wrapping one_over_one_plus_x_for_x_in_0_1
+class OneOverOnePlusXForXIn01Op final : public UnaryOpBase {
+public:
+  std::int32_t MinInput() const {
+    return 0;
+  }
+  std::int32_t Tolerance() const {
+    return 6;
+  }
+  std::int32_t ReferenceOp(std::int32_t x) const {
+    using F = FixedPoint<std::int32_t, 0>;
+    const double d = ToDouble(F::FromRaw(x));
+    const double e = 1 / (1 + d);
+    return F::FromDouble(e).raw();
+  }
+  template <typename tRawType>
+  tRawType Op(tRawType x) const {
+    using F = FixedPoint<tRawType, 0>;
+    const F f = F::FromRaw(x);
+    return one_over_one_plus_x_for_x_in_0_1(f).raw();
+  }
+};
+
+// Op wrapping logistic
+template <int tIntegerBits>
+class LogisticOp final : public UnaryOpBase {
+public:
+  std::int32_t Tolerance() const {
+    return 155;
+  }
+  std::int32_t ReferenceOp(std::int32_t x) const {
+    using F = FixedPoint<std::int32_t, tIntegerBits>;
+    using F0 = FixedPoint<std::int32_t, 0>;
+    const double d = ToDouble(F::FromRaw(x));
+    const double e = 1 / (1 + std::exp(-d));
+    return F0::FromDouble(e).raw();
+  }
+  template <typename tRawType>
+  tRawType Op(tRawType x) const {
+    using F = FixedPoint<tRawType, tIntegerBits>;
+    const F f = F::FromRaw(x);
+    return logistic(f).raw();
+  }
+};
+
+// Tests a given op, on a given list of int32 input values.
+template <typename tUnaryOpType>
+void TestUnaryOp(const tUnaryOpType& unary_op, const std::vector<std::int32_t>& testvals_int32) {
+  Check(0 == (testvals_int32.size() % SimdVectorSize));
+  for (std::size_t i = 0; i < testvals_int32.size(); i += SimdVectorSize) {
+    // First, clamp input int32 values accoding to the MinInput() and MaxInput()
+    // bounds returned by the op.
+    std::int32_t input[SimdVectorSize] = {0};
+    for (std::size_t j = 0; j < SimdVectorSize; j++) {
+      const std::int32_t raw_input = testvals_int32[i + j];
+      input[j] = std::min(unary_op.MaxInput(), std::max(unary_op.MinInput(), raw_input));
+    }
+    // Compute reference results and check that the actual results on
+    // scalar inputs agree with them, to the Tolerance() returned by the op.
+    std::int32_t reference[SimdVectorSize] = {0};
+    std::int32_t actual_scalar[SimdVectorSize] = {0};
+    for (std::size_t j = 0; j < SimdVectorSize; j++) {
+      reference[j] = unary_op.ReferenceOp(input[j]);
+      actual_scalar[j] = unary_op.Op(input[j]);
+      const std::int64_t diff = static_cast<std::int64_t>(actual_scalar[j]) - static_cast<std::int64_t>(reference[j]);
+      Check(std::abs(diff) <= unary_op.Tolerance());
+    }
+    // Check that the actual results on SIMD inputs agree *exactly* with the
+    // actual results on scalar inputs. I.e. SIMD must make absolutely no difference
+    // to the results, regardless of the fact that both scalar and SIMD results
+    // may differ from the reference results.
+    std::int32_t actual_simd[SimdVectorSize] = {0};
+    StoreSimdVector(actual_simd, unary_op.Op(LoadSimdVector(input)));
+    for (std::size_t j = 0; j < SimdVectorSize; j++) {
+      Check(actual_simd[j] == actual_scalar[j]);
+    }
   }
 }
-
-void test_RoundingDivideByPOT(const std::vector<std::int32_t>& testvals_int32) {
-  for (auto a : testvals_int32) {
-    test_RoundingDivideByPOT(a);
-  }
-}
-
 
 template <int tIntegerBits>
 void test_convert(FixedPoint<std::int32_t, tIntegerBits> x) {
@@ -105,184 +365,8 @@ void test_ExactMulByPot(const std::vector<std::int32_t>& testvals_int32) {
   }
 }
 
-void test_exp_on_interval_between_negative_one_quarter_and_0_excl(
-    FixedPoint<std::int32_t, 0> a) {
-  double a_double = ToDouble(a);
-  double expected = std::exp(a_double);
-  double actual =
-      ToDouble(exp_on_interval_between_negative_one_quarter_and_0_excl(a));
-  double error = expected - actual;
-  Check(std::abs(error) < 3e-7);
-}
-
-void test_exp_on_interval_between_negative_one_quarter_and_0_excl(
-    const std::vector<std::int32_t>& testvals_int32) {
-  for (auto a : testvals_int32) {
-    typedef FixedPoint<std::int32_t, 0> F;
-    F aq = SaturatingRoundingMultiplyByPOT<-3>(F::FromRaw(a)) -
-           F::ConstantPOT<-3>();
-    test_exp_on_interval_between_negative_one_quarter_and_0_excl(aq);
-  }
-}
-
-template <int tIntegerBits>
-void test_exp_on_negative_values(FixedPoint<std::int32_t, tIntegerBits> a) {
-  double a_double = ToDouble(a);
-  double expected = std::exp(a_double);
-  double actual = ToDouble(exp_on_negative_values(a));
-  double error = expected - actual;
-  Check(std::abs(error) < 3e-7);
-}
-
-template <int tIntegerBits>
-void test_exp_on_negative_values(const std::vector<std::int32_t>& testvals_int32) {
-  for (auto a : testvals_int32) {
-    if (a < 0) {
-      FixedPoint<std::int32_t, tIntegerBits> aq;
-      aq.raw() = a;
-      test_exp_on_negative_values(aq);
-    }
-  }
-}
-
-void test_one_minus_x_over_one_plus_x_for_x_in_0_1(FixedPoint<std::int32_t, 0> a) {
-  double a_double = ToDouble(a);
-  double expected = (1 - a_double) / (1 + a_double);
-  FixedPoint<std::int32_t, 0> retval = one_minus_x_over_one_plus_x_for_x_in_0_1(a);
-  double actual = ToDouble(retval);
-  double error = expected - actual;
-  Check(std::abs(error) < 6e-9);
-}
-
-void test_one_minus_x_over_one_plus_x_for_x_in_0_1(
-    const std::vector<std::int32_t>& testvals_int32) {
-  for (auto a : testvals_int32) {
-    if (a > 0) {
-      FixedPoint<std::int32_t, 0> aq;
-      aq.raw() = a;
-      test_one_minus_x_over_one_plus_x_for_x_in_0_1(aq);
-    }
-  }
-}
-
-template <int tIntegerBits>
-void test_tanh(FixedPoint<std::int32_t, tIntegerBits> a) {
-  double a_double = ToDouble(a);
-  double expected = std::tanh(a_double);
-  double actual = ToDouble(tanh(a));
-  double error = expected - actual;
-  Check(std::abs(error) < 1.5e-7);
-}
-
-template <int tIntegerBits>
-void test_tanh(const std::vector<std::int32_t>& testvals_int32) {
-  for (auto a : testvals_int32) {
-    FixedPoint<std::int32_t, tIntegerBits> aq;
-    aq.raw() = a;
-    test_tanh(aq);
-  }
-}
-
-void test_one_over_one_plus_x_for_x_in_0_1(FixedPoint<std::int32_t, 0> a) {
-  double a_double = ToDouble(a);
-  double expected = 1. / (1 + a_double);
-  FixedPoint<std::int32_t, 0> retval = one_over_one_plus_x_for_x_in_0_1(a);
-  double actual = ToDouble(retval);
-  double error = expected - actual;
-  Check(std::abs(error) < 3e-9);
-}
-
-void test_one_over_one_plus_x_for_x_in_0_1(
-    const std::vector<std::int32_t>& testvals_int32) {
-  for (auto a : testvals_int32) {
-    if (a > 0) {
-      FixedPoint<std::int32_t, 0> aq;
-      aq.raw() = a;
-      test_one_over_one_plus_x_for_x_in_0_1(aq);
-    }
-  }
-}
-
-template <int tIntegerBits>
-void test_logistic(FixedPoint<std::int32_t, tIntegerBits> a) {
-  double a_double = ToDouble(a);
-  double expected = 1. / (1 + std::exp(-a_double));
-  double actual = ToDouble(logistic(a));
-  double error = expected - actual;
-  Check(std::abs(error) < 8e-8);
-}
-
-template <int tIntegerBits>
-void test_logistic(const std::vector<std::int32_t>& testvals_int32) {
-  for (auto a : testvals_int32) {
-    FixedPoint<std::int32_t, tIntegerBits> aq;
-    aq.raw() = a;
-    test_logistic(aq);
-  }
-}
-
-#ifdef GEMMLOWP_NEON
-void test_int32x4(const std::vector<std::int32_t>& testvals_int32) {
-  size_t n = testvals_int32.size();
-  size_t n4 = n - (n % 4);
-  std::vector<std::int32_t> results_int32(n4);
-  std::vector<std::int32_t> results_int32x4(n4);
-
-  for (size_t i = 0; i < n4; i++) {
-    results_int32[i] =
-        tanh(FixedPoint<std::int32_t, 4>::FromRaw(testvals_int32[i])).raw();
-  }
-  for (size_t i = 0; i < n4; i++) {
-    vst1q_s32(
-        &results_int32x4[i],
-        tanh(FixedPoint<int32x4_t, 4>::FromRaw(vld1q_s32(&testvals_int32[i])))
-            .raw());
-  }
-
-  for (size_t i = 0; i < n4; i++) {
-    Check(results_int32[i] == results_int32x4[i]);
-  }
-}
-#endif  // GEMMLOWP_NEON
-
-#ifdef GEMMLOWP_SSE4
-#define LOAD_SI128(ptr)                                       \
-  (((unsigned long)(ptr)&15) == 0)                            \
-      ? _mm_load_si128(reinterpret_cast<const __m128i*>(ptr)) \
-      : _mm_loadu_si128(reinterpret_cast<const __m128i*>(ptr))
-#define STORE_SI128(ptr, val)                                 \
-  (((unsigned long)(ptr)&15) == 0)                            \
-      ? _mm_store_si128(reinterpret_cast<__m128i*>(ptr), val) \
-      : _mm_storeu_si128(reinterpret_cast<__m128i*>(ptr), val)
-
-template <int tIntegerBits>
-void test_tanh_m128i(const std::vector<std::int32_t>& testvals_int32) {
-  size_t n = testvals_int32.size();
-  size_t n4 = n / 4;
-  std::uint32_t results_m128i[4];
-
-  for (size_t i = 0; i < n4; i += 4) {
-    typedef FixedPoint<std::int32_t, tIntegerBits> F_input;
-    typedef FixedPoint<__m128i, tIntegerBits> F4_input;
-    typedef FixedPoint<std::int32_t, 0> F_output;
-    typedef FixedPoint<__m128i, 0> F4_output;
-
-    __m128i arguments = LOAD_SI128(&testvals_int32[i]);
-    F4_output results = tanh(F4_input::FromRaw(arguments));
-
-    STORE_SI128(results_m128i, results.raw());
-    for (size_t j = 0; j < 4; j++) {
-      double expected =
-          std::tanh(ToDouble(F_input::FromRaw(testvals_int32[i + j])));
-      double computed = ToDouble(F_output::FromRaw(results_m128i[j]));
-      double error = std::abs(expected - computed);
-      Check(error < 1.5e-7);
-    }
-  }
-}
-#endif  // GEMMLOWP_SSE4
-
-int main() {
+// Make the list of test values to test each op against.
+std::vector<std::int32_t> MakeTestValsInt32() {
   std::vector<std::int32_t> testvals_int32;
 
   for (int i = 0; i < 31; i++) {
@@ -304,15 +388,63 @@ int main() {
   testvals_int32.push_back(std::numeric_limits<std::int32_t>::max() - 1);
   testvals_int32.push_back(std::numeric_limits<std::int32_t>::max());
 
-  std::uint32_t random = 1;
+  std::mt19937 random_engine;
+  std::uniform_int_distribution<std::int32_t> uniform_distribution(
+    std::numeric_limits<std::int32_t>::min(),
+    std::numeric_limits<std::int32_t>::max());
   for (int i = 0; i < 1000; i++) {
-    random = random * 1664525 + 1013904223;
-    testvals_int32.push_back(static_cast<std::int32_t>(random));
+    testvals_int32.push_back(uniform_distribution(random_engine));
+  }
+
+  // SIMD tests will require the length of testvals_int32 to be a multiple
+  // of SIMD vector size.
+  while (testvals_int32.size() % SimdVectorSize) {
+    testvals_int32.push_back(0);
   }
 
   std::sort(testvals_int32.begin(), testvals_int32.end());
+  return testvals_int32;
+}
 
-  test_RoundingDivideByPOT(testvals_int32);
+}  // end anonymous namespace
+
+}  // end namespace gemmlowp
+
+int main() {
+  using namespace gemmlowp;
+
+  const std::vector<std::int32_t> testvals_int32 = MakeTestValsInt32();
+
+  for (int s = 0; s < 32; s++) {
+    TestUnaryOp(RoundingDivideByPOTOp(s), testvals_int32);
+  }
+
+  TestUnaryOp(ExpOnIntervalBetweenNegativeOneQuarterAnd0ExclOp(), testvals_int32);
+  TestUnaryOp(ExpOnNegativeValuesOp<0>(), testvals_int32);
+  TestUnaryOp(ExpOnNegativeValuesOp<1>(), testvals_int32);
+  TestUnaryOp(ExpOnNegativeValuesOp<2>(), testvals_int32);
+  TestUnaryOp(ExpOnNegativeValuesOp<3>(), testvals_int32);
+  TestUnaryOp(ExpOnNegativeValuesOp<4>(), testvals_int32);
+  TestUnaryOp(ExpOnNegativeValuesOp<5>(), testvals_int32);
+  TestUnaryOp(ExpOnNegativeValuesOp<6>(), testvals_int32);
+
+  TestUnaryOp(OneMinusXOverOnePlusXForXIn01Op(), testvals_int32);
+  TestUnaryOp(TanhOp<0>(), testvals_int32);
+  TestUnaryOp(TanhOp<1>(), testvals_int32);
+  TestUnaryOp(TanhOp<2>(), testvals_int32);
+  TestUnaryOp(TanhOp<3>(), testvals_int32);
+  TestUnaryOp(TanhOp<4>(), testvals_int32);
+  TestUnaryOp(TanhOp<5>(), testvals_int32);
+  TestUnaryOp(TanhOp<6>(), testvals_int32);
+
+  TestUnaryOp(OneOverOnePlusXForXIn01Op(), testvals_int32);
+  TestUnaryOp(LogisticOp<0>(), testvals_int32);
+  TestUnaryOp(LogisticOp<1>(), testvals_int32);
+  TestUnaryOp(LogisticOp<2>(), testvals_int32);
+  TestUnaryOp(LogisticOp<3>(), testvals_int32);
+  TestUnaryOp(LogisticOp<4>(), testvals_int32);
+  TestUnaryOp(LogisticOp<5>(), testvals_int32);
+  TestUnaryOp(LogisticOp<6>(), testvals_int32);
 
   for (auto a : testvals_int32) {
     FixedPoint<std::int32_t, 4> x;
@@ -343,43 +475,6 @@ int main() {
   test_ExactMulByPot<3, 2>(testvals_int32);
   test_ExactMulByPot<-4, 5>(testvals_int32);
   test_ExactMulByPot<-2, 6>(testvals_int32);
-
-  test_exp_on_interval_between_negative_one_quarter_and_0_excl(testvals_int32);
-  test_exp_on_negative_values<1>(testvals_int32);
-  test_exp_on_negative_values<2>(testvals_int32);
-  test_exp_on_negative_values<3>(testvals_int32);
-  test_exp_on_negative_values<4>(testvals_int32);
-  test_exp_on_negative_values<5>(testvals_int32);
-  test_exp_on_negative_values<6>(testvals_int32);
-
-  test_one_minus_x_over_one_plus_x_for_x_in_0_1(testvals_int32);
-  test_tanh<1>(testvals_int32);
-  test_tanh<2>(testvals_int32);
-  test_tanh<3>(testvals_int32);
-  test_tanh<4>(testvals_int32);
-  test_tanh<5>(testvals_int32);
-  test_tanh<6>(testvals_int32);
-
-  test_one_over_one_plus_x_for_x_in_0_1(testvals_int32);
-  test_logistic<1>(testvals_int32);
-  test_logistic<2>(testvals_int32);
-  test_logistic<3>(testvals_int32);
-  test_logistic<4>(testvals_int32);
-  test_logistic<5>(testvals_int32);
-  test_logistic<6>(testvals_int32);
-
-#ifdef GEMMLOWP_NEON
-  test_int32x4(testvals_int32);
-#endif  // GEMMLOWP_NEON
-
-#ifdef GEMMLOWP_SSE4
-  test_tanh_m128i<1>(testvals_int32);
-  test_tanh_m128i<2>(testvals_int32);
-  test_tanh_m128i<3>(testvals_int32);
-  test_tanh_m128i<4>(testvals_int32);
-  test_tanh_m128i<5>(testvals_int32);
-  test_tanh_m128i<6>(testvals_int32);
-#endif  // GEMMLOWP_SSE4
 
   std::cerr << "All tests passed." << std::endl;
 }

--- a/test/test_fixedpoint.cc
+++ b/test/test_fixedpoint.cc
@@ -21,50 +21,50 @@
 using namespace gemmlowp;
 
 template <int tIntegerBits>
-void test_convert(FixedPoint<int32_t, tIntegerBits> x) {
-  typedef FixedPoint<int32_t, tIntegerBits> F;
+void test_convert(FixedPoint<std::int32_t, tIntegerBits> x) {
+  typedef FixedPoint<std::int32_t, tIntegerBits> F;
   F y = F::FromDouble(ToDouble(x));
   Check(y == x);
 }
 
 template <int tIntegerBits_a, int tIntegerBits_b>
-void test_Rescale(FixedPoint<int32_t, tIntegerBits_a> a) {
-  FixedPoint<int32_t, tIntegerBits_b> actual = Rescale<tIntegerBits_b>(a);
-  FixedPoint<int32_t, tIntegerBits_b> expected =
-      FixedPoint<int32_t, tIntegerBits_b>::FromDouble(ToDouble(a));
+void test_Rescale(FixedPoint<std::int32_t, tIntegerBits_a> a) {
+  FixedPoint<std::int32_t, tIntegerBits_b> actual = Rescale<tIntegerBits_b>(a);
+  FixedPoint<std::int32_t, tIntegerBits_b> expected =
+      FixedPoint<std::int32_t, tIntegerBits_b>::FromDouble(ToDouble(a));
   Check(actual == expected);
 }
 
 template <int tIntegerBits_a, int tIntegerBits_b>
-void test_Rescale(const std::vector<int32_t>& testvals_int32) {
+void test_Rescale(const std::vector<std::int32_t>& testvals_int32) {
   for (auto a : testvals_int32) {
-    FixedPoint<int32_t, tIntegerBits_a> aq;
+    FixedPoint<std::int32_t, tIntegerBits_a> aq;
     aq.raw() = a;
     test_Rescale<tIntegerBits_a, tIntegerBits_b>(aq);
   }
 }
 
 template <int tIntegerBits_a, int tIntegerBits_b>
-void test_mul(FixedPoint<int32_t, tIntegerBits_a> a,
-              FixedPoint<int32_t, tIntegerBits_b> b) {
+void test_mul(FixedPoint<std::int32_t, tIntegerBits_a> a,
+              FixedPoint<std::int32_t, tIntegerBits_b> b) {
   static const int ProductIntegerBits = tIntegerBits_a + tIntegerBits_b;
-  using ProductFixedPoint = FixedPoint<int32_t, ProductIntegerBits>;
+  using ProductFixedPoint = FixedPoint<std::int32_t, ProductIntegerBits>;
   ProductFixedPoint ab;
   ab = a * b;
   double a_double = ToDouble(a);
   double b_double = ToDouble(b);
   double ab_double = a_double * b_double;
   ProductFixedPoint expected = ProductFixedPoint::FromDouble(ab_double);
-  int64_t diff = int64_t(ab.raw()) - int64_t(expected.raw());
+  std::int64_t diff = std::int64_t(ab.raw()) - std::int64_t(expected.raw());
   Check(std::abs(diff) <= 1);
 }
 
 template <int tIntegerBits_a, int tIntegerBits_b>
-void test_mul(const std::vector<int32_t>& testvals_int32) {
+void test_mul(const std::vector<std::int32_t>& testvals_int32) {
   for (auto a : testvals_int32) {
     for (auto b : testvals_int32) {
-      FixedPoint<int32_t, tIntegerBits_a> aq;
-      FixedPoint<int32_t, tIntegerBits_b> bq;
+      FixedPoint<std::int32_t, tIntegerBits_a> aq;
+      FixedPoint<std::int32_t, tIntegerBits_b> bq;
       aq.raw() = a;
       bq.raw() = b;
       test_mul(aq, bq);
@@ -73,23 +73,23 @@ void test_mul(const std::vector<int32_t>& testvals_int32) {
 }
 
 template <int tExponent, int tIntegerBits_a>
-void test_ExactMulByPot(FixedPoint<int32_t, tIntegerBits_a> a) {
+void test_ExactMulByPot(FixedPoint<std::int32_t, tIntegerBits_a> a) {
   double x = ToDouble(a) * std::pow(2.0, tExponent);
   double y = ToDouble(ExactMulByPot<tExponent>(a));
   Check(x == y);
 }
 
 template <int tExponent, int tIntegerBits_a>
-void test_ExactMulByPot(const std::vector<int32_t>& testvals_int32) {
+void test_ExactMulByPot(const std::vector<std::int32_t>& testvals_int32) {
   for (auto a : testvals_int32) {
-    FixedPoint<int32_t, tIntegerBits_a> aq;
+    FixedPoint<std::int32_t, tIntegerBits_a> aq;
     aq.raw() = a;
     test_ExactMulByPot<tExponent, tIntegerBits_a>(aq);
   }
 }
 
 void test_exp_on_interval_between_negative_one_quarter_and_0_excl(
-    FixedPoint<int32_t, 0> a) {
+    FixedPoint<std::int32_t, 0> a) {
   double a_double = ToDouble(a);
   double expected = std::exp(a_double);
   double actual =
@@ -99,9 +99,9 @@ void test_exp_on_interval_between_negative_one_quarter_and_0_excl(
 }
 
 void test_exp_on_interval_between_negative_one_quarter_and_0_excl(
-    const std::vector<int32_t>& testvals_int32) {
+    const std::vector<std::int32_t>& testvals_int32) {
   for (auto a : testvals_int32) {
-    typedef FixedPoint<int32_t, 0> F;
+    typedef FixedPoint<std::int32_t, 0> F;
     F aq = SaturatingRoundingMultiplyByPOT<-3>(F::FromRaw(a)) -
            F::ConstantPOT<-3>();
     test_exp_on_interval_between_negative_one_quarter_and_0_excl(aq);
@@ -109,7 +109,7 @@ void test_exp_on_interval_between_negative_one_quarter_and_0_excl(
 }
 
 template <int tIntegerBits>
-void test_exp_on_negative_values(FixedPoint<int32_t, tIntegerBits> a) {
+void test_exp_on_negative_values(FixedPoint<std::int32_t, tIntegerBits> a) {
   double a_double = ToDouble(a);
   double expected = std::exp(a_double);
   double actual = ToDouble(exp_on_negative_values(a));
@@ -118,30 +118,30 @@ void test_exp_on_negative_values(FixedPoint<int32_t, tIntegerBits> a) {
 }
 
 template <int tIntegerBits>
-void test_exp_on_negative_values(const std::vector<int32_t>& testvals_int32) {
+void test_exp_on_negative_values(const std::vector<std::int32_t>& testvals_int32) {
   for (auto a : testvals_int32) {
     if (a < 0) {
-      FixedPoint<int32_t, tIntegerBits> aq;
+      FixedPoint<std::int32_t, tIntegerBits> aq;
       aq.raw() = a;
       test_exp_on_negative_values(aq);
     }
   }
 }
 
-void test_one_minus_x_over_one_plus_x_for_x_in_0_1(FixedPoint<int32_t, 0> a) {
+void test_one_minus_x_over_one_plus_x_for_x_in_0_1(FixedPoint<std::int32_t, 0> a) {
   double a_double = ToDouble(a);
   double expected = (1 - a_double) / (1 + a_double);
-  FixedPoint<int32_t, 0> retval = one_minus_x_over_one_plus_x_for_x_in_0_1(a);
+  FixedPoint<std::int32_t, 0> retval = one_minus_x_over_one_plus_x_for_x_in_0_1(a);
   double actual = ToDouble(retval);
   double error = expected - actual;
   Check(std::abs(error) < 6e-9);
 }
 
 void test_one_minus_x_over_one_plus_x_for_x_in_0_1(
-    const std::vector<int32_t>& testvals_int32) {
+    const std::vector<std::int32_t>& testvals_int32) {
   for (auto a : testvals_int32) {
     if (a > 0) {
-      FixedPoint<int32_t, 0> aq;
+      FixedPoint<std::int32_t, 0> aq;
       aq.raw() = a;
       test_one_minus_x_over_one_plus_x_for_x_in_0_1(aq);
     }
@@ -149,7 +149,7 @@ void test_one_minus_x_over_one_plus_x_for_x_in_0_1(
 }
 
 template <int tIntegerBits>
-void test_tanh(FixedPoint<int32_t, tIntegerBits> a) {
+void test_tanh(FixedPoint<std::int32_t, tIntegerBits> a) {
   double a_double = ToDouble(a);
   double expected = std::tanh(a_double);
   double actual = ToDouble(tanh(a));
@@ -158,28 +158,28 @@ void test_tanh(FixedPoint<int32_t, tIntegerBits> a) {
 }
 
 template <int tIntegerBits>
-void test_tanh(const std::vector<int32_t>& testvals_int32) {
+void test_tanh(const std::vector<std::int32_t>& testvals_int32) {
   for (auto a : testvals_int32) {
-    FixedPoint<int32_t, tIntegerBits> aq;
+    FixedPoint<std::int32_t, tIntegerBits> aq;
     aq.raw() = a;
     test_tanh(aq);
   }
 }
 
-void test_one_over_one_plus_x_for_x_in_0_1(FixedPoint<int32_t, 0> a) {
+void test_one_over_one_plus_x_for_x_in_0_1(FixedPoint<std::int32_t, 0> a) {
   double a_double = ToDouble(a);
   double expected = 1. / (1 + a_double);
-  FixedPoint<int32_t, 0> retval = one_over_one_plus_x_for_x_in_0_1(a);
+  FixedPoint<std::int32_t, 0> retval = one_over_one_plus_x_for_x_in_0_1(a);
   double actual = ToDouble(retval);
   double error = expected - actual;
   Check(std::abs(error) < 3e-9);
 }
 
 void test_one_over_one_plus_x_for_x_in_0_1(
-    const std::vector<int32_t>& testvals_int32) {
+    const std::vector<std::int32_t>& testvals_int32) {
   for (auto a : testvals_int32) {
     if (a > 0) {
-      FixedPoint<int32_t, 0> aq;
+      FixedPoint<std::int32_t, 0> aq;
       aq.raw() = a;
       test_one_over_one_plus_x_for_x_in_0_1(aq);
     }
@@ -187,7 +187,7 @@ void test_one_over_one_plus_x_for_x_in_0_1(
 }
 
 template <int tIntegerBits>
-void test_logistic(FixedPoint<int32_t, tIntegerBits> a) {
+void test_logistic(FixedPoint<std::int32_t, tIntegerBits> a) {
   double a_double = ToDouble(a);
   double expected = 1. / (1 + std::exp(-a_double));
   double actual = ToDouble(logistic(a));
@@ -196,24 +196,24 @@ void test_logistic(FixedPoint<int32_t, tIntegerBits> a) {
 }
 
 template <int tIntegerBits>
-void test_logistic(const std::vector<int32_t>& testvals_int32) {
+void test_logistic(const std::vector<std::int32_t>& testvals_int32) {
   for (auto a : testvals_int32) {
-    FixedPoint<int32_t, tIntegerBits> aq;
+    FixedPoint<std::int32_t, tIntegerBits> aq;
     aq.raw() = a;
     test_logistic(aq);
   }
 }
 
 #ifdef GEMMLOWP_NEON
-void test_int32x4(const std::vector<int32_t>& testvals_int32) {
+void test_int32x4(const std::vector<std::int32_t>& testvals_int32) {
   size_t n = testvals_int32.size();
   size_t n4 = n - (n % 4);
-  std::vector<int32_t> results_int32(n4);
-  std::vector<int32_t> results_int32x4(n4);
+  std::vector<std::int32_t> results_int32(n4);
+  std::vector<std::int32_t> results_int32x4(n4);
 
   for (size_t i = 0; i < n4; i++) {
     results_int32[i] =
-        tanh(FixedPoint<int32_t, 4>::FromRaw(testvals_int32[i])).raw();
+        tanh(FixedPoint<std::int32_t, 4>::FromRaw(testvals_int32[i])).raw();
   }
   for (size_t i = 0; i < n4; i++) {
     vst1q_s32(
@@ -239,15 +239,15 @@ void test_int32x4(const std::vector<int32_t>& testvals_int32) {
       : _mm_storeu_si128(reinterpret_cast<__m128i*>(ptr), val)
 
 template <int tIntegerBits>
-void test_tanh_m128i(const std::vector<int32_t>& testvals_int32) {
+void test_tanh_m128i(const std::vector<std::int32_t>& testvals_int32) {
   size_t n = testvals_int32.size();
   size_t n4 = n / 4;
-  uint32_t results_m128i[4];
+  std::uint32_t results_m128i[4];
 
   for (size_t i = 0; i < n4; i += 4) {
-    typedef FixedPoint<int32_t, tIntegerBits> F_input;
+    typedef FixedPoint<std::int32_t, tIntegerBits> F_input;
     typedef FixedPoint<__m128i, tIntegerBits> F4_input;
-    typedef FixedPoint<int32_t, 0> F_output;
+    typedef FixedPoint<std::int32_t, 0> F_output;
     typedef FixedPoint<__m128i, 0> F4_output;
 
     __m128i arguments = LOAD_SI128(&testvals_int32[i]);
@@ -266,7 +266,7 @@ void test_tanh_m128i(const std::vector<int32_t>& testvals_int32) {
 #endif  // GEMMLOWP_SSE4
 
 int main() {
-  std::vector<int32_t> testvals_int32;
+  std::vector<std::int32_t> testvals_int32;
 
   for (int i = 0; i < 31; i++) {
     testvals_int32.push_back((1 << i) - 2);
@@ -280,23 +280,23 @@ int main() {
     testvals_int32.push_back(-(1 << i) + 1);
     testvals_int32.push_back(-(1 << i) + 2);
   }
-  testvals_int32.push_back(std::numeric_limits<int32_t>::min());
-  testvals_int32.push_back(std::numeric_limits<int32_t>::min() + 1);
-  testvals_int32.push_back(std::numeric_limits<int32_t>::min() + 2);
-  testvals_int32.push_back(std::numeric_limits<int32_t>::max() - 2);
-  testvals_int32.push_back(std::numeric_limits<int32_t>::max() - 1);
-  testvals_int32.push_back(std::numeric_limits<int32_t>::max());
+  testvals_int32.push_back(std::numeric_limits<std::int32_t>::min());
+  testvals_int32.push_back(std::numeric_limits<std::int32_t>::min() + 1);
+  testvals_int32.push_back(std::numeric_limits<std::int32_t>::min() + 2);
+  testvals_int32.push_back(std::numeric_limits<std::int32_t>::max() - 2);
+  testvals_int32.push_back(std::numeric_limits<std::int32_t>::max() - 1);
+  testvals_int32.push_back(std::numeric_limits<std::int32_t>::max());
 
-  uint32_t random = 1;
+  std::uint32_t random = 1;
   for (int i = 0; i < 1000; i++) {
     random = random * 1664525 + 1013904223;
-    testvals_int32.push_back(static_cast<int32_t>(random));
+    testvals_int32.push_back(static_cast<std::int32_t>(random));
   }
 
   std::sort(testvals_int32.begin(), testvals_int32.end());
 
   for (auto a : testvals_int32) {
-    FixedPoint<int32_t, 4> x;
+    FixedPoint<std::int32_t, 4> x;
     x.raw() = a;
     test_convert(x);
   }

--- a/test/test_fixedpoint.cc
+++ b/test/test_fixedpoint.cc
@@ -111,6 +111,23 @@ class RoundingDivideByPOTOp final : public UnaryOpBase {
   const int exponent_;
 };
 
+// Op wrapping SaturatingRoundingMultiplyByPOT
+template <int tExponent>
+class SaturatingRoundingMultiplyByPOTOp final : public UnaryOpBase {
+ public:
+  std::int32_t ReferenceOp(std::int32_t x) const {
+    const double d = static_cast<double>(x) * std::pow(2., tExponent);
+    const double clamp_min = std::numeric_limits<std::int32_t>::min();
+    const double clamp_max = std::numeric_limits<std::int32_t>::max();
+    const double clamped = std::min(clamp_max, std::max(clamp_min, d));
+    return static_cast<std::int32_t>(std::round(clamped));
+  }
+  template <typename tRawType>
+  tRawType Op(tRawType x) const {
+    return SaturatingRoundingMultiplyByPOT<tExponent>(x);
+  }
+};
+
 // Op wrapping exp_on_interval_between_negative_one_quarter_and_0_excl
 class ExpOnIntervalBetweenNegativeOneQuarterAnd0ExclOp final
     : public UnaryOpBase {
@@ -391,6 +408,28 @@ int main() {
   for (int s = 0; s < 32; s++) {
     TestUnaryOp(RoundingDivideByPOTOp(s), testvals_int32);
   }
+
+  TestUnaryOp(SaturatingRoundingMultiplyByPOTOp<-31>(), testvals_int32);
+  TestUnaryOp(SaturatingRoundingMultiplyByPOTOp<-30>(), testvals_int32);
+  TestUnaryOp(SaturatingRoundingMultiplyByPOTOp<-29>(), testvals_int32);
+  TestUnaryOp(SaturatingRoundingMultiplyByPOTOp<-17>(), testvals_int32);
+  TestUnaryOp(SaturatingRoundingMultiplyByPOTOp<-16>(), testvals_int32);
+  TestUnaryOp(SaturatingRoundingMultiplyByPOTOp<-15>(), testvals_int32);
+  TestUnaryOp(SaturatingRoundingMultiplyByPOTOp<-4>(), testvals_int32);
+  TestUnaryOp(SaturatingRoundingMultiplyByPOTOp<-3>(), testvals_int32);
+  TestUnaryOp(SaturatingRoundingMultiplyByPOTOp<-2>(), testvals_int32);
+  TestUnaryOp(SaturatingRoundingMultiplyByPOTOp<-1>(), testvals_int32);
+  TestUnaryOp(SaturatingRoundingMultiplyByPOTOp<0>(), testvals_int32);
+  TestUnaryOp(SaturatingRoundingMultiplyByPOTOp<1>(), testvals_int32);
+  TestUnaryOp(SaturatingRoundingMultiplyByPOTOp<2>(), testvals_int32);
+  TestUnaryOp(SaturatingRoundingMultiplyByPOTOp<3>(), testvals_int32);
+  TestUnaryOp(SaturatingRoundingMultiplyByPOTOp<4>(), testvals_int32);
+  TestUnaryOp(SaturatingRoundingMultiplyByPOTOp<15>(), testvals_int32);
+  TestUnaryOp(SaturatingRoundingMultiplyByPOTOp<16>(), testvals_int32);
+  TestUnaryOp(SaturatingRoundingMultiplyByPOTOp<17>(), testvals_int32);
+  TestUnaryOp(SaturatingRoundingMultiplyByPOTOp<29>(), testvals_int32);
+  TestUnaryOp(SaturatingRoundingMultiplyByPOTOp<30>(), testvals_int32);
+  TestUnaryOp(SaturatingRoundingMultiplyByPOTOp<31>(), testvals_int32);
 
   TestUnaryOp(ExpOnIntervalBetweenNegativeOneQuarterAnd0ExclOp(),
               testvals_int32);


### PR DESCRIPTION
This Pull Request expands test_fixedpoint.cc to consistently ensure that both scalar and SIMD paths agree with reference implementations. Scalar and SIMD paths are required to agree bit-for-bit. Agreement with the reference code is also required to be bit-perfect for basic operations such as rounding shifts, while the existing tolerance is kept for math functions (such as tanh).

The biggest change is in rounding-right-shift. Previously we were taking the ARM RSHL/RSHR instruction as the ground-truth. However, the behavior of this instruction is not exactly what one would expect rounding-to-nearest to do. Indeed, half-integral values are always rounded upwards, instead of being rounded away-from-zero. So this PR fixes this on all paths, to implement exact round-to-nearest behavior with half-integral values rounded away from zero.

This means some extra work on all architectures, including on ARM where we cannot just directly use RSHL/RSHR anymore. We still use these instructions but with a fix-up applied to their operand.

A cosmetic, unrelated change is that I consistently namespaced cstdint types like int32_t with std:: . We had been relying on this accidentally compiling.