### PR TITLE
Generalize usage of correct rounding shifts in output stages.

### DIFF
--- a/internal/output.h
+++ b/internal/output.h
@@ -114,10 +114,8 @@ struct OutputStageEvalImpl<OutputStageQuantizeDownInt32ToUint8Scale,
     const std::int32_t result_shift = output_stage.result_shift;
     const std::int32_t result_mult_int = output_stage.result_mult_int;
     const std::int32_t result_offset = output_stage.result_offset;
-    const std::int32_t kRoundingTerm =
-        (result_shift < 1) ? 0 : (1 << (result_shift - 1));
-    return ((input + result_offset) * result_mult_int + kRoundingTerm) >>
-           result_shift;
+    return RoundingDivideByPOT((input + result_offset) * result_mult_int,
+        result_shift);
   }
 
   const OutputStage& output_stage;
@@ -138,10 +136,8 @@ struct OutputStageEvalImpl<
     const std::int32_t result_shift = output_stage.result_shift;
     const std::int32_t result_mult_int = output_stage.result_mult_int(row);
     const std::int32_t result_offset = output_stage.result_offset(row);
-    const std::int32_t kRoundingTerm =
-        (result_shift < 1) ? 0 : (1 << (result_shift - 1));
-    return ((input + result_offset) * result_mult_int + kRoundingTerm) >>
-           result_shift;
+    return RoundingDivideByPOT((input + result_offset) * result_mult_int,
+        result_shift);
   }
 
   const OutputStage& output_stage;
@@ -162,10 +158,8 @@ struct OutputStageEvalImpl<
     const std::int32_t result_shift = output_stage.result_shift;
     const std::int32_t result_mult_int = output_stage.result_mult_int(col);
     const std::int32_t result_offset = output_stage.result_offset(col);
-    const std::int32_t kRoundingTerm =
-        (result_shift < 1) ? 0 : (1 << (result_shift - 1));
-    return ((input + result_offset) * result_mult_int + kRoundingTerm) >>
-           result_shift;
+    return RoundingDivideByPOT((input + result_offset) * result_mult_int,
+        result_shift);
   }
 
   const OutputStage& output_stage;
@@ -184,12 +178,8 @@ struct OutputStageEvalImpl<OutputStageQuantizeDownInt32ToUint8ScaleByFixedPoint,
   OutputType Eval(InputType input, int, int) const {
     const std::int32_t mulhigh_val = SaturatingRoundingDoublingHighMul(
         input.data, output_stage.result_fixedpoint_multiplier);
-    const std::int32_t result_shift = output_stage.result_shift;
-    const std::int32_t kRoundingTerm =
-        (result_shift < 1) ? 0 : (1 << (result_shift - 1));
-    const std::int32_t shifted_val =
-        (mulhigh_val + kRoundingTerm) >> result_shift;
-    return shifted_val + output_stage.result_offset_after_shift;
+    return RoundingDivideByPOT(mulhigh_val, output_stage.result_shift) +
+        output_stage.result_offset_after_shift;
   }
 
   const OutputStage& output_stage;

--- a/internal/output.h
+++ b/internal/output.h
@@ -115,7 +115,7 @@ struct OutputStageEvalImpl<OutputStageQuantizeDownInt32ToUint8Scale,
     const std::int32_t result_mult_int = output_stage.result_mult_int;
     const std::int32_t result_offset = output_stage.result_offset;
     return RoundingDivideByPOT((input + result_offset) * result_mult_int,
-        result_shift);
+                               result_shift);
   }
 
   const OutputStage& output_stage;
@@ -137,7 +137,7 @@ struct OutputStageEvalImpl<
     const std::int32_t result_mult_int = output_stage.result_mult_int(row);
     const std::int32_t result_offset = output_stage.result_offset(row);
     return RoundingDivideByPOT((input + result_offset) * result_mult_int,
-        result_shift);
+                               result_shift);
   }
 
   const OutputStage& output_stage;
@@ -159,7 +159,7 @@ struct OutputStageEvalImpl<
     const std::int32_t result_mult_int = output_stage.result_mult_int(col);
     const std::int32_t result_offset = output_stage.result_offset(col);
     return RoundingDivideByPOT((input + result_offset) * result_mult_int,
-        result_shift);
+                               result_shift);
   }
 
   const OutputStage& output_stage;
