### PR TITLE
Experiment with a new ARM64 kernel on signed int8 values

### DIFF
--- a/standalone/neon-gemm-kernel-benchmark.cc
+++ b/standalone/neon-gemm-kernel-benchmark.cc
@@ -1803,19 +1803,18 @@ struct Crazy {
       "dup v31.4s, wzr\n"
 
       "ld1 {v0.16b}, [%[rhs_ptr]], #16\n"
+      "ld1 {v4.16b}, [%[lhs_ptr]], #16\n"
       "ld1 {v1.16b}, [%[rhs_ptr]], #16\n"
+      "ld1 {v5.16b}, [%[lhs_ptr]], #16\n"
       "ld1 {v2.16b}, [%[rhs_ptr]], #16\n"
       "ld1 {v3.16b}, [%[rhs_ptr]], #16\n"
 
-      "ld1 {v4.16b}, [%[lhs_ptr]], #16\n"
-      "ld1 {v5.16b}, [%[lhs_ptr]], #16\n"
-      "ld1 {v6.16b}, [%[lhs_ptr]], #16\n"
-      "ld1 {v7.16b}, [%[lhs_ptr]], #16\n"
-
       "smull    v8.8h,  v0.8b,  v4.8b\n"
       "smull    v9.8h,  v1.8b,  v4.8b\n"
+      "ld1 {v6.16b}, [%[lhs_ptr]], #16\n"
       "smull    v10.8h,  v2.8b,  v4.8b\n"
       "smull    v11.8h,  v3.8b,  v4.8b\n"
+      "ld1 {v7.16b}, [%[lhs_ptr]], #16\n"
       "smull    v12.8h,  v0.8b,  v5.8b\n"
       "smull    v13.8h,  v1.8b,  v5.8b\n"
       "smull    v14.8h,  v2.8b,  v5.8b\n"
@@ -1830,6 +1829,10 @@ struct Crazy {
       "smlal2   v13.8h,  v1.16b,  v5.16b\n"
       "smlal2   v14.8h,  v2.16b,  v5.16b\n"
       "smlal2   v15.8h,  v3.16b,  v5.16b\n"
+
+      "subs %w[depth], %w[depth], #16\n"
+
+      "beq after_loop_last16_%=\n"
 
       "loop_%=:\n"
 
@@ -1956,44 +1959,108 @@ struct Crazy {
 
       "bne loop_%=\n"
 
+      "after_loop_last16_%=:\n"
+
+      "sadalp  v16.4s, v8.8h\n"
+      "smull    v8.8h,  v0.8b,  v6.8b\n"
+      "sadalp  v17.4s, v9.8h\n"
+      "smull    v9.8h,  v1.8b,  v6.8b\n"
+      "sadalp  v18.4s, v10.8h\n"
+      "smull    v10.8h,  v2.8b,  v6.8b\n"
+      "sadalp  v19.4s, v11.8h\n"
+      "smull    v11.8h,  v3.8b,  v6.8b\n"
+      "sadalp  v20.4s, v12.8h\n"
+      "smull    v12.8h,  v0.8b,  v7.8b\n"
+      "sadalp  v21.4s, v13.8h\n"
+      "smull    v13.8h,  v1.8b,  v7.8b\n"
+      "sadalp  v22.4s, v14.8h\n"
+      "smull    v14.8h,  v2.8b,  v7.8b\n"
+      "sadalp  v23.4s, v15.8h\n"
+      "smull    v15.8h,  v3.8b,  v7.8b\n"
+
+      "smlal2   v8.8h,  v0.16b,  v6.16b\n"
+      "smlal2   v9.8h,  v1.16b,  v6.16b\n"
+      "smlal2   v10.8h,  v2.16b,  v6.16b\n"
+      "smlal2   v11.8h,  v3.16b,  v6.16b\n"
+
+      "smlal2   v12.8h,  v0.16b,  v7.16b\n"
+      "smlal2   v13.8h,  v1.16b,  v7.16b\n"
+      "smlal2   v14.8h,  v2.16b,  v7.16b\n"
+      "smlal2   v15.8h,  v3.16b,  v7.16b\n"
+
+      "sadalp  v24.4s, v8.8h\n"
+      "smull    v8.8h,  v0.8b,  v4.8b\n"
+      "sadalp  v25.4s, v9.8h\n"
+      "smull    v9.8h,  v1.8b,  v4.8b\n"
+      "sadalp  v26.4s, v10.8h\n"
+      "smull    v10.8h,  v2.8b,  v4.8b\n"
+      "sadalp  v27.4s, v11.8h\n"
+      "smull    v11.8h,  v3.8b,  v4.8b\n"
+      "sadalp  v28.4s, v12.8h\n"
+      "smull    v12.8h,  v0.8b,  v5.8b\n"
+      "sadalp  v29.4s, v13.8h\n"
+      "smull    v13.8h,  v1.8b,  v5.8b\n"
+      "sadalp  v30.4s, v14.8h\n"
+      "smull    v14.8h,  v2.8b,  v5.8b\n"
+      "sadalp  v31.4s, v15.8h\n"
+
+      "smull    v15.8h,  v3.8b,  v5.8b\n"
+
+      "smlal2   v8.8h,  v0.16b,  v4.16b\n"
+      "smlal2   v9.8h,  v1.16b,  v4.16b\n"
+      "smlal2   v10.8h,  v2.16b,  v4.16b\n"
+      "smlal2   v11.8h,  v3.16b,  v4.16b\n"
+
+      // Loop. Decrement loop index (depth) by 16, since we just handled
+      // 16 levels of depth.  Do this subs a bit before the end of the loop
+      // for better dispatch on A57.
+      "subs %w[depth], %w[depth], #16\n"
+
+      "smlal2   v12.8h,  v0.16b,  v5.16b\n"
+      "smlal2   v13.8h,  v1.16b,  v5.16b\n"
+      "smlal2   v14.8h,  v2.16b,  v5.16b\n"
+      "smlal2   v15.8h,  v3.16b,  v5.16b\n"
+
       // Reduce aggregators horizontally
-      "addp v0.4s, v16.4s, v17.4s\n"
-      "addp v1.4s, v18.4s, v19.4s\n"
-      "addp v2.4s, v20.4s, v21.4s\n"
-      "addp v3.4s, v22.4s, v23.4s\n"
-      "addp v4.4s, v24.4s, v25.4s\n"
-      "addp v5.4s, v26.4s, v27.4s\n"
-      "addp v6.4s, v28.4s, v29.4s\n"
-      "addp v7.4s, v30.4s, v31.4s\n"
+      "addp v0.4s, v16.4s, v20.4s\n"
+      "mov x0, %[accum_ptr]\n"
+      "addp v1.4s, v24.4s, v28.4s\n"
+      "ld1 {v12.16b}, [x0], #16\n"
+      "addp v2.4s, v17.4s, v21.4s\n"
+      "addp v3.4s, v25.4s, v29.4s\n"
+      "ld1 {v13.16b}, [x0], #16\n"
+      "addp v4.4s, v18.4s, v22.4s\n"
+      "addp v5.4s, v26.4s, v30.4s\n"
+      "ld1 {v14.16b}, [x0], #16\n"
+      "addp v6.4s, v19.4s, v23.4s\n"
+      "addp v7.4s, v27.4s, v31.4s\n"
+      "ld1 {v15.16b}, [x0], #16\n"
+      "mov x0, %[accum_ptr]\n"
 
       "addp v8.4s, v0.4s, v1.4s\n"
       "addp v9.4s, v2.4s, v3.4s\n"
       "addp v10.4s, v4.4s, v5.4s\n"
       "addp v11.4s, v6.4s, v7.4s\n"
 
-      "mov x0, %[rowmajor_accumulator_buffer]\n"
-      "st1 {v8.16b}, [x0], #16\n"
-      "st1 {v9.16b}, [x0], #16\n"
-      "st1 {v10.16b}, [x0], #16\n"
-      "st1 {v11.16b}, [x0], #16\n"
+      "add v12.4s, v12.4s, v8.4s\n"
+      "add v13.4s, v13.4s, v9.4s\n"
+      "add v14.4s, v14.4s, v10.4s\n"
+      "add v15.4s, v15.4s, v11.4s\n"
+
+      "st1 {v12.16b}, [x0], #16\n"
+      "st1 {v13.16b}, [x0], #16\n"
+      "st1 {v14.16b}, [x0], #16\n"
+      "st1 {v15.16b}, [x0], #16\n"
       :  // outputs
       [lhs_ptr] "+r"(lhs_ptr), [rhs_ptr] "+r"(rhs_ptr),
       [depth] "+r"(depth)
       :  // inputs
-      [rowmajor_accumulator_buffer] "r"(rowmajor_accumulator_buffer)
+      [accum_ptr] "r"(accum_ptr)
       :  // clobbers
       "cc", "memory", "x0", "v0", "v1", "v2", "v3", "v4", "v5", "v6",
       "v7", "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15", "v16",
       "v17", "v18", "v19", "v20", "v21", "v22", "v23", "v24", "v25", "v26",
       "v27", "v28", "v29", "v30", "v31");
-
-    // accumulate row-major accumulators into global (column-major) accumulators
-    for (int l = 0; l < kLhsWidth; l++) {
-      for (int r = 0; r < kRhsWidth; r++) {
-        accum_ptr[l + kLhsWidth * r] +=
-            rowmajor_accumulator_buffer[r + l * kRhsWidth];
-      }
-    }
   }
 };
 

