### PR TITLE
Remove the old requantizing less-than-8-bit stuff.

### DIFF
--- a/doc/less-than-8-bit.md
+++ b/doc/less-than-8-bit.md
@@ -25,6 +25,9 @@ O(N^3) compute stage. For large enough matrices, that should be worth it.
 
 ### The present
 
+TODO(benoitjacob): update this documentation. This 'present' state just
+became the past (February 2017).
+
 At the moment, this less-than-8-bit mode of gemmlowp is not much used in
 practice, because the implicit requantization of operands from 8bit to
 less-than-8bit turned out to be more expensive than initially expected, both in

--- a/internal/multi_thread_gemm.h
+++ b/internal/multi_thread_gemm.h
@@ -449,13 +449,13 @@ struct GemmWithPackedRhsTask : Task {
       for (int r = 0; r < rows; r += block_params.l2_rows) {
         int rs = std::min(block_params.l2_rows, rows - r);
 
-        PackLhs<BitDepthParams>(&packed_lhs, lhs.block(r, 0, rs, depth));
+        PackLhs(&packed_lhs, lhs.block(r, 0, rs, depth));
 
         Compute(kernel, block_params, &packed_result, packed_lhs, packed_rhs);
 
         auto curr_result_block = MatrixBlockBounds(
             result_block.start_row + r, result_block.start_col + c, rs, cs);
-        UnpackResult<BitDepthParams>(&result, curr_result_block, packed_result,
+        UnpackResult(&result, curr_result_block, packed_result,
                                      depth, packed_lhs.sums_of_each_slice(),
                                      packed_rhs.sums_of_each_slice(),
                                      lhs_offset, rhs_offset, output_pipeline);
@@ -637,7 +637,7 @@ void MultiThreadGemm(GemmContextType* context, const KernelBase& kernel,
     int cs = std::min(block_params.l2_cols, cols - c);
 
     // Pack a large block of the RHS.
-    PackRhs<BitDepthParams>(&packed_rhs, rhs.block(0, c, depth, cs));
+    PackRhs(&packed_rhs, rhs.block(0, c, depth, cs));
 
     // Give work to each worker.
     int next_start_row = 0;

--- a/internal/pack.h
+++ b/internal/pack.h
@@ -29,7 +29,6 @@
 
 #include <cstring>
 
-#include "../public/bit_depth.h"
 #include "allocator.h"
 #include "block_params.h"
 #include "common.h"
@@ -188,94 +187,6 @@ class SideMap {
   int width_, depth_, stride_;
 };
 
-template <RoundingMode tRoundingMode>
-class ScalarRoundingOffsetGenerator {
- public:
-  std::uint8_t get() {
-    assert(false);  // This generic path should never be called.
-    return 0;
-  }
-};
-
-// A RoundingOffsetGenerator for rounding-to-nearest, always returning
-// the midpoint value 127.
-template <>
-class ScalarRoundingOffsetGenerator<RoundingMode::Nearest> {
- public:
-  std::uint8_t get() { return 127; }
-};
-
-// A RoundingOffsetGenerator based on a 8-bit Xorshift.
-// This gives good results as Xorshift naturally generates
-// uniform random *nonzero* bytes i.e. 255 different values,
-// so it only remains for us to subtract one.
-template <>
-class ScalarRoundingOffsetGenerator<RoundingMode::ProbabilisticXorshift> {
- public:
-  ScalarRoundingOffsetGenerator() { x_ = 128; }
-
-  std::uint8_t get() {
-    std::uint8_t result = x_ - 1;
-    // Xorshift8(7,5,3)
-    x_ ^= x_ << 7;
-    x_ ^= x_ >> 5;
-    x_ ^= x_ << 3;
-    return result;
-  }
-
- private:
-  // State
-  std::uint8_t x_;
-};
-
-// A RoundingOffsetGenerator based on an 8-bit add/mod
-// low-discrepancy sequence.  See less-than-8-bit.txt for
-// an explanation (the constant 97 is important - it must
-// be both relatively prime to 255, in order for the sequence
-// to be full-period, and c/255 should be close to 0.38 to
-// obtain low discrepancy).  Uses a small bit hack to avoid
-// expensive % operations.
-template <>
-class ScalarRoundingOffsetGenerator<RoundingMode::ProbabilisticAddmod> {
-  static const std::uint8_t AddConst = 97;
-
- public:
-  ScalarRoundingOffsetGenerator() { x_ = 1; }  // Start must be non-zero
-
-  std::uint8_t get() {
-    // The +'d boolean term causes the increment to skip over 255,
-    // (recalling that 255+1 = 256 = 0 for an 8 bit uint),
-    // thus implementing %255
-    x_ += (AddConst + (x_ >= (255 - AddConst)));
-    return x_;
-  }
-
- private:
-  // State
-  std::uint8_t x_;
-};
-
-// Requantizes a source uint8 value in [0..255] range
-// to the range specified by BitDepth, [0..((2^bits)-1)].
-// Bias must be avoided. Currently this is achieved
-// by probabilistic rounding.
-template <typename QuantizationParams>
-std::uint8_t Requantize(
-    std::uint8_t raw_src_val,
-    ScalarRoundingOffsetGenerator<QuantizationParams::kRoundingMode>*
-        rounding_offset_generator) {
-  static const int kBits = QuantizationParams::BitDepth::kBits;
-  static const std::uint8_t kMaxVal = (1 << kBits) - 1;
-
-  if (kBits == 8) {
-    return raw_src_val;
-  }
-
-  std::uint16_t scaled = static_cast<std::uint16_t>(raw_src_val) * kMaxVal;
-  std::uint8_t rounding_offset = rounding_offset_generator->get();
-  return (scaled + rounding_offset) / 255;
-}
-
 // A PackingRegisterBlock is a small fixed-size block of a matrix being
 // packed. This class is the generic non-optimized implementation,
 // it is inherited by the generic implementation of PackingRegisterBlock,
@@ -292,7 +203,7 @@ std::uint8_t Requantize(
 //   2. Packing a complete block into the destination, see Pack. This is the
 //      most critical part, so it's convenient that unaligned boundaries have
 //      already been handled in step 1.
-template <typename QuantizationParams, typename SrcMapType,
+template <typename SrcMapType,
           typename PackedSideBlock>
 class PackingRegisterBlockBase {
  public:
@@ -304,9 +215,6 @@ class PackingRegisterBlockBase {
   static const int kCellDepth = CellFormat::kDepth;
   static const int kCellSize = CellFormat::kSize;
   static const SideMapOrder kSrcOrder = SrcMapType::kOrder;
-
-  typedef ScalarRoundingOffsetGenerator<QuantizationParams::kRoundingMode>
-      RoundingOffsetGenerator;
 
   PackingRegisterBlockBase() : complete_src_(nullptr, 0, 0, 0) {}
 
@@ -344,8 +252,7 @@ class PackingRegisterBlockBase {
   // Packs a complete block into the destination. This is the most
   // critical part and the part that we most typically want to
   // override in architecture-specific optimized specializations.
-  void Pack(PackedSideBlock* dst, int start_width,
-            RoundingOffsetGenerator* rounding_offset_generator) {
+  void Pack(PackedSideBlock* dst, int start_width) {
     std::uint8_t* dst_ptr = dst->current_data();
     for (int cell_start_depth = 0; cell_start_depth < kRegisterSize;
          cell_start_depth += kCellDepth) {
@@ -359,11 +266,9 @@ class PackingRegisterBlockBase {
         for (int w = 0; w < kCellWidth; w++) {
           std::int32_t sum = 0;
           for (int d = 0; d < kCellDepth; d++) {
-            const std::uint8_t raw_src_val = src_cell_map(w, d);
-            const std::uint8_t requantized = Requantize<QuantizationParams>(
-                raw_src_val, rounding_offset_generator);
-            dst_ptr[OffsetIntoCell<CellFormat>(w, d)] = requantized;
-            sum += requantized;
+            const std::uint8_t src_val = src_cell_map(w, d);
+            dst_ptr[OffsetIntoCell<CellFormat>(w, d)] = src_val;
+            sum += src_val;
           }
           cell_sums_of_each_slice_ptr[w] += sum;
         }
@@ -374,14 +279,14 @@ class PackingRegisterBlockBase {
   }
 };
 
-template <typename QuantizationParams, typename SrcMapType,
+template <typename SrcMapType,
           typename PackedSideBlock>
 class PackingRegisterBlock
-    : public PackingRegisterBlockBase<QuantizationParams, SrcMapType,
+    : public PackingRegisterBlockBase<SrcMapType,
                                       PackedSideBlock> {};
 
 // Large-scale implementation of packing.
-template <typename QuantizationParams, typename SrcMapType,
+template <typename SrcMapType,
           typename PackedSideBlock>
 class PackSideBlockImpl {
  public:
@@ -392,10 +297,8 @@ class PackSideBlockImpl {
   static const int kKernelWidth = CellFormat::kWidth * kCells;
   static const int kCellDepth = CellFormat::kDepth;
 
-  typedef PackingRegisterBlock<QuantizationParams, SrcMapType, PackedSideBlock>
+  typedef PackingRegisterBlock<SrcMapType, PackedSideBlock>
       PackingRegisterBlockType;
-  typedef typename PackingRegisterBlockType::RoundingOffsetGenerator
-      RoundingOffsetGenerator;
 
   PackSideBlockImpl(PackedSideBlock* packed_side_block,
                     const SrcMapType& src_map)
@@ -461,14 +364,14 @@ class PackSideBlockImpl {
         for (int d = 0; d < register_aligned_depth; d += kRegisterSize) {
           b.UseCompleteSrcInPlace(src_map_.block(start_width, start_depth + d,
                                                  width, kRegisterSize));
-          b.Pack(packed_side_block_, start_width, &rounding_offset_generator_);
+          b.Pack(packed_side_block_, start_width);
         }
       }
       if (register_aligned_depth < depth) {
         b.MakeCompleteSrc(
             src_map_.block(start_width, start_depth + register_aligned_depth,
                            width, depth - register_aligned_depth));
-        b.Pack(packed_side_block_, start_width, &rounding_offset_generator_);
+        b.Pack(packed_side_block_, start_width);
       }
     } else {
       assert(width < kKernelWidth);
@@ -476,7 +379,7 @@ class PackSideBlockImpl {
         const int ds = std::min(+kRegisterSize, depth - d);
         b.MakeCompleteSrc(
             src_map_.block(start_width, start_depth + d, width, ds));
-        b.Pack(packed_side_block_, start_width, &rounding_offset_generator_);
+        b.Pack(packed_side_block_, start_width);
       }
     }
   }
@@ -487,23 +390,10 @@ class PackSideBlockImpl {
   // A map on the block of the original matrix block being packed,
   // i.e. the 'source'.
   const SrcMapType& src_map_;
-
-  // Used for requantization in the less-than-8-bit case.
-  // Otherwise unused.
-  RoundingOffsetGenerator rounding_offset_generator_;
-};
-
-// Quantization parameters for the side (LHS or RHS) being packed,
-// with the rounding strategy having been already resolved to a specific
-// rounding mode.
-template <typename tBitDepth, RoundingMode tRoundingMode>
-struct QuantizationParams {
-  typedef tBitDepth BitDepth;
-  static const RoundingMode kRoundingMode = tRoundingMode;
 };
 
 // Packs a block of the input LHS matrix, into a PackedSideBlock
-template <typename BitDepthParams, typename PackedSideBlock,
+template <typename PackedSideBlock,
           typename MatrixMapType>
 void PackLhs(PackedSideBlock* dst, const MatrixMapType& src) {
   ScopedProfilingLabel label("pack LHS");
@@ -513,28 +403,13 @@ void PackLhs(PackedSideBlock* dst, const MatrixMapType& src) {
   typedef typename MatrixMapType::Scalar Scalar;
   typedef SideMap<Scalar, kSideMapOrder> SideMapType;
   SideMapType src_side_map(src.data(), src.rows(), src.cols(), src.stride());
-  typedef typename BitDepthParams::LhsBitDepth BitDepth;
-  typedef typename BitDepthParams::RoundingStrategy RoundingStrategy;
-  const int accumulation_depth = src_side_map.depth();
-  if (accumulation_depth < RoundingStrategy::kRoundingModeSizeThreshold) {
-    typedef QuantizationParams<BitDepth,
-                               RoundingStrategy::kRoundingModeForSmallSizes>
-        QParams;
-    typedef PackSideBlockImpl<QParams, SideMapType, PackedSideBlock> ImplType;
-    ImplType impl(dst, src_side_map);
-    impl.PackL2();
-  } else {
-    typedef QuantizationParams<BitDepth,
-                               RoundingStrategy::kRoundingModeForLargeSizes>
-        QParams;
-    typedef PackSideBlockImpl<QParams, SideMapType, PackedSideBlock> ImplType;
-    ImplType impl(dst, src_side_map);
-    impl.PackL2();
-  }
+  typedef PackSideBlockImpl<SideMapType, PackedSideBlock> ImplType;
+  ImplType impl(dst, src_side_map);
+  impl.PackL2();
 }
 
 // Packs a block of the input RHS matrix, into a PackedSideBlock
-template <typename BitDepthParams, typename PackedSideBlock,
+template <typename PackedSideBlock,
           typename MatrixMapType>
 void PackRhs(PackedSideBlock* dst, const MatrixMapType& src) {
   ScopedProfilingLabel label("pack RHS");
@@ -544,24 +419,9 @@ void PackRhs(PackedSideBlock* dst, const MatrixMapType& src) {
   typedef typename MatrixMapType::Scalar Scalar;
   typedef SideMap<Scalar, kSideMapOrder> SideMapType;
   SideMapType src_side_map(src.data(), src.cols(), src.rows(), src.stride());
-  typedef typename BitDepthParams::RhsBitDepth BitDepth;
-  typedef typename BitDepthParams::RoundingStrategy RoundingStrategy;
-  const int accumulation_depth = src_side_map.depth();
-  if (accumulation_depth < RoundingStrategy::kRoundingModeSizeThreshold) {
-    typedef QuantizationParams<BitDepth,
-                               RoundingStrategy::kRoundingModeForSmallSizes>
-        QParams;
-    typedef PackSideBlockImpl<QParams, SideMapType, PackedSideBlock> ImplType;
-    ImplType impl(dst, src_side_map);
-    impl.PackL2();
-  } else {
-    typedef QuantizationParams<BitDepth,
-                               RoundingStrategy::kRoundingModeForLargeSizes>
-        QParams;
-    typedef PackSideBlockImpl<QParams, SideMapType, PackedSideBlock> ImplType;
-    ImplType impl(dst, src_side_map);
-    impl.PackL2();
-  }
+  typedef PackSideBlockImpl<SideMapType, PackedSideBlock> ImplType;
+  ImplType impl(dst, src_side_map);
+  impl.PackL2();
 }
 
 }  // namespace gemmlowp

--- a/internal/pack_neon.h
+++ b/internal/pack_neon.h
@@ -23,150 +23,18 @@
 
 namespace gemmlowp {
 
-template <RoundingMode tRoundingMode>
-class NEONRoundingOffsetGenerator {
- public:
-  uint8x16_t get() {
-    assert(false);  // This generic path should never be called.
-    return vdupq_n_u8(0);
-  }
-};
-
-// A RoundingOffsetGenerator for rounding-to-nearest, always returning
-// the midpoint value 127.
-template <>
-class NEONRoundingOffsetGenerator<RoundingMode::Nearest> {
- public:
-  uint8x16_t get() { return vdupq_n_u8(127); }
-};
-
-// Variant of NEONRoundingOffsetGenerator that produces
-// random NEON 128-bit vectors using a 8-bit Xorshift.
-template <>
-class NEONRoundingOffsetGenerator<RoundingMode::ProbabilisticXorshift> {
- public:
-  NEONRoundingOffsetGenerator() {
-    std::uint8_t s = 128;
-    std::uint8_t a[16];
-    for (int i = 0; i < 16; i++) {
-      a[i] = s;
-      // Xorshift8(7,7,1). Very important to choose a different
-      // xorshift than we do in get(), otherwise lanes would contain
-      // the same values!
-      s ^= s << 7;
-      s ^= s >> 7;
-      s ^= s << 1;
-    }
-    x_ = vld1q_u8(a);
-  }
-
-  uint8x16_t get() {
-    // Xorshift produces values in [1..255], we want [0..254].
-    uint8x16_t result = vsubq_u8(x_, vdupq_n_u8(1));
-    // Xorshift8(7,5,3)
-    x_ = veorq_u8(x_, vshlq_n_u8(x_, 7));
-    x_ = veorq_u8(x_, vshrq_n_u8(x_, 5));
-    x_ = veorq_u8(x_, vshlq_n_u8(x_, 3));
-    return result;
-  }
-
- private:
-  // State
-  uint8x16_t x_;
-};
-
-// Variant of NEONRoundingOffsetGenerator that produces
-// rounding vectors using an 8-bit add/mod low-discrepancy sequence.
-template <>
-class NEONRoundingOffsetGenerator<RoundingMode::ProbabilisticAddmod> {
- public:
-  NEONRoundingOffsetGenerator() {
-    std::uint8_t s = 128;
-    std::uint8_t a[16];
-    // The initial offset is set by offsetting each lane to one
-    // more iteration of the sequence (s0...s15)  Then, upon iteration,
-    // each lane moves ahead by 16.
-    for (int i = 0; i < 16; i++) {
-      a[i] = s;
-      s += (97 + (s >= 158));
-    }
-    x_ = vld1q_u8(a);
-  }
-
-  uint8x16_t get() {
-    // Get moves the lane ahead by 16 iterations of the sequence
-    // x_ = (x + (16*97)) % 255.  (16*97)%255 = 22.  255-22=233,
-    // so x_ += (22 + (x >= 233)).
-    // There's an excessively opaque bit hack here:
-    // A "true" compare on NEON produces an all-1s result (0xff).
-    // So instead of adding in the comparison result, we subtract it
-    // to get the same effect as adding 1.
-    uint8x16_t extra_one = vcgeq_u8(x_, vdupq_n_u8(233));
-    x_ = vaddq_u8(x_, vdupq_n_u8(22));
-    x_ = vsubq_u8(x_, extra_one);
-    return x_;
-  }
-
- private:
-  // State
-  uint8x16_t x_;
-};
-
-// Requantizes source uint8 values in [0..255] range
-// to the range specified by BitDepth, [0..((2^bits)-1)].
-// Bias must be avoided. Currently this is achieved
-// by probabilistic rounding.
-template <typename QuantizationParams>
-uint8x16_t Requantize(
-    uint8x16_t raw_src_data,
-    NEONRoundingOffsetGenerator<QuantizationParams::kRoundingMode>*
-        rounding_offset_generator) {
-  static const int kBits = QuantizationParams::BitDepth::kBits;
-  static const std::uint8_t kMaxVal = (1 << kBits) - 1;
-
-  if (kBits == 8) {
-    return raw_src_data;
-  }
-
-  uint8x16_t rounding_offset = rounding_offset_generator->get();
-
-  // Compute:
-  //   x = maxval * src + rounding_offset
-  uint16x8_t x[2];
-  const uint8x8_t maxval_dup = vdup_n_u8(kMaxVal);
-  x[0] = vmlal_u8(vmovl_u8(vget_low_u8(rounding_offset)), maxval_dup,
-                  vget_low_u8(raw_src_data));
-  x[1] = vmlal_u8(vmovl_u8(vget_high_u8(rounding_offset)), maxval_dup,
-                  vget_high_u8(raw_src_data));
-
-  // Divide by 255 (truncating).
-  //
-  // Here we use the following formula, valid for all integers y in 0..65534
-  // (which is more than we need since we've already early-returned
-  // if kBits==8).
-  //
-  //     y/255 = (y + 1 + (y >> 8)) >> 8.
-  uint8x8_t result[2];
-  for (int i = 0; i < 2; i++) {
-    result[i] = vshrn_n_u16(
-        vaddq_u16(vaddq_u16(x[i], vdupq_n_u16(1)), vshrq_n_u16(x[i], 8)), 8);
-  }
-
-  return vcombine_u8(result[0], result[1]);
-}
-
 typedef SideMap<const std::uint8_t, SideMapOrder::WidthMajor>
     WidthMajorUint8SideMap;
 
 template <int Cells>
 using DepthMajorSideFormatNCells4x2 = KernelSideFormat<CellFormat<4, 2>, Cells>;
 
-template <typename QuantizationParams, int Cells>
+template <int Cells>
 class PackingRegisterBlock<
-    QuantizationParams, WidthMajorUint8SideMap,
+    WidthMajorUint8SideMap,
     PackedSideBlock<DepthMajorSideFormatNCells4x2<Cells> > >
     : public PackingRegisterBlockBase<
-          QuantizationParams, WidthMajorUint8SideMap,
+          WidthMajorUint8SideMap,
           PackedSideBlock<DepthMajorSideFormatNCells4x2<Cells> > > {
  public:
   typedef DepthMajorSideFormatNCells4x2<Cells> KernelSideFormat;
@@ -177,19 +45,14 @@ class PackingRegisterBlock<
   static const int kCellDepth = CellFormat::kDepth;
   static const int kCellSize = CellFormat::kSize;
 
-  typedef NEONRoundingOffsetGenerator<QuantizationParams::kRoundingMode>
-      RoundingOffsetGenerator;
-
-  void Pack(PackedSideBlock<KernelSideFormat>* dst, int start_width,
-            RoundingOffsetGenerator* rounding_offset_generator) {
+  void Pack(PackedSideBlock<KernelSideFormat>* dst, int start_width) {
     std::uint8_t* dst_ptr = dst->current_data();
     const std::uint8_t* const src_ptr = this->complete_src_.data();
     const int stride = this->complete_src_.stride();
-    // Load and requantize source WidthMajor data
+    // Load source WidthMajor data
     uint8x16_t src_lines[4 * kCells];
     for (int i = 0; i < 4 * kCells; i++) {
-      src_lines[i] = Requantize<QuantizationParams>(
-          vld1q_u8(src_ptr + i * stride), rounding_offset_generator);
+      src_lines[i] = vld1q_u8(src_ptr + i * stride);
     }
     // Reorder the data within registers to make DepthMajor 4x2 cells
     uint8x16x2_t src_lines_intertwined_2x[2 * kCells];
@@ -267,12 +130,12 @@ template <int Cells>
 using WidthMajorSideFormatNCells4x2 =
     KernelSideFormat<CellFormat<4, 2, CellOrder::WidthMajor>, Cells>;
 
-template <typename QuantizationParams, int Cells>
+template <int Cells>
 class PackingRegisterBlock<
-    QuantizationParams, WidthMajorUint8SideMap,
+    WidthMajorUint8SideMap,
     PackedSideBlock<WidthMajorSideFormatNCells4x2<Cells> > >
     : public PackingRegisterBlockBase<
-          QuantizationParams, WidthMajorUint8SideMap,
+          WidthMajorUint8SideMap,
           PackedSideBlock<WidthMajorSideFormatNCells4x2<Cells> > > {
  public:
   typedef WidthMajorSideFormatNCells4x2<Cells> KernelSideFormat;
@@ -283,15 +146,11 @@ class PackingRegisterBlock<
   static const int kCellDepth = CellFormat::kDepth;
   static const int kCellSize = CellFormat::kSize;
 
-  typedef NEONRoundingOffsetGenerator<QuantizationParams::kRoundingMode>
-      RoundingOffsetGenerator;
-
-  void Pack(PackedSideBlock<KernelSideFormat>* dst, int start_width,
-            RoundingOffsetGenerator* rounding_offset_generator) {
+  void Pack(PackedSideBlock<KernelSideFormat>* dst, int start_width) {
     std::uint8_t* dst_ptr = dst->current_data();
     const std::uint8_t* src_ptr = this->complete_src_.data();
     const int stride = this->complete_src_.stride();
-    // Load and requantize source WidthMajor data
+    // Load source WidthMajor data
     uint16x8_t src_lines[kCells * 4];
     for (int i = 0; i < kCells; i++) {
 // This packing path is used with our current
@@ -300,8 +159,7 @@ class PackingRegisterBlock<
 // register allocation) on Nexus 5.
 
 #define GEMMLOWP_UNROLLED_LOOP_ITER(k)                                        \
-  src_lines[4 * i + k] = vreinterpretq_u16_u8(Requantize<QuantizationParams>( \
-      vld1q_u8(src_ptr), rounding_offset_generator));                         \
+  src_lines[4 * i + k] = vreinterpretq_u16_u8(vld1q_u8(src_ptr));             \
   src_ptr += stride;
 
       GEMMLOWP_UNROLLED_LOOP_ITER(0)

--- a/internal/pack_sse.h
+++ b/internal/pack_sse.h
@@ -22,37 +22,6 @@
 
 namespace gemmlowp {
 
-// Requantizes source values pointed by raw_src_ptr in [0..255] range
-// to the range specified by BitDepth, [0..((2^bits)-1)].
-// This is in-place requantization, where the input is
-// not modified if 8bit integers are used. SSE does not
-// have less than 8bit kernels currently. Altought SSE registers
-// hold 16 std::uint8_t elements, only first 8 std::uint8_t elements are
-// requantized. The packing only use first 8 std::uint8_t elements
-// of the SSE registers. Therefore, requantizing all 16 std::uint8_t
-// elements will be wasteful computation.
-template <typename QuantizationParams>
-void SSERequantize(
-    __m128i* raw_src_ptr,
-    ScalarRoundingOffsetGenerator<QuantizationParams::kRoundingMode>*
-        rounding_offset_generator) {
-  static const int kBits = QuantizationParams::BitDepth::kBits;
-  static const std::uint8_t kMaxVal = (1 << kBits) - 1;
-  if (kBits == 8) {
-    return;
-  }
-
-  std::uint8_t* raw_src_ui8_ptr = (std::uint8_t*)&raw_src_ptr[0];
-
-  // modify only first 8 elements in the register (see note above)
-  for (int i = 0; i < 8; ++i) {
-    std::uint16_t scaled =
-        static_cast<std::uint16_t>(raw_src_ui8_ptr[i]) * kMaxVal;
-    std::uint8_t rounding_offset = rounding_offset_generator->get();
-    raw_src_ui8_ptr[i] = (scaled + rounding_offset) / 255;
-  }
-}
-
 // TODO: Add DepthMajorUint8SideMap
 
 typedef SideMap<const std::uint8_t, SideMapOrder::WidthMajor>
@@ -62,12 +31,12 @@ template <int Cells>
 using WidthMajorSideFormatNCells4x2 =
     KernelSideFormat<CellFormat<4, 2, CellOrder::WidthMajor>, Cells>;
 
-template <typename QuantizationParams, int Cells>
+template <int Cells>
 class PackingRegisterBlock<
-    QuantizationParams, WidthMajorUint8SideMap,
+    WidthMajorUint8SideMap,
     PackedSideBlock<WidthMajorSideFormatNCells4x2<Cells> > >
     : public PackingRegisterBlockBase<
-          QuantizationParams, WidthMajorUint8SideMap,
+          WidthMajorUint8SideMap,
           PackedSideBlock<WidthMajorSideFormatNCells4x2<Cells> > > {
  public:
   typedef WidthMajorSideFormatNCells4x2<Cells> KernelSideFormat;
@@ -78,11 +47,7 @@ class PackingRegisterBlock<
   static const int kCellDepth = CellFormat::kDepth;
   static const int kCellSize = CellFormat::kSize;
 
-  typedef ScalarRoundingOffsetGenerator<QuantizationParams::kRoundingMode>
-      RoundingOffsetGenerator;
-
-  void Pack(PackedSideBlock<KernelSideFormat>* dst, int start_width,
-            RoundingOffsetGenerator* rounding_offset_generator) {
+  void Pack(PackedSideBlock<KernelSideFormat>* dst, int start_width) {
     std::uint8_t* dst_ptr = dst->current_data();
     const int width_stride = this->complete_src_.width_stride();
     int depth_step = 8;
@@ -113,20 +78,14 @@ class PackingRegisterBlock<
         __m128i xmm7 = _mm_shuffle_epi32(xmm6, 0x80);
 
         __m128i xmm9 = _mm_blend_epi16(xmm5, xmm7, 0xcc);
-        SSERequantize<QuantizationParams>(&xmm9, rounding_offset_generator);
-
         __m128i xmm10 = _mm_blend_epi16(xmm8, xmm6, 0xcc);
-        SSERequantize<QuantizationParams>(&xmm10, rounding_offset_generator);
 
         _mm_storel_epi64(reinterpret_cast<__m128i*>(&dst_ptr[0]), xmm9);
         _mm_storel_epi64(
             reinterpret_cast<__m128i*>(&dst_ptr[kCellSize * kCells]), xmm10);
 
         __m128i xmm11 = _mm_shuffle_epi32(xmm9, 0xee);
-        SSERequantize<QuantizationParams>(&xmm11, rounding_offset_generator);
-
         __m128i xmm12 = _mm_shuffle_epi32(xmm10, 0xee);
-        SSERequantize<QuantizationParams>(&xmm12, rounding_offset_generator);
 
         _mm_storel_epi64(
             reinterpret_cast<__m128i*>(&dst_ptr[2 * kCellSize * kCells]),

--- a/internal/single_thread_gemm.h
+++ b/internal/single_thread_gemm.h
@@ -110,24 +110,24 @@ void SingleThreadGemm(SingleThreadGemmContext* context,
   const bool pack_rhs_once = block_params.l2_cols >= cols;
 
   if (pack_rhs_once) {
-    PackRhs<BitDepthParams>(&packed_rhs, rhs);
+    PackRhs(&packed_rhs, rhs);
   }
 
   for (int r = 0; r < rows; r += block_params.l2_rows) {
     int rs = std::min(block_params.l2_rows, rows - r);
 
-    PackLhs<BitDepthParams>(&packed_lhs, lhs.block(r, 0, rs, depth));
+    PackLhs(&packed_lhs, lhs.block(r, 0, rs, depth));
 
     for (int c = 0; c < cols; c += block_params.l2_cols) {
       int cs = std::min(block_params.l2_cols, cols - c);
 
       if (!pack_rhs_once) {
-        PackRhs<BitDepthParams>(&packed_rhs, rhs.block(0, c, depth, cs));
+        PackRhs(&packed_rhs, rhs.block(0, c, depth, cs));
       }
 
       Compute(kernel, block_params, &packed_result, packed_lhs, packed_rhs);
 
-      UnpackResult<BitDepthParams>(
+      UnpackResult(
           result, MatrixBlockBounds(r, c, rs, cs), packed_result, depth,
           packed_lhs.sums_of_each_slice(), packed_rhs.sums_of_each_slice(),
           lhs_offset, rhs_offset, output_pipeline);

--- a/internal/unpack.h
+++ b/internal/unpack.h
@@ -55,38 +55,6 @@ class PackedResult {
   const BlockParams& block_params_;
 };
 
-template <std::uint32_t numerator, std::uint32_t denominator>
-std::int32_t RoundingMultiplyByConstantFraction(std::int32_t x) {
-  if (numerator == denominator) {
-    return x;
-  }
-
-  // We'll use only signed arithmetic here. This is
-  // simpler (since this function operates on signed int32's) and
-  // more friendly to ARM NEON, where this allows us to use the
-  // VQRDMULH instruction.
-  static const std::int32_t int_quotient =
-      (numerator + denominator / 2) / denominator;
-  static const std::int32_t remaining_numerator =
-      numerator - int_quotient * denominator;
-  static const std::int32_t scaled_remaining_numerator =
-      static_cast<std::int32_t>(
-          (static_cast<std::int64_t>(remaining_numerator) * (1ll << 31)) /
-          denominator);
-
-  const std::int64_t scaled_remaining_product =
-      static_cast<std::int64_t>(x) *
-      static_cast<std::int64_t>(scaled_remaining_numerator);
-
-  const std::int32_t scaled_remaining_product_nudge =
-      (scaled_remaining_product > 0 ? 1 : -1) * (1 << 30);
-
-  const std::int32_t remaining_product = static_cast<std::int32_t>(
-      (scaled_remaining_product + scaled_remaining_product_nudge) / (1u << 31));
-
-  return x * int_quotient + remaining_product;
-}
-
 struct MatrixBlockBounds {
   int start_row;
   int start_col;
@@ -100,7 +68,7 @@ struct MatrixBlockBounds {
         cols(cols_) {}
 };
 
-template <typename BitDepthParams, typename ResultBlockType,
+template <typename ResultBlockType,
           typename PackedResultType, typename LhsOffset, typename RhsOffset,
           typename OutputPipelineType>
 struct UnpackResultImplGeneric {
@@ -117,10 +85,6 @@ struct UnpackResultImplGeneric {
     auto src_map = src.Map();
     // No top-level blocking in the depth dimension at the moment.
     // Too much loss of precision.
-    const int kLhsBits = BitDepthParams::LhsBitDepth::kBits;
-    const int kRhsBits = BitDepthParams::RhsBitDepth::kBits;
-    const std::int32_t kLhsMax = (1 << kLhsBits) - 1;
-    const std::int32_t kRhsMax = (1 << kRhsBits) - 1;
     OutputPipelineExecutor<OutputPipelineType, FragmentInt32x1x1>
         output_pipeline_executor(output_pipeline);
     for (int c = 0; c < dst_block.cols; c++) {
@@ -131,18 +95,9 @@ struct UnpackResultImplGeneric {
         //   doc/low-precision.txt
         //   doc/less-than-8-bit.txt
         // We have 4 terms to sum: xx, x1, 1x, 11.
-        // In case of requantization, we first need to scale them back
-        // to the original scale, using RoundingMultiplyByConstantFraction.
-        std::int32_t raw_xx = src_map(r, c);
-        std::int32_t raw_x1 = lhs_sums_of_each_slice[r] * rhs_offset(c_dst);
-        std::int32_t raw_1x = rhs_sums_of_each_slice[c] * lhs_offset(r_dst);
-        std::int32_t term_xx =
-            RoundingMultiplyByConstantFraction<255 * 255, kLhsMax * kRhsMax>(
-                raw_xx);
-        std::int32_t term_x1 =
-            RoundingMultiplyByConstantFraction<255, kLhsMax>(raw_x1);
-        std::int32_t term_1x =
-            RoundingMultiplyByConstantFraction<255, kRhsMax>(raw_1x);
+        std::int32_t term_xx = src_map(r, c);
+        std::int32_t term_x1 = lhs_sums_of_each_slice[r] * rhs_offset(c_dst);
+        std::int32_t term_1x = rhs_sums_of_each_slice[c] * lhs_offset(r_dst);
         std::int32_t term_11 = lhs_offset(r_dst) * rhs_offset(c_dst) * depth;
         // Sum the 4 terms.
         FragmentInt32x1x1 sum = term_xx + term_x1 + term_1x + term_11;
@@ -153,14 +108,14 @@ struct UnpackResultImplGeneric {
   }
 };
 
-template <typename BitDepthParams, typename ResultBlockType,
+template <typename ResultBlockType,
           typename PackedResultType, typename LhsOffset, typename RhsOffset,
           typename OutputPipelineType>
 struct UnpackResultImpl
-    : UnpackResultImplGeneric<BitDepthParams, ResultBlockType, PackedResultType,
+    : UnpackResultImplGeneric<ResultBlockType, PackedResultType,
                               LhsOffset, RhsOffset, OutputPipelineType> {};
 
-template <typename BitDepthParams, typename ResultBlockType,
+template <typename ResultBlockType,
           typename PackedResultType, typename LhsOffset, typename RhsOffset,
           typename OutputPipelineType>
 void UnpackResult(ResultBlockType* dst, const MatrixBlockBounds& dst_block,
@@ -170,7 +125,7 @@ void UnpackResult(ResultBlockType* dst, const MatrixBlockBounds& dst_block,
                   const LhsOffset& lhs_offset, const RhsOffset& rhs_offset,
                   const OutputPipelineType& output_pipeline) {
   ScopedProfilingLabel label("unpack");
-  UnpackResultImpl<BitDepthParams, ResultBlockType, PackedResultType, LhsOffset,
+  UnpackResultImpl<ResultBlockType, PackedResultType, LhsOffset,
                    RhsOffset,
                    OutputPipelineType>::Unpack(dst, dst_block, src, depth,
                                                lhs_sums_of_each_slice,

--- a/internal/unpack_neon.h
+++ b/internal/unpack_neon.h
@@ -24,30 +24,6 @@
 
 namespace gemmlowp {
 
-template <std::uint32_t numerator, std::uint32_t denominator>
-int32x4_t RoundingMultiplyByConstantFraction(int32x4_t x) {
-  static_assert(numerator > 0 && denominator > 0,
-                "only supporting positive num/denom");
-
-  if (numerator == denominator) {
-    return x;
-  }
-
-  static const std::int32_t int_quotient =
-      (numerator + denominator / 2) / denominator;
-  static const std::int32_t remaining_numerator =
-      numerator - int_quotient * denominator;
-  static const std::int32_t scaled_remaining_numerator =
-      static_cast<std::int32_t>(
-          (static_cast<std::int64_t>(remaining_numerator) * (1ll << 31)) /
-          denominator);
-  // Note: vqrdmulh instruction is rounding doubling multiply high.
-  const int32x4_t remaining_product =
-      vqrdmulhq_n_s32(x, scaled_remaining_numerator);
-
-  return vmlaq_n_s32(remaining_product, x, int_quotient);
-}
-
 template <typename tScalar, VectorShape tShape>
 int32x4_t get_int32x4_t_and_inc(
     ConstIterator<VectorMap<tScalar, tShape>>* iterator) {
@@ -65,11 +41,11 @@ int32x4_t get_int32x4_t_and_inc(
   return result;
 }
 
-template <typename BitDepthParams, typename PackedResultType,
+template <typename PackedResultType,
           typename OutputScalar, typename LhsOffset, typename RhsOffset,
           typename OutputPipelineType>
 struct UnpackResultImpl<
-    BitDepthParams, MatrixMap<OutputScalar, MapOrder::ColMajor>,
+    MatrixMap<OutputScalar, MapOrder::ColMajor>,
     PackedResultType, LhsOffset, RhsOffset, OutputPipelineType> {
   typedef MatrixMap<OutputScalar, MapOrder::ColMajor> ResultBlockType;
   static void Unpack(ResultBlockType* dst, const MatrixBlockBounds& dst_block,
@@ -83,10 +59,6 @@ struct UnpackResultImpl<
     assert(dst_block.start_row + dst_block.rows <= dst->rows());
     assert(dst_block.start_col >= 0);
     assert(dst_block.start_col + dst_block.cols <= dst->cols());
-    const int kLhsBits = BitDepthParams::LhsBitDepth::kBits;
-    const int kRhsBits = BitDepthParams::RhsBitDepth::kBits;
-    const std::int32_t kLhsMax = (1 << kLhsBits) - 1;
-    const std::int32_t kRhsMax = (1 << kRhsBits) - 1;
     auto src_map = src.Map();
     OutputPipelineExecutor<OutputPipelineType, FragmentInt32x1x1>
         output_pipeline_executor_int32x1x1(output_pipeline);
@@ -110,39 +82,23 @@ struct UnpackResultImpl<
         // Compute the sum of the 4 terms,
         //   q = term_xx + term_x1 + term_1x_plus_term_11
         // Refer to the generic code in unpack.h.
-        int32x4_t raw_xx[4];
-        for (int i = 0; i < 4; i++) {
-          raw_xx[i] = vld1q_s32(src_ptr);
-          src_ptr += 4;
-        }
-        int32x4_t raw_x1[4];
-        for (int i = 0; i < 4; i++) {
-          const int32x4_t sum_x1 = vld1q_s32(sums_of_each_slice_ptr);
-          raw_x1[i] = vmulq_n_s32(sum_x1, rhs_offset_c);
-          sums_of_each_slice_ptr += 4;
-        }
-        int32x4_t raw_1x[4];
-        int32x4_t term_11[4];
-        for (int i = 0; i < 4; i++) {
-          const int32x4_t lhs_offsets = get_int32x4_t_and_inc(&lhs_offset_iter);
-          raw_1x[i] = vmulq_n_s32(lhs_offsets, rhs_sums_of_each_slice_c);
-          term_11[i] = vmulq_n_s32(lhs_offsets, rhs_offset_c * depth);
-        }
         int32x4_t term_xx[4];
         for (int i = 0; i < 4; i++) {
-          term_xx[i] =
-              RoundingMultiplyByConstantFraction<255 * 255, kLhsMax * kRhsMax>(
-                  raw_xx[i]);
+          term_xx[i] = vld1q_s32(src_ptr);
+          src_ptr += 4;
         }
         int32x4_t term_x1[4];
         for (int i = 0; i < 4; i++) {
-          term_x1[i] =
-              RoundingMultiplyByConstantFraction<255, kLhsMax>(raw_x1[i]);
+          const int32x4_t sum_x1 = vld1q_s32(sums_of_each_slice_ptr);
+          term_x1[i] = vmulq_n_s32(sum_x1, rhs_offset_c);
+          sums_of_each_slice_ptr += 4;
         }
         int32x4_t term_1x[4];
+        int32x4_t term_11[4];
         for (int i = 0; i < 4; i++) {
-          term_1x[i] =
-              RoundingMultiplyByConstantFraction<255, kRhsMax>(raw_1x[i]);
+          const int32x4_t lhs_offsets = get_int32x4_t_and_inc(&lhs_offset_iter);
+          term_1x[i] = vmulq_n_s32(lhs_offsets, rhs_sums_of_each_slice_c);
+          term_11[i] = vmulq_n_s32(lhs_offsets, rhs_offset_c * depth);
         }
         int32x4x4_t q;
         for (int i = 0; i < 4; i++) {
@@ -160,21 +116,14 @@ struct UnpackResultImpl<
         // Compute the sum of the 4 terms,
         //   q = term_xx + term_x1 + term_1x_plus_term_11
         // Refer to the generic code in unpack.h.
-        const int32x4_t raw_xx = vld1q_s32(src_ptr);
+        const int32x4_t term_xx = vld1q_s32(src_ptr);
         src_ptr += 4;
-        const int32x4_t term_xx =
-            RoundingMultiplyByConstantFraction<255 * 255, kLhsMax * kRhsMax>(
-                raw_xx);
         const int32x4_t sum_x1 = vld1q_s32(sums_of_each_slice_ptr);
-        const int32x4_t raw_x1 = vmulq_n_s32(sum_x1, rhs_offset_c);
+        const int32x4_t term_x1 = vmulq_n_s32(sum_x1, rhs_offset_c);
         sums_of_each_slice_ptr += 4;
-        const int32x4_t term_x1 =
-            RoundingMultiplyByConstantFraction<255, kLhsMax>(raw_x1);
         const int32x4_t lhs_offsets = get_int32x4_t_and_inc(&lhs_offset_iter);
-        const int32x4_t raw_1x =
-            vmulq_n_s32(lhs_offsets, rhs_sums_of_each_slice_c);
         const int32x4_t term_1x =
-            RoundingMultiplyByConstantFraction<255, kRhsMax>(raw_1x);
+            vmulq_n_s32(lhs_offsets, rhs_sums_of_each_slice_c);
         const int32x4_t term_11 =
             vmulq_n_s32(lhs_offsets, rhs_offset_c * depth);
         int32x4_t q =
@@ -187,17 +136,10 @@ struct UnpackResultImpl<
       // to the code in unpack.h, see comments there.
       for (int r = dst_rows_aligned4; r < dst_block.rows; r++) {
         int r_dst = r + dst_block.start_row;
-        const std::int32_t raw_xx = src_map(r, c);
-        const std::int32_t raw_x1 = lhs_sums_of_each_slice[r] * rhs_offset_c;
-        const std::int32_t raw_1x =
-            rhs_sums_of_each_slice_c * lhs_offset(r_dst);
-        const std::int32_t term_xx =
-            RoundingMultiplyByConstantFraction<255 * 255, kLhsMax * kRhsMax>(
-                raw_xx);
-        const std::int32_t term_x1 =
-            RoundingMultiplyByConstantFraction<255, kLhsMax>(raw_x1);
+        const std::int32_t term_xx = src_map(r, c);
+        const std::int32_t term_x1 = lhs_sums_of_each_slice[r] * rhs_offset_c;
         const std::int32_t term_1x =
-            RoundingMultiplyByConstantFraction<255, kRhsMax>(raw_1x);
+            rhs_sums_of_each_slice_c * lhs_offset(r_dst);
         const std::int32_t term_11 = lhs_offset(r) * rhs_offset(c) * depth;
         FragmentInt32x1x1 sum = term_xx + term_x1 + term_1x + term_11;
         output_pipeline_executor_int32x1x1.Execute(sum, dst, r_dst, c_dst);

--- a/public/bit_depth.h
+++ b/public/bit_depth.h
@@ -12,113 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// bit_depth.h: defines the BitDepthSetting enum
+// bit_depth.h: defines the settins controlling LHS/RHS bit depth
 
 #ifndef GEMMLOWP_PUBLIC_BIT_DEPTH_H_
 #define GEMMLOWP_PUBLIC_BIT_DEPTH_H_
 
 namespace gemmlowp {
 
-// A specific bit depth to requantize an operand (Lhs or Rhs) to.
-// The case tBits==8 means no requantization, since at the moment
-// we only accept 8-bit input data.
+// A specific bit depth of an operand (Lhs or Rhs).
 template <int tBits>
 struct BitDepth {
   static const int kBits = tBits;
   static_assert(kBits >= 1 && kBits <= 8, "bad bit depth");
 };
 
-// A rounding mode to use when requantizing an operand.
-// The requantizing operation is:
-//   dst = (src * maxval + rounding_offset) / 255;
-// Where dst and src are uint8, maxval is 2^(dstbits)-1,
-// and the intermediate values are computed as uint16s
-// so no overflow occurs.
-// The rounding_offset in the above formula is a value
-// in [0..254] determined by the RoundingMode as follows:
-enum class RoundingMode {
-  Exact,                  // No rounding, do nothing. Use with bit_depth == 8.
-  Nearest,                // rounding_offset = 127
-  ProbabilisticXorshift,  // rounding_offset given by 8-bit Xorshift PRNG
-  ProbabilisticAddmod     // rounding_offset given by 8-bit add/mod LDSG
-};
-
-// A rounding strategy is a heuristic for choosing a rounding mode.
-// When the bit depth is 8 bit like the source, there is no
-// quantization to be done, so this is moot. In this case, we use
-// the following "no-op" "strategy",
-struct ExactRoundingStrategyFor8Bit {
-  static const RoundingMode kRoundingModeForSmallSizes = RoundingMode::Exact;
-  static const RoundingMode kRoundingModeForLargeSizes = RoundingMode::Exact;
-  static const int kRoundingModeSizeThreshold = 0;
-};
-
-// Default rounding strategy when actually requantizing to less than 8 bit.
-// Round-to-nearest tends to give the best results for small enough
-// accumulation sizes (i.e. accumulation depth, but we refrain from using
-// the word "depth" here as it gets confusing with "bit depth").
-// Some flavor of probabilistic tends to perform better for larger sizes.
-// See doc/less-than-8-bit.txt for details.
-struct DefaultRoundingStrategyForLessThan8Bit {
-  static const RoundingMode kRoundingModeForSmallSizes = RoundingMode::Nearest;
-  static const RoundingMode kRoundingModeForLargeSizes =
-      RoundingMode::ProbabilisticAddmod;
-
-  // The threshold on the depth dimension at which we switch to
-  // probabilistic rounding instead of rounding-to-nearest when
-  // requantizing input data. Indeed, both statistical theory and
-  // empirical measurements show that for given input data and bit depth,
-  // probabilistic rounding gives more accurate results for large enough
-  // depth, while rounding-to-nearest does for smaller depth. This threshold
-  // is naively determined from some experiments with Inception at 7bit/5bit
-  // on a set of 10,000 images with 8-bit Xorshift probabilistic rounding:
-  //
-  //   7 bit weights, 5 bit activations, switch at 64:   59.82% top-1 accuracy
-  //   7 bit weights, 5 bit activations, switch at 128:  59.58% top-1 accuracy
-  //   7 bit weights, 5 bit activations, switch at 192:  63.37% top-1 accuracy
-  //   7 bit weights, 5 bit activations, switch at 256:  63.47% top-1 accuracy
-  //   7 bit weights, 5 bit activations, switch at 320:  63.71% top-1 accuracy
-  //   7 bit weights, 5 bit activations, switch at 384:  63.71% top-1 accuracy
-  //   7 bit weights, 5 bit activations, switch at 448:  63.58% top-1 accuracy
-  //   7 bit weights, 5 bit activations, switch at 512:  64.10% top-1 accuracy
-  //   7 bit weights, 5 bit activations, switch at 640:  62.49% top-1 accuracy
-  //   7 bit weights, 5 bit activations, switch at 768:  62.49% top-1 accuracy
-  //   7 bit weights, 5 bit activations, switch at 1024: 58.96% top-1 accuracy
-  //
-  // So here, 384 looks comfortably in the middle of a plateau of good values,
-  // and it's a roundish number (3/2 * 256) so let's stick with that for now.
-  // It would be nice to work out the theory of this, and understand how this
-  // should depend on the distribution of inputs and the bit depth.
-  //
-  // Repeating the same evaluation with AddMod:
-  //   7 bit weights, 5 bit activations, switch at 64:   62.65% top-1 accuracy
-  //   7 bit weights, 5 bit activations, switch at 128:  62.65% top-1 accuracy
-  //   7 bit weights, 5 bit activations, switch at 192:  63.81% top-1 accuracy
-  //   7 bit weights, 5 bit activations, switch at 256:  64.23% top-1 accuracy
-  //   7 bit weights, 5 bit activations, switch at 320:  64.16% top-1 accuracy
-  //   7 bit weights, 5 bit activations, switch at 384:  64.16% top-1 accuracy
-  //   7 bit weights, 5 bit activations, switch at 448:  64.16% top-1 accuracy
-  //   7 bit weights, 5 bit activations, switch at 512:  64.52% top-1 accuracy
-  //   7 bit weights, 5 bit activations, switch at 640:  62.74% top-1 accuracy
-  //   7 bit weights, 5 bit activations, switch at 768:  62.74% top-1 accuracy
-  //   7 bit weights, 5 bit activations, switch at 1024: 59.74% top-1 accuracy
-  //
-  // The behavior is similar, so 384 remains a good choice.
-
-  static const int kRoundingModeSizeThreshold = 384;
-};
-
+// Default: LHS and RHS are 8bit.
 struct DefaultL8R8BitDepthParams {
   typedef BitDepth<8> LhsBitDepth;
   typedef BitDepth<8> RhsBitDepth;
-  typedef ExactRoundingStrategyFor8Bit RoundingStrategy;
 };
 
-struct DefaultL7R5BitDepthParams {
-  typedef BitDepth<7> LhsBitDepth;
-  typedef BitDepth<5> RhsBitDepth;
-  typedef DefaultRoundingStrategyForLessThan8Bit RoundingStrategy;
-};
+// Deprecated: when gemmlowp used to allow requantizing 8bit
+// inputs to less-than-8-bit depths, the public setting allowing
+// that was DefaultL7R5BitDepthParams. That requantization
+// feature has been removed, but as the whole point of that
+// requantization was to make less-than-8-bit an internal
+// optimization without any impact on the API (other than lowering
+// accuracy), we can temporarily support users who were using it
+// by mapping it to the default 8bit behavior.
+using DefaultL7R5BitDepthParams = DefaultL8R8BitDepthParams;
 
 }  // namespace gemmlowp
 

--- a/public/gemmlowp.h
+++ b/public/gemmlowp.h
@@ -25,13 +25,6 @@
 
 namespace gemmlowp {
 
-inline bool IsRequantizationWorthIt(int rows, int cols) {
-  // We pack depth*(rows+cols) and compute depth*rows*cols.
-  // Thus the ratio of compute/packing cost is rows*cols/(rows+cols)
-  // In the square case rows==cols==N, it becomes N/2.
-  return 2 * rows * cols >= (rows + cols) * kMinimumWidthForRequantization;
-}
-
 class GemmContext : public MultiThreadGemmContext {};
 
 // Computes a general matrix product ("GEMM").
@@ -60,33 +53,15 @@ void GemmWithOutputPipelinePC(GemmContextType* context,
   }
 
   if (cols == 1) {
-    if (IsRequantizationWorthIt(rows, cols)) {
-      typedef DefaultKernel<KernelFamily::Gemv, BitDepthParams> Kernel;
-      MultiThreadGemm<typename Kernel::Format, InputScalar, OutputScalar,
-                      BitDepthParams>(context, Kernel(), lhs, rhs, result,
-                                      lhs_offset, rhs_offset, output_pipeline);
-    } else {
-      typedef DefaultKernel<KernelFamily::Gemv, DefaultL8R8BitDepthParams>
-          Kernel;
-      MultiThreadGemm<typename Kernel::Format, InputScalar, OutputScalar,
-                      DefaultL8R8BitDepthParams>(context, Kernel(), lhs, rhs,
-                                                 result, lhs_offset, rhs_offset,
-                                                 output_pipeline);
-    }
+    typedef DefaultKernel<KernelFamily::Gemv, BitDepthParams> Kernel;
+    MultiThreadGemm<typename Kernel::Format, InputScalar, OutputScalar,
+                    BitDepthParams>(context, Kernel(), lhs, rhs, result,
+                                    lhs_offset, rhs_offset, output_pipeline);
   } else {
-    if (IsRequantizationWorthIt(rows, cols)) {
-      typedef DefaultKernel<KernelFamily::Gemm, BitDepthParams> Kernel;
-      MultiThreadGemm<typename Kernel::Format, InputScalar, OutputScalar,
-                      BitDepthParams>(context, Kernel(), lhs, rhs, result,
-                                      lhs_offset, rhs_offset, output_pipeline);
-    } else {
-      typedef DefaultKernel<KernelFamily::Gemm, DefaultL8R8BitDepthParams>
-          Kernel;
-      MultiThreadGemm<typename Kernel::Format, InputScalar, OutputScalar,
-                      DefaultL8R8BitDepthParams>(context, Kernel(), lhs, rhs,
-                                                 result, lhs_offset, rhs_offset,
-                                                 output_pipeline);
-    }
+    typedef DefaultKernel<KernelFamily::Gemm, BitDepthParams> Kernel;
+    MultiThreadGemm<typename Kernel::Format, InputScalar, OutputScalar,
+                    BitDepthParams>(context, Kernel(), lhs, rhs, result,
+                                    lhs_offset, rhs_offset, output_pipeline);
   }
 }
 


### PR DESCRIPTION
Map the DefaultL7R5BitDepthParams setting to DefaultL8R8BitDepthParams
so that this change does not break any user relying on it, since
the whole point of requantization was to make this an implementation
detail.

Instead, from now on, using actual less-than-8-bit settings will only
have the effect of selecting a different GEMM kernel. In other words,
it is now the responsibility of the user to know the actual bit-depth
(i.e. range) of their 8bit values. In exchange for that responsibility,
users of lower-than-8-bit depths will enjoy the increased performance
of corresponding kernels without the overhead of requantization.