@@ -179,7 +179,7 @@ struct OutputStageEvalImpl<OutputStageQuantizeDownInt32ToUint8ScaleByFixedPoint,
     const std::int32_t mulhigh_val = SaturatingRoundingDoublingHighMul(
         input.data, output_stage.result_fixedpoint_multiplier);
     return RoundingDivideByPOT(mulhigh_val, output_stage.result_shift) +
-        output_stage.result_offset_after_shift;
+           output_stage.result_offset_after_shift;
   }
 
   const OutputStage& output_stage;

--- a/internal/output_neon.h
+++ b/internal/output_neon.h
@@ -75,12 +75,9 @@ struct OutputStageEvalImpl<OutputStageQuantizeDownInt32ToUint8Scale,
     const std::int32_t result_shift = output_stage.result_shift;
     const std::int32_t result_mult_int = output_stage.result_mult_int;
     const std::int32_t result_offset = output_stage.result_offset;
-    const std::int32_t preshift_offset =
-        (result_shift < 1) ? 0 : (1 << (result_shift - 1));
-    const int32x4_t a = vaddq_s32(input, vdupq_n_s32(result_offset));
-    const int32x4_t b =
-        vmlaq_n_s32(vdupq_n_s32(preshift_offset), a, result_mult_int);
-    return vshlq_s32(b, vdupq_n_s32(-result_shift));
+    const int32x4_t a = vaddq_s32(vdupq_n_s32(result_offset), input);
+    const int32x4_t b = vmulq_n_s32(a, result_mult_int);
+    return RoundingDivideByPOT(b, result_shift);
   }
 
   const OutputStage& output_stage;
@@ -101,16 +98,13 @@ struct OutputStageEvalImpl<
 
   OutputType Eval(InputType input, int row, int col) const {
     const std::int32_t result_shift = output_stage.result_shift;
-    const std::int32_t preshift_offset =
-        (result_shift < 1) ? 0 : (1 << (result_shift - 1));
     const int32x4_t result_mult_int =
         vld1q_s32(output_stage.result_mult_int.data(row));
     const int32x4_t result_offset =
         vld1q_s32(output_stage.result_offset.data(row));
-    const int32x4_t a = vaddq_s32(input, result_offset);
-    const int32x4_t b =
-        vmlaq_s32(vdupq_n_s32(preshift_offset), a, result_mult_int);
-    return vshlq_s32(b, vdupq_n_s32(-result_shift));
+    const int32x4_t a = vaddq_s32(result_offset, input);
+    const int32x4_t b = vmulq_s32(a, result_mult_int);
+    return RoundingDivideByPOT(b, result_shift);
   }
 
   const OutputStage& output_stage;
@@ -131,16 +125,13 @@ struct OutputStageEvalImpl<
 
   OutputType Eval(InputType input, int row, int col) const {
     const std::int32_t result_shift = output_stage.result_shift;
-    const std::int32_t preshift_offset =
-        (result_shift < 1) ? 0 : (1 << (result_shift - 1));
     const int32x4_t result_mult_int =
         vld1q_s32(output_stage.result_mult_int.data(col));
     const int32x4_t result_offset =
         vld1q_s32(output_stage.result_offset.data(row));
-    const int32x4_t a = vaddq_s32(input, result_offset);
-    const int32x4_t b =
-        vmlaq_s32(vdupq_n_s32(preshift_offset), a, result_mult_int);
-    return vshlq_s32(b, vdupq_n_s32(-result_shift));
+    const int32x4_t a = vaddq_s32(result_offset, input);
+    const int32x4_t b = vmulq_s32(a, result_mult_int);
+    return RoundingDivideByPOT(b, result_shift);
   }
 
   const OutputStage& output_stage;
@@ -156,22 +147,18 @@ struct OutputStageEvalImpl<OutputStageQuantizeDownInt32ToUint8ScaleByFixedPoint,
   typedef OutputStageQuantizeDownInt32ToUint8ScaleByFixedPoint OutputStage;
 
   OutputStageEvalImpl(const OutputStage& s)