--- a/standalone/neon-gemm-kernel-benchmark.cc
+++ b/standalone/neon-gemm-kernel-benchmark.cc
@@ -1773,7 +1773,7 @@ struct NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators_noexpand_A57 {
 
 // Faster kernel by ARM. Not expanding operands before multiplication.
 // Tuned for A57. Compare to NEON_32bit_GEMM_Uint8Operands_Uint32Accumulators_noexpand
-struct Crazy {
+struct NEON_64bit_GEMM_Int8Operands_Int32Accumulators_AccumTwoWithin16Bits {
   typedef std::int8_t OperandType;
   typedef std::int32_t AccumulatorType;
   typedef KernelFormat<KernelSideFormat<CellFormat<4, 16, CellOrder::WidthMajor>, 1>,
@@ -3091,7 +3091,7 @@ int main() {
 
 #ifdef __aarch64__
   std::cout << "CPU architecture: ARM 64bit" << std::endl;
-  BENCHMARK(Crazy);
+  BENCHMARK(NEON_64bit_GEMM_Int8Operands_Int32Accumulators_AccumTwoWithin16Bits);
   BENCHMARK(NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators);
   BENCHMARK(NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators_noexpand_A57);
   BENCHMARK(NEON_64bit_GEMM_Int32_WithScalar);

--- a/standalone/neon-gemm-kernel-benchmark.cc
+++ b/standalone/neon-gemm-kernel-benchmark.cc
@@ -1770,9 +1770,6 @@ struct NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators_noexpand_A57 {
   }
 };
 
-
-// Faster kernel by ARM. Not expanding operands before multiplication.
-// Tuned for A57. Compare to NEON_32bit_GEMM_Uint8Operands_Uint32Accumulators_noexpand
 struct NEON_64bit_GEMM_Int8Operands_Int32Accumulators_AccumTwoWithin16Bits {
   typedef std::int8_t OperandType;
   typedef std::int32_t AccumulatorType;

--- a/standalone/neon-gemm-kernel-benchmark.cc
+++ b/standalone/neon-gemm-kernel-benchmark.cc
@@ -1812,6 +1812,25 @@ struct Crazy {
       "ld1 {v6.16b}, [%[lhs_ptr]], #16\n"
       "ld1 {v7.16b}, [%[lhs_ptr]], #16\n"
 
+      "smull    v8.8h,  v0.8b,  v4.8b\n"
+      "smull    v9.8h,  v1.8b,  v4.8b\n"
+      "smull    v10.8h,  v2.8b,  v4.8b\n"
+      "smull    v11.8h,  v3.8b,  v4.8b\n"
+      "smull    v12.8h,  v0.8b,  v5.8b\n"
+      "smull    v13.8h,  v1.8b,  v5.8b\n"
+      "smull    v14.8h,  v2.8b,  v5.8b\n"
+      "smull    v15.8h,  v3.8b,  v5.8b\n"
+
+      "smlal2   v8.8h,  v0.16b,  v4.16b\n"
+      "smlal2   v9.8h,  v1.16b,  v4.16b\n"
+      "smlal2   v10.8h,  v2.16b,  v4.16b\n"
+      "smlal2   v11.8h,  v3.16b,  v4.16b\n"
+
+      "smlal2   v12.8h,  v0.16b,  v5.16b\n"
+      "smlal2   v13.8h,  v1.16b,  v5.16b\n"
+      "smlal2   v14.8h,  v2.16b,  v5.16b\n"
+      "smlal2   v15.8h,  v3.16b,  v5.16b\n"
+
       "loop_%=:\n"
 
       // Overview of register layout:
@@ -1864,45 +1883,25 @@ struct Crazy {
       //                                                Accumulator
       //
 
-      "smull    v8.8h,  v0.8b,  v4.8b\n"
-      "smull    v9.8h,  v1.8b,  v4.8b\n"
-      "smull    v10.8h,  v2.8b,  v4.8b\n"
-      "smull    v11.8h,  v3.8b,  v4.8b\n"
-      "smull    v12.8h,  v0.8b,  v5.8b\n"
-      "smull    v13.8h,  v1.8b,  v5.8b\n"
-      "smull    v14.8h,  v2.8b,  v5.8b\n"
-      "smull    v15.8h,  v3.8b,  v5.8b\n"
 
-      "smlal2   v8.8h,  v0.16b,  v4.16b\n"
-      "smlal2   v9.8h,  v1.16b,  v4.16b\n"
-      "smlal2   v10.8h,  v2.16b,  v4.16b\n"
-      "smlal2   v11.8h,  v3.16b,  v4.16b\n"
-
-      "ld1 {v4.16b}, [%[lhs_ptr]], #16\n"
-
-      "smlal2   v12.8h,  v0.16b,  v5.16b\n"
-      "smlal2   v13.8h,  v1.16b,  v5.16b\n"
-      "smlal2   v14.8h,  v2.16b,  v5.16b\n"
-      "smlal2   v15.8h,  v3.16b,  v5.16b\n"
-
-      "ld1 {v5.16b}, [%[lhs_ptr]], #16\n"
 
       "sadalp  v16.4s, v8.8h\n"
-      "sadalp  v17.4s, v9.8h\n"
-      "sadalp  v18.4s, v10.8h\n"
-      "sadalp  v19.4s, v11.8h\n"
-      "sadalp  v20.4s, v12.8h\n"
-      "sadalp  v21.4s, v13.8h\n"
-      "sadalp  v22.4s, v14.8h\n"
-      "sadalp  v23.4s, v15.8h\n"
-
+      "ld1 {v4.16b}, [%[lhs_ptr]], #16\n"
       "smull    v8.8h,  v0.8b,  v6.8b\n"
+      "sadalp  v17.4s, v9.8h\n"
+      "ld1 {v5.16b}, [%[lhs_ptr]], #16\n"
       "smull    v9.8h,  v1.8b,  v6.8b\n"
+      "sadalp  v18.4s, v10.8h\n"
       "smull    v10.8h,  v2.8b,  v6.8b\n"
+      "sadalp  v19.4s, v11.8h\n"
       "smull    v11.8h,  v3.8b,  v6.8b\n"
+      "sadalp  v20.4s, v12.8h\n"
       "smull    v12.8h,  v0.8b,  v7.8b\n"
+      "sadalp  v21.4s, v13.8h\n"
       "smull    v13.8h,  v1.8b,  v7.8b\n"
+      "sadalp  v22.4s, v14.8h\n"
       "smull    v14.8h,  v2.8b,  v7.8b\n"
+      "sadalp  v23.4s, v15.8h\n"
       "smull    v15.8h,  v3.8b,  v7.8b\n"
 
       "smlal2   v8.8h,  v0.16b,  v6.16b\n"
@@ -1921,21 +1920,39 @@ struct Crazy {
       "smlal2   v15.8h,  v3.16b,  v7.16b\n"
       "ld1 {v3.16b}, [%[rhs_ptr]], #16\n"
 
-      "ld1 {v7.16b}, [%[lhs_ptr]], #16\n"
-
       "sadalp  v24.4s, v8.8h\n"
+      "smull    v8.8h,  v0.8b,  v4.8b\n"
       "sadalp  v25.4s, v9.8h\n"
+      "ld1 {v7.16b}, [%[lhs_ptr]], #16\n"
+      "smull    v9.8h,  v1.8b,  v4.8b\n"
       "sadalp  v26.4s, v10.8h\n"
+      "smull    v10.8h,  v2.8b,  v4.8b\n"
       "sadalp  v27.4s, v11.8h\n"
+      "smull    v11.8h,  v3.8b,  v4.8b\n"
       "sadalp  v28.4s, v12.8h\n"
+      "smull    v12.8h,  v0.8b,  v5.8b\n"
       "sadalp  v29.4s, v13.8h\n"
+      "smull    v13.8h,  v1.8b,  v5.8b\n"
       "sadalp  v30.4s, v14.8h\n"
+      "smull    v14.8h,  v2.8b,  v5.8b\n"
       "sadalp  v31.4s, v15.8h\n"
+
+      "smull    v15.8h,  v3.8b,  v5.8b\n"
+
+      "smlal2   v8.8h,  v0.16b,  v4.16b\n"
+      "smlal2   v9.8h,  v1.16b,  v4.16b\n"
+      "smlal2   v10.8h,  v2.16b,  v4.16b\n"
+      "smlal2   v11.8h,  v3.16b,  v4.16b\n"
 
       // Loop. Decrement loop index (depth) by 16, since we just handled
       // 16 levels of depth.  Do this subs a bit before the end of the loop
       // for better dispatch on A57.
       "subs %w[depth], %w[depth], #16\n"
+
+      "smlal2   v12.8h,  v0.16b,  v5.16b\n"
+      "smlal2   v13.8h,  v1.16b,  v5.16b\n"
+      "smlal2   v14.8h,  v2.16b,  v5.16b\n"
+      "smlal2   v15.8h,  v3.16b,  v5.16b\n"
 
       "bne loop_%=\n"
 

--- a/standalone/neon-gemm-kernel-benchmark.cc
+++ b/standalone/neon-gemm-kernel-benchmark.cc
@@ -1802,6 +1802,16 @@ struct Crazy {
       "dup v30.4s, wzr\n"
       "dup v31.4s, wzr\n"
 
+      "ld1 {v0.16b}, [%[rhs_ptr]], #16\n"
+      "ld1 {v1.16b}, [%[rhs_ptr]], #16\n"
+      "ld1 {v2.16b}, [%[rhs_ptr]], #16\n"
+      "ld1 {v3.16b}, [%[rhs_ptr]], #16\n"
+
+      "ld1 {v4.16b}, [%[lhs_ptr]], #16\n"
+      "ld1 {v5.16b}, [%[lhs_ptr]], #16\n"
+      "ld1 {v6.16b}, [%[lhs_ptr]], #16\n"
+      "ld1 {v7.16b}, [%[lhs_ptr]], #16\n"
+
       "loop_%=:\n"
 
       // Overview of register layout:
@@ -1854,16 +1864,6 @@ struct Crazy {
       //                                                Accumulator
       //
 
-      "ld1 {v0.16b}, [%[rhs_ptr]], #16\n"
-      "ld1 {v1.16b}, [%[rhs_ptr]], #16\n"
-      "ld1 {v2.16b}, [%[rhs_ptr]], #16\n"
-      "ld1 {v3.16b}, [%[rhs_ptr]], #16\n"
-
-      "ld1 {v4.16b}, [%[lhs_ptr]], #16\n"
-      "ld1 {v5.16b}, [%[lhs_ptr]], #16\n"
-      "ld1 {v6.16b}, [%[lhs_ptr]], #16\n"
-      "ld1 {v7.16b}, [%[lhs_ptr]], #16\n"
-
       "smull    v8.8h,  v0.8b,  v4.8b\n"
       "smull    v9.8h,  v1.8b,  v4.8b\n"
       "smull    v10.8h,  v2.8b,  v4.8b\n"
@@ -1877,10 +1877,15 @@ struct Crazy {
       "smlal2   v9.8h,  v1.16b,  v4.16b\n"
       "smlal2   v10.8h,  v2.16b,  v4.16b\n"
       "smlal2   v11.8h,  v3.16b,  v4.16b\n"
+
+      "ld1 {v4.16b}, [%[lhs_ptr]], #16\n"
+
       "smlal2   v12.8h,  v0.16b,  v5.16b\n"
       "smlal2   v13.8h,  v1.16b,  v5.16b\n"
       "smlal2   v14.8h,  v2.16b,  v5.16b\n"
       "smlal2   v15.8h,  v3.16b,  v5.16b\n"
+
+      "ld1 {v5.16b}, [%[lhs_ptr]], #16\n"
 
       "sadalp  v16.4s, v8.8h\n"
       "sadalp  v17.4s, v9.8h\n"
@@ -1904,10 +1909,19 @@ struct Crazy {
       "smlal2   v9.8h,  v1.16b,  v6.16b\n"
       "smlal2   v10.8h,  v2.16b,  v6.16b\n"
       "smlal2   v11.8h,  v3.16b,  v6.16b\n"
+
+      "ld1 {v6.16b}, [%[lhs_ptr]], #16\n"
+
       "smlal2   v12.8h,  v0.16b,  v7.16b\n"
+      "ld1 {v0.16b}, [%[rhs_ptr]], #16\n"
       "smlal2   v13.8h,  v1.16b,  v7.16b\n"
+      "ld1 {v1.16b}, [%[rhs_ptr]], #16\n"
       "smlal2   v14.8h,  v2.16b,  v7.16b\n"
+      "ld1 {v2.16b}, [%[rhs_ptr]], #16\n"
       "smlal2   v15.8h,  v3.16b,  v7.16b\n"
+      "ld1 {v3.16b}, [%[rhs_ptr]], #16\n"
+
+      "ld1 {v7.16b}, [%[lhs_ptr]], #16\n"
 
       "sadalp  v24.4s, v8.8h\n"
       "sadalp  v25.4s, v9.8h\n"

--- a/standalone/neon-gemm-kernel-benchmark.cc
+++ b/standalone/neon-gemm-kernel-benchmark.cc
@@ -27,12 +27,12 @@
 
 /*
 Build and run this benchmark on Android/ARM/32bit:
-export CXX=~/android/toolchains/arm-linux-androideabi-4.8/bin/arm-linux-androideabi-g++
-$CXX -fPIE -pie -O3 --std=c++11 neon-gemm-kernel-benchmark.cc -o benchmark -mfloat-abi=softfp -mfpu=neon && adb push benchmark /data/local/tmp && adb shell /data/local/tmp/benchmark
+export CXX=~/android/toolchains/arm-linux-androideabi/bin/arm-linux-androideabi-clang++
+$CXX -fPIE -static -O3 --std=c++11 neon-gemm-kernel-benchmark.cc -o benchmark -mfloat-abi=softfp -mfpu=neon-vfpv4 && adb push benchmark /data/local/tmp && adb shell /data/local/tmp/benchmark
 
 Build and run this benchmark on Android/ARM/64bit:
-export CXX=~/android/toolchains/aarch64-linux-android-4.9/bin/aarch64-linux-android-g++
-$CXX -fPIE -pie -O3 --std=c++11 neon-gemm-kernel-benchmark.cc -o benchmark && adb push benchmark /data/local/tmp && adb shell /data/local/tmp/benchmark
+export CXX=~/android/toolchains/aarch64-linux-android/bin/aarch64-linux-android-clang++
+$CXX -fPIE -static -O3 --std=c++11 neon-gemm-kernel-benchmark.cc -o benchmark && adb push benchmark /data/local/tmp && adb shell /data/local/tmp/benchmark
 */
 
 #include <sched.h>
@@ -1484,7 +1484,7 @@ struct NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators {
 
       // Loop. Decrement loop index (depth) by 2, since we just handled 2
       // levels of depth.
-      "subs %[depth], %[depth], #2\n"
+      "subs %w[depth], %w[depth], #2\n"
       "bne loop_%=\n"
 
       // Store accumulators
@@ -1719,7 +1719,7 @@ struct NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators_noexpand_A57 {
       // Loop. Decrement loop index (depth) by 16, since we just handled
       // 16 levels of depth.  Do this subs a bit before the end of the loop
       // for better dispatch on A57.
-      "subs %[depth], %[depth], #16\n"
+      "subs %w[depth], %w[depth], #16\n"
       "uadalp v30.4s, v8.8h\n"
       "uadalp v31.4s, v9.8h\n"
 
@@ -1847,7 +1847,7 @@ struct NEON_64bit_GEMM_Int32_WithScalar {
 
       // Loop. Decrement loop index (depth) by 1, since we just handled 1
       // level of depth.
-      "subs %[depth], %[depth], #1\n"
+      "subs %w[depth], %w[depth], #1\n"
       "bne loop_%=\n"
 
       // Store accumulators
@@ -1973,7 +1973,7 @@ struct NEON_64bit_GEMM_Float32_WithVectorDuplicatingScalar {
 
       // Loop. Decrement loop index (depth) by 1, since we just handled 1
       // level of depth.
-      "subs %[depth], %[depth], #1\n"
+      "subs %w[depth], %w[depth], #1\n"
       "bne loop_%=\n"
 
       // Store accumulators
@@ -2090,7 +2090,7 @@ struct NEON_64bit_GEMM_Float32_WithScalar {
 
       // Loop. Decrement loop index (depth) by 1, since we just handled 1
       // level of depth.
-      "subs %[depth], %[depth], #1\n"
+      "subs %w[depth], %w[depth], #1\n"
       "bne loop_%=\n"
 
       // Store accumulators
@@ -2209,7 +2209,7 @@ struct NEON_64bit_GEMM_Float32_WithScalar_A57 {
       // Loop. Decrement loop index (depth) by 1, since we just handled
       // 1 level of depth.  Do this a bit before the end of the loop for
       // better dispatch on A57.
-      "subs %[depth], %[depth], #1\n"
+      "subs %w[depth], %w[depth], #1\n"
       "fmla v30.4s, v4.4s, v1.s[2]\n"
       "fmla v31.4s, v4.4s, v1.s[3]\n"
 
@@ -2381,7 +2381,7 @@ struct NEON_64bit_GEMM_Float32_WithScalar_A53 {
       "nop\n"
       "nop\n"
       "fmla v26.4s, v4.4s, v0.s[2]\n"
-      "subs %[depth], %[depth], #1\n"
+      "subs %w[depth], %w[depth], #1\n"
       "fmla v27.4s, v4.4s, v0.s[3]\n"
       "fmla v28.4s, v4.4s, v1.s[0]\n"
 


### PR DESCRIPTION
This new kernel takes advantage of the fact that int8*int8 sits in [-2^14 ; 2^14 ) therefore two can be accumulated within int16 without overflow. This allows much higher throughput than we thought possible with still bit-for-bit the exact same results as our existing 8bit kernels: 22.5 GFlop/s on the big core of both Pixel XL and Nexus 5X device; 16.6 GFlop/s on the little core Pixel XL; no improvement on the little core of Nexus 5X.

Results on Pixel XL device:

NEON_64bit_GEMM_Int8Operands_Int32Accumulators_AccumTwoWithin16Bits(depth=1024) on CPU #0: 16.6715 Gop/s
NEON_64bit_GEMM_Int8Operands_Int32Accumulators_AccumTwoWithin16Bits(depth=1024) on CPU #1: 16.6488 Gop/s
NEON_64bit_GEMM_Int8Operands_Int32Accumulators_AccumTwoWithin16Bits(depth=1024) on CPU #2: 22.5221 Gop/s
NEON_64bit_GEMM_Int8Operands_Int32Accumulators_AccumTwoWithin16Bits(depth=1024) on CPU #3: 22.5202 Gop/s
NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators(depth=768) on CPU #0: 11.6102 Gop/s
NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators(depth=768) on CPU #1: 11.6271 Gop/s
NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators(depth=768) on CPU #2: 15.6764 Gop/s
NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators(depth=768) on CPU #3: 15.6755 Gop/s
NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators_noexpand_A57(depth=1024) on CPU #0: 12.5515 Gop/s
NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators_noexpand_A57(depth=1024) on CPU #1: 12.5604 Gop/s
NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators_noexpand_A57(depth=1024) on CPU #2: 16.9495 Gop/s
NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators_noexpand_A57(depth=1024) on CPU #3: 16.9529 Gop/s

Results on Nexus 5X device:

NEON_64bit_GEMM_Int8Operands_Int32Accumulators_AccumTwoWithin16Bits(depth=1024) on CPU #0: 8.75869 Gop/s
NEON_64bit_GEMM_Int8Operands_Int32Accumulators_AccumTwoWithin16Bits(depth=1024) on CPU #1: 8.75823 Gop/s
NEON_64bit_GEMM_Int8Operands_Int32Accumulators_AccumTwoWithin16Bits(depth=1024) on CPU #2: 8.75871 Gop/s
NEON_64bit_GEMM_Int8Operands_Int32Accumulators_AccumTwoWithin16Bits(depth=1024) on CPU #3: 8.75836 Gop/s
NEON_64bit_GEMM_Int8Operands_Int32Accumulators_AccumTwoWithin16Bits(depth=1024) on CPU #4: 22.5004 Gop/s
NEON_64bit_GEMM_Int8Operands_Int32Accumulators_AccumTwoWithin16Bits(depth=1024) on CPU #5: 22.5003 Gop/s
NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators(depth=768) on CPU #0: 8.84419 Gop/s
NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators(depth=768) on CPU #1: 8.84215 Gop/s
NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators(depth=768) on CPU #2: 8.84363 Gop/s
NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators(depth=768) on CPU #3: 8.84394 Gop/s
NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators(depth=768) on CPU #4: 12.5687 Gop/s
NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators(depth=768) on CPU #5: 12.565 Gop/s
NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators_noexpand_A57(depth=1024) on CPU #0: 6.38292 Gop/s
NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators_noexpand_A57(depth=1024) on CPU #1: 6.38061 Gop/s
NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators_noexpand_A57(depth=1024) on CPU #2: 6.38206 Gop/s
NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators_noexpand_A57(depth=1024) on CPU #3: 6.38277 Gop/s
NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators_noexpand_A57(depth=1024) on CPU #4: 18.1624 Gop/s
NEON_64bit_GEMM_Uint8Operands_Uint32Accumulators_noexpand_A57(depth=1024) on CPU #5: 18.1637 Gop/s