-      : output_stage(s),
-        preshift_offset((s.result_shift < 1) ? 0
-                                             : (1 << (s.result_shift - 1))) {}
+      : output_stage(s) {}
 
   OutputType Eval(InputType input, int, int) const {
     const std::int32_t result_shift = output_stage.result_shift;
     const std::int32_t result_fixedpoint_multiplier =
         output_stage.result_fixedpoint_multiplier;
     const int32x4_t m = vqrdmulhq_n_s32(input, result_fixedpoint_multiplier);
-    const int32x4_t b = vaddq_s32(m, vdupq_n_s32(preshift_offset));
-    const int32x4_t c = vshlq_s32(b, vdupq_n_s32(-result_shift));
+    const int32x4_t c = RoundingDivideByPOT(m, result_shift);
     return vaddq_s32(c, vdupq_n_s32(output_stage.result_offset_after_shift));
   }
 
   const OutputStage& output_stage;
-  const std::int32_t preshift_offset;
 };
 
 // Implementation of OutputStageSaturatingCastToUint8 for NEONFragmentInt32x4x1

--- a/internal/output_neon.h
+++ b/internal/output_neon.h
@@ -146,8 +146,7 @@ struct OutputStageEvalImpl<OutputStageQuantizeDownInt32ToUint8ScaleByFixedPoint,
   typedef NEONFragmentInt32x4x1 OutputType;
   typedef OutputStageQuantizeDownInt32ToUint8ScaleByFixedPoint OutputStage;
 
-  OutputStageEvalImpl(const OutputStage& s)
-      : output_stage(s) {}
+  OutputStageEvalImpl(const OutputStage& s) : output_stage(s) {}
 
   OutputType Eval(InputType input, int, int) const {
     const std::int32_t result_shift = output_stage.result_shift;

--- a/test/test.cc
+++ b/test/test.cc
@@ -1428,10 +1428,14 @@ void TestOutputStages(int rows, int depth, int cols, int result_offset,
   std::vector<std::int32_t> diffs_caused_by_fixedpoint;
   for (int r = 0; r < rows; r++) {
     for (int c = 0; c < cols; c++) {
-      const std::int32_t actual = result_quantized_down_by_fixedpoint_int32(r, c);
+      const std::int32_t actual =
+          result_quantized_down_by_fixedpoint_int32(r, c);
       const std::int32_t raw = result_raw_int32(r, c);
-      const std::int32_t expected = quantize_down_by_fixedpoint_stage.result_offset_after_shift +
-      RoundingDivideByPOT(SaturatingRoundingDoublingHighMul(raw, result_fixedpoint_multiplier), result_fixedpoint_shift);
+      const std::int32_t expected =
+          quantize_down_by_fixedpoint_stage.result_offset_after_shift +
+          RoundingDivideByPOT(SaturatingRoundingDoublingHighMul(
+                                  raw, result_fixedpoint_multiplier),
+                              result_fixedpoint_shift);
       Check(actual == expected);
     }
   }
@@ -1580,7 +1584,6 @@ void test() {
   TestOutputStages<MapOrder::ColMajor>(63, 10, 127, 5, 17, 14);
   TestOutputStages<MapOrder::RowMajor>(630, 10, 1270, 5, 17, 14);
   TestOutputStages<MapOrder::ColMajor>(630, 10, 1270, 5, 17, 14);
-
 
   // Test per channel quantization.
   TestWithSmallDataPerChannelQuantization();

--- a/test/test.cc
+++ b/test/test.cc
@@ -1221,19 +1221,17 @@ void TestOutputStages(int rows, int depth, int cols, int result_offset,
       &context, lhs.const_map(), rhs.const_map(), &result_quantized_down_int32,
       lhs_offset, rhs_offset, quantize_down_pipeline);
 
-  std::uint64_t sum = 0;
+  std::int64_t sum = 0;
   for (int r = 0; r < rows; r++) {
     for (int c = 0; c < cols; c++) {
       std::int32_t raw = result_raw_int32(r, c);
-      const std::int32_t rounding =
-          (result_shift < 1) ? 0 : (1 << (result_shift - 1));
-      std::int32_t expected =
-          ((raw + result_offset) * result_mult_int + rounding) >> result_shift;
+      std::int32_t expected = RoundingDivideByPOT(
+          (raw + result_offset) * result_mult_int, result_shift);
       Check(expected == result_quantized_down_int32(r, c));
       sum += expected;
     }
   }
-  std::uint64_t avg = sum / (rows * cols);
+  std::int64_t avg = sum / (rows * cols);
   // Test that the average quantized-down value falls reasonably in the
   // middle of the [0..255] range. Otherwise, the multiplier / shift need to be
   // adjusted.
@@ -1385,12 +1383,9 @@ void TestOutputStages(int rows, int depth, int cols, int result_offset,
       bias_clamp_quantize_cast_pipeline);
   for (int r = 0; r < rows; r++) {
     for (int c = 0; c < cols; c++) {
-      const std::int32_t rounding =
-          (result_shift < 1) ? 0 : (1 << (result_shift - 1));
-      std::int32_t quantized =
-          ((result_biased_clamped(r, c) + result_offset) * result_mult_int +
-           rounding) >>
-          result_shift;
+      std::int32_t quantized = RoundingDivideByPOT(
+          (result_biased_clamped(r, c) + result_offset) * result_mult_int,
+          result_shift);
       std::uint8_t expected = std::min(std::max(quantized, 0), 255);
       Check(expected == result_biased_clamped_quantized_casted(r, c));
     }
@@ -1433,20 +1428,13 @@ void TestOutputStages(int rows, int depth, int cols, int result_offset,
   std::vector<std::int32_t> diffs_caused_by_fixedpoint;
   for (int r = 0; r < rows; r++) {
     for (int c = 0; c < cols; c++) {
-      std::int32_t diff = result_quantized_down_int32(r, c) -
-                          result_quantized_down_by_fixedpoint_int32(r, c);
-      Check(std::abs(diff) <= 1);
-      diffs_caused_by_fixedpoint.push_back(diff);
+      const std::int32_t actual = result_quantized_down_by_fixedpoint_int32(r, c);
+      const std::int32_t raw = result_raw_int32(r, c);
+      const std::int32_t expected = quantize_down_by_fixedpoint_stage.result_offset_after_shift +
+      RoundingDivideByPOT(SaturatingRoundingDoublingHighMul(raw, result_fixedpoint_multiplier), result_fixedpoint_shift);
+      Check(actual == expected);
     }
   }
-  // For large enough matrices, check that most diffs are 0
-  std::sort(diffs_caused_by_fixedpoint.begin(),
-            diffs_caused_by_fixedpoint.end());
-  Check(
-      diffs_caused_by_fixedpoint[diffs_caused_by_fixedpoint.size() * 1 / 100] ==
-      0);
-  Check(diffs_caused_by_fixedpoint[diffs_caused_by_fixedpoint.size() * 99 /
-                                   100] == 0);
 
   // Test the variant of the familiar default pipeline consisting of
   // quantize-down and
@@ -1592,6 +1580,7 @@ void test() {
   TestOutputStages<MapOrder::ColMajor>(63, 10, 127, 5, 17, 14);
   TestOutputStages<MapOrder::RowMajor>(630, 10, 1270, 5, 17, 14);
   TestOutputStages<MapOrder::ColMajor>(630, 10, 1270, 5, 17, 14);
+
 
   // Test per channel quantization.
   TestWithSmallDataPerChannelQuantization();


### PR DESCRIPTION
This only makes a difference for negative values.

Consequently, the legacy output pipeline (as exposed by Gemm, EightBitIntGemm
entry points) is unaffected. Indeed, since it adds the result_offset
before shifting, and is immediately followed by clamping to [0,255],
the behavior of the rounding shift on negative values is
irrelevant to it. That is why the ReferenceEightBitIntGemm function
in test.cc did not need to be updated.

On the other hand, more general output pipelines are affected. In principle,
it is the task of TestOutputStages to test them. Unfortunately, that function
is not in such a good shape at the moment; for instance, the hard-coded
offsets
  const int lhs_offset = 12;
  const int rhs_offset = -34;
at test.cc:1188 are not large-negative enough to actually produce negative
accumulators and thus exercise the nuance being addressed here. I took a
look at fixing this function and fixed what could be fixed without a
complete rewrite, but ultimately this needs a rewrite to take a fully
principled approach to generating quantized GEMM call patterns from
the quantization of a float GEMM workload, as illustrated in
doc/quantization_example.cc.