### PR TITLE
New fast kernel on ARM64, associated with new L8R8WithLhsNonzeroBitDepthParams

### DIFF
--- a/internal/kernel.h
+++ b/internal/kernel.h
@@ -145,6 +145,12 @@ struct KernelSideFormat {
   static const int kCells = tCells;
   static const int kWidth = kCells * Cell::kWidth;
   static const int kDepth = Cell::kDepth;
+  typedef std::uint8_t Scalar;
+};
+
+template <typename tCellFormat, int tCells>
+struct KernelSideFormatInt8 : KernelSideFormat<tCellFormat, tCells> {
+  typedef std::int8_t Scalar;
 };
 
 // KernelFormat describes fully the input data layout that a kernel expects.
@@ -208,6 +214,19 @@ struct KernelBase {
                    std::size_t run_depth) const = 0;
 
   virtual ~KernelBase() {}
+};
+
+template <typename KernelScalarType>
+struct ZeroPointInputValue {};
+
+template <>
+struct ZeroPointInputValue<std::uint8_t> {
+  static constexpr std::uint8_t kValue = 0;
+};
+
+template <>
+struct ZeroPointInputValue<std::int8_t> {
+  static constexpr std::uint8_t kValue = 128;
 };
 
 }  // namespace gemmlowp

--- a/internal/kernel_default.h
+++ b/internal/kernel_default.h
@@ -20,47 +20,69 @@
 
 #include "../public/bit_depth.h"
 #include "common.h"
+#include "kernel_reference.h"
 
 namespace gemmlowp {
 
 enum class KernelFamily { Gemm, Gemv };
 
-template <KernelFamily Family, int ProductBits>
-struct DefaultKernelImpl : DefaultKernelImpl<Family, ProductBits + 1> {
-  static_assert(ProductBits <= 16, "Bit depth too large");
-};
+template <KernelFamily Family, bool MaxProductIsLessThan4096,
+          bool LhsAlwaysNonzero>
+struct DefaultKernelImpl {};
+
+// Partial specialization implementing the logic that if we want to use
+// a kernel for LhsAlwaysNonzero but do not have such a kernel, then we fall
+// back to a generic kernel not taking advantage of LhsAlwaysNonzero.
+template <KernelFamily Family, bool LhsAlwaysNonzero>
+struct DefaultKernelImpl<Family, true, LhsAlwaysNonzero>
+    : DefaultKernelImpl<Family, false, LhsAlwaysNonzero> {};
+
+// Partial specialization implementing the logic that if we want to use
+// a kernel for MaxProductIsLessThan4096 but do not have such a kernel, then we
+// fall back to a generic kernel not taking advantage of
+// MaxProductIsLessThan4096.
+template <KernelFamily Family, bool MaxProductIsLessThan4096>
+struct DefaultKernelImpl<Family, MaxProductIsLessThan4096, true>
+    : DefaultKernelImpl<Family, MaxProductIsLessThan4096, false> {};
 
 template <KernelFamily Family, typename BitDepthParams>
 struct DefaultKernel
-    : DefaultKernelImpl<Family, BitDepthParams::LhsBitDepth::kBits +
-                                    BitDepthParams::RhsBitDepth::kBits> {};
+    : DefaultKernelImpl<Family,
+                        (BitDepthParams::LhsRange::kMaxValue *
+                             BitDepthParams::RhsRange::kMaxValue <
+                         4096),
+                        (BitDepthParams::LhsRange::kMinValue > 0)> {};
 
 }  // end namespace gemmlowp
 
-#define GEMMLOWP_SET_DEFAULT_KERNEL(op, max_product_bits, kernel)           \
-  namespace gemmlowp {                                                      \
-  template <>                                                               \
-  struct DefaultKernelImpl<KernelFamily::op, max_product_bits> : kernel {}; \
+#define GEMMLOWP_SET_DEFAULT_KERNEL(Op, MaxProductIsLessThan4096,      \
+                                    LhsAlwaysNonzero, Kernel)          \
+  namespace gemmlowp {                                                 \
+  template <>                                                          \
+  struct DefaultKernelImpl<KernelFamily::Op, MaxProductIsLessThan4096, \
+                           LhsAlwaysNonzero> : Kernel {};              \
   }
 
 #if defined GEMMLOWP_NEON_32
 #include "kernel_neon.h"
-GEMMLOWP_SET_DEFAULT_KERNEL(Gemm, 16, NEON_32_Kernel12x4Depth2)
-GEMMLOWP_SET_DEFAULT_KERNEL(Gemm, 12,
+GEMMLOWP_SET_DEFAULT_KERNEL(Gemm, false, false, NEON_32_Kernel12x4Depth2)
+GEMMLOWP_SET_DEFAULT_KERNEL(Gemm, true, false,
                             NEON_32_Kernel12x4Depth2Assuming12BitProducts)
-GEMMLOWP_SET_DEFAULT_KERNEL(Gemv, 16, NEONKernel4Nx1Depth2<3>)
+GEMMLOWP_SET_DEFAULT_KERNEL(Gemv, false, false, NEONKernel4Nx1Depth2<3>)
 #elif defined GEMMLOWP_NEON_64
 #include "kernel_neon.h"
-GEMMLOWP_SET_DEFAULT_KERNEL(Gemm, 16, NEON_64_Kernel12x8Depth2)
-GEMMLOWP_SET_DEFAULT_KERNEL(Gemv, 16, NEONKernel4Nx1Depth2<3>)
+GEMMLOWP_SET_DEFAULT_KERNEL(Gemm, false, false, NEON_64_Kernel12x8Depth2)
+GEMMLOWP_SET_DEFAULT_KERNEL(Gemm, false, true,
+                            NEON_64bit_GEMM_Int8Operands_LhsNonzero)
+GEMMLOWP_SET_DEFAULT_KERNEL(Gemv, false, false, NEONKernel4Nx1Depth2<3>)
 #elif defined GEMMLOWP_SSE4_32
 #include "kernel_sse.h"
-GEMMLOWP_SET_DEFAULT_KERNEL(Gemm, 16, SSE4_32_Kernel4x4Depth2)
-GEMMLOWP_SET_DEFAULT_KERNEL(Gemv, 16, SSE4_32_Kernel4x4Depth2)
+GEMMLOWP_SET_DEFAULT_KERNEL(Gemm, false, false, SSE4_32_Kernel4x4Depth2)
+GEMMLOWP_SET_DEFAULT_KERNEL(Gemv, false, false, SSE4_32_Kernel4x4Depth2)
 #elif defined GEMMLOWP_SSE4_64
 #include "kernel_sse.h"
-GEMMLOWP_SET_DEFAULT_KERNEL(Gemm, 16, SSE4_64_Kernel12x4Depth2)
-GEMMLOWP_SET_DEFAULT_KERNEL(Gemv, 16, SSE4_64_Kernel12x4Depth2)
+GEMMLOWP_SET_DEFAULT_KERNEL(Gemm, false, false, SSE4_64_Kernel12x4Depth2)
+GEMMLOWP_SET_DEFAULT_KERNEL(Gemv, false, false, SSE4_64_Kernel12x4Depth2)
 #else
 #ifndef GEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK
 #error \
@@ -71,10 +93,10 @@ slow fallback, define GEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK."
 #endif
 #include "kernel_reference.h"
 namespace gemmlowp {
-typedef ReferenceKernel<KernelFormat<KernelSideFormat<CellFormat<4, 4>, 2>,
-                                     KernelSideFormat<CellFormat<4, 4>, 2> > >
+typedef ReferenceKernel<KernelFormat<
+    KernelSideFormat<CellFormat<4, 16, CellOrder::WidthMajor>, 1>,
+    KernelSideFormat<CellFormat<4, 16, CellOrder::WidthMajor>, 1> > >
     DefaultReferenceKernel;
-}
 GEMMLOWP_SET_DEFAULT_KERNEL(Gemm, 16, DefaultReferenceKernel)
 GEMMLOWP_SET_DEFAULT_KERNEL(Gemv, 16, DefaultReferenceKernel)
 #endif

--- a/internal/kernel_neon.h
+++ b/internal/kernel_neon.h
@@ -160,7 +160,7 @@ struct NEON_32_Kernel12x4Depth2 : KernelBase {
         /* end of main loop */
 
         /* Accumulate our local accumulator registers into the destination block
-           */
+         */
 
         // Compute stride between consecutive columns, in bytes
         "mov r0, #4\n"  // multiply by 4 = sizeof(int32)
@@ -643,6 +643,328 @@ struct NEON_32_Kernel12x4Depth2Assuming12BitProducts : KernelBase {
 // The kernels here are specifically arm 64bit assembly, not arm 32bit.
 #ifdef GEMMLOWP_NEON_64
 
+struct NEON_64bit_GEMM_Int8Operands_LhsNonzero : KernelBase {
+  typedef KernelFormat<
+      KernelSideFormatInt8<CellFormat<4, 16, CellOrder::WidthMajor>, 1>,
+      KernelSideFormatInt8<CellFormat<4, 16, CellOrder::WidthMajor>, 1> >
+      Format;
+  const char* Name() const override {
+    return "NEON, 4x4, depth 16, accumulating two within signed int16";
+  }
+
+  // TODO(benoitjacob): reorder function arguments so dst comes last
+  void Run(std::int32_t* dst_ptr, std::size_t dst_row_stride,
+           std::size_t dst_col_stride, const std::uint8_t* lhs_ptr,
+           const std::uint8_t* rhs_ptr, std::size_t start_depth,
+           std::size_t run_depth) const override {
+    asm volatile(
+        // Clear accumulators, and, interleaved with it,
+        // initial loads of the first loop iteration,
+        // taken out of the loop so that in the loop itself we have
+        // optimal streaming of data from memory.
+        "ld1 {v0.16b}, [%[rhs_ptr]], #16\n"
+        "dup v16.4s, wzr\n"
+        "ld1 {v4.16b}, [%[lhs_ptr]], #16\n"
+        "dup v17.4s, wzr\n"
+        "ld1 {v1.16b}, [%[rhs_ptr]], #16\n"
+        "dup v18.4s, wzr\n"
+        "ld1 {v5.16b}, [%[lhs_ptr]], #16\n"
+        "dup v19.4s, wzr\n"
+        "ld1 {v2.16b}, [%[rhs_ptr]], #16\n"
+        "dup v20.4s, wzr\n"
+        "ld1 {v3.16b}, [%[rhs_ptr]], #16\n"
+        "dup v21.4s, wzr\n"
+        "ld1 {v6.16b}, [%[lhs_ptr]], #16\n"
+        "dup v22.4s, wzr\n"
+        "ld1 {v7.16b}, [%[lhs_ptr]], #16\n"
+        "dup v23.4s, wzr\n"
+        "dup v24.4s, wzr\n"
+        "dup v25.4s, wzr\n"
+        "dup v26.4s, wzr\n"
+        "dup v27.4s, wzr\n"
+        "dup v28.4s, wzr\n"
+        "dup v29.4s, wzr\n"
+        "dup v30.4s, wzr\n"
+        "dup v31.4s, wzr\n"
+
+        // Multiply dst_col_stride by 4 == sizeof(int32) to use
+        // it as a byte offset below.
+        "lsl %[dst_col_stride], %[dst_col_stride], #2\n"
+
+        // Initial arithmetic of the first loop iteration,
+        // taken out of the loop so that in the loop itself we have
+        // optimal streaming of data from memory.
+        "smull    v8.8h,  v0.8b,  v4.8b\n"
+        "smull    v9.8h,  v1.8b,  v4.8b\n"
+        "smull    v10.8h,  v2.8b,  v4.8b\n"
+        "smull    v11.8h,  v3.8b,  v4.8b\n"
+        "smull    v12.8h,  v0.8b,  v5.8b\n"
+        "smull    v13.8h,  v1.8b,  v5.8b\n"
+        "smull    v14.8h,  v2.8b,  v5.8b\n"
+        "smull    v15.8h,  v3.8b,  v5.8b\n"
+
+        // Multiply-accumulate second-half, again into the same
+        // 16bit local accumulator registers. This is where we
+        // take advantage of having int8 instead of uint8 and therefore
+        // being able to accumulate two products into int16.
+        "smlal2   v8.8h,  v0.16b,  v4.16b\n"
+        "smlal2   v9.8h,  v1.16b,  v4.16b\n"
+        "smlal2   v10.8h,  v2.16b,  v4.16b\n"
+        "smlal2   v11.8h,  v3.16b,  v4.16b\n"
+        "smlal2   v12.8h,  v0.16b,  v5.16b\n"
+        "smlal2   v13.8h,  v1.16b,  v5.16b\n"
+        "smlal2   v14.8h,  v2.16b,  v5.16b\n"
+        "smlal2   v15.8h,  v3.16b,  v5.16b\n"
+
+        "subs %[run_depth], %[run_depth], #16\n"
+
+        // If the loop depth is only 16, then we can skip the general loop
+        // and go straight to the final part of the code.
+        "beq after_loop_last16_%=\n"
+
+        // General loop.
+        "loop_%=:\n"
+
+        // Overview of register layout:
+        //
+        // A 4x16 block of Rhs is stored in 8 bit in v0--v3.
+        // A 4x16 block of Lhs is stored in 8 bit in v4--v7.
+        //
+        // A 4x4 block of accumulators is stored in v16-v31 (as 4x32 bit
+        // components which need to be horizontally-added at the end)
+        //
+        // The Lhs vectors are multiplied by the Rhs vectors with a widening
+        // multiply over the 8 first levels of depth, producing int16x8
+        // vectors of products for each position in the accumulator matrix.
+        // Here comes the special trick: since the operands are signed int8,
+        // their range being [ -2^7 , 2^7 ), their products are in range
+        // [ -2^14 , 2^14 - 1 ), meaning that we can add two such values
+        // without any risk of overflowing int16.
+        // We thus proceed with the 8 next levels of depth, multiplying
+        // again Lhs by Rhs, accumulating into this existing int16x8 vector.
+        //
+        // Only then, having processed 16 levels of depth, do we need to
+        // horizontally add these int16x8 accumulators into the final
+        // int32x4 accumulators.
+        //
+        // As we do not have enough registers to store all 16 int16x8
+        // temporary-16bit-accumulators, we have them cycle through v8--v15.
+        //
+        //
+        // Register layout (ignoring the v8--v15 temporary 16bit accumulators):
+        //
+        //                               +--------+--------+--------+--------+
+        //                               |v0.b[0] |v1.b[0] |v2.b[0] |v3.b[0] |
+        //                          Rhs  +--------+--------+--------+--------+
+        //                               |  ...   |  ...   |  ...   |  ...   |
+        //                               +--------+--------+--------+--------|
+        //                               |v0.b[15]|v1.b[15]|v2.b[15]|v3.b[15]|
+        //                               +--------+--------+--------+--------+
+        //
+        //                               |        |        |        |        |
+        //
+        //    Lhs                        |        |        |        |        |
+        //
+        //  +-------+-----+--------+ - - +--------+--------+--------+--------+
+        //  |v4.b[0]| ... |v4.b[15]|     | v16.4s | v17.4s | v18.4s | v19.4s |
+        //  |v5.b[0]| ... |v5.b[15]|     | v20.4s | v21.4s | v22.4s | v23.4s |
+        //  |v6.b[0]| ... |v6.b[15]|     | v24.4s | v25.4s | v26.4s | v27.4s |
+        //  |v7.b[0]| ... |v7.b[15]|     | v28.4s | v29.4s | v30.4s | v31.4s |
+        //  +-------+--------------+ - - +--------+--------+--------+--------+
+        //
+        //                                                Accumulator
+        //
+
+        // Some multiplications and 16-bit accumulation were already done above,
+        // so we start right away in the middle.
+        "sadalp  v16.4s, v8.8h\n"
+        "ld1 {v4.16b}, [%[lhs_ptr]], #16\n"
+        "smull    v8.8h,  v0.8b,  v6.8b\n"
+        "sadalp  v17.4s, v9.8h\n"
+        "ld1 {v5.16b}, [%[lhs_ptr]], #16\n"
+        "smull    v9.8h,  v1.8b,  v6.8b\n"
+        "sadalp  v18.4s, v10.8h\n"
+        "smull    v10.8h,  v2.8b,  v6.8b\n"
+        "sadalp  v19.4s, v11.8h\n"
+        "smull    v11.8h,  v3.8b,  v6.8b\n"
+        "sadalp  v20.4s, v12.8h\n"
+        "smull    v12.8h,  v0.8b,  v7.8b\n"
+        "sadalp  v21.4s, v13.8h\n"
+        "smull    v13.8h,  v1.8b,  v7.8b\n"
+        "sadalp  v22.4s, v14.8h\n"
+        "smull    v14.8h,  v2.8b,  v7.8b\n"
+        "sadalp  v23.4s, v15.8h\n"
+        "smull    v15.8h,  v3.8b,  v7.8b\n"
+
+        // Multiply-accumulate second-half, again into the same
+        // 16bit local accumulator registers. This is where we
+        // take advantage of having int8 instead of uint8 and therefore
+        // being able to accumulate two products into int16.
+        "smlal2   v8.8h,  v0.16b,  v6.16b\n"
+        "smlal2   v9.8h,  v1.16b,  v6.16b\n"
+        "smlal2   v10.8h,  v2.16b,  v6.16b\n"
+        "smlal2   v11.8h,  v3.16b,  v6.16b\n"
+
+        "ld1 {v6.16b}, [%[lhs_ptr]], #16\n"
+
+        "smlal2   v12.8h,  v0.16b,  v7.16b\n"
+        "ld1 {v0.16b}, [%[rhs_ptr]], #16\n"
+        "smlal2   v13.8h,  v1.16b,  v7.16b\n"
+        "ld1 {v1.16b}, [%[rhs_ptr]], #16\n"
+        "smlal2   v14.8h,  v2.16b,  v7.16b\n"
+        "ld1 {v2.16b}, [%[rhs_ptr]], #16\n"
+        "smlal2   v15.8h,  v3.16b,  v7.16b\n"
+        "ld1 {v3.16b}, [%[rhs_ptr]], #16\n"
+
+        "sadalp  v24.4s, v8.8h\n"
+        "smull    v8.8h,  v0.8b,  v4.8b\n"
+        "sadalp  v25.4s, v9.8h\n"
+        "ld1 {v7.16b}, [%[lhs_ptr]], #16\n"
+        "smull    v9.8h,  v1.8b,  v4.8b\n"
+        "sadalp  v26.4s, v10.8h\n"
+        "smull    v10.8h,  v2.8b,  v4.8b\n"
+        "sadalp  v27.4s, v11.8h\n"
+        "smull    v11.8h,  v3.8b,  v4.8b\n"
+        "sadalp  v28.4s, v12.8h\n"
+        "smull    v12.8h,  v0.8b,  v5.8b\n"
+        "sadalp  v29.4s, v13.8h\n"
+        "smull    v13.8h,  v1.8b,  v5.8b\n"
+        "sadalp  v30.4s, v14.8h\n"
+        "smull    v14.8h,  v2.8b,  v5.8b\n"
+        "sadalp  v31.4s, v15.8h\n"
+        "smull    v15.8h,  v3.8b,  v5.8b\n"
+
+        // Multiply-accumulate second-half, again into the same
+        // 16bit local accumulator registers. This is where we
+        // take advantage of having int8 instead of uint8 and therefore
+        // being able to accumulate two products into int16.
+        "smlal2   v8.8h,  v0.16b,  v4.16b\n"
+        "smlal2   v9.8h,  v1.16b,  v4.16b\n"
+        "smlal2   v10.8h,  v2.16b,  v4.16b\n"
+        "smlal2   v11.8h,  v3.16b,  v4.16b\n"
+
+        // Loop. Decrement loop index (depth) by 16, since we just handled
+        // 16 levels of depth.  Do this subs a bit before the end of the loop
+        // for better dispatch on A57.
+        "subs %[run_depth], %[run_depth], #16\n"
+
+        "smlal2   v12.8h,  v0.16b,  v5.16b\n"
+        "smlal2   v13.8h,  v1.16b,  v5.16b\n"
+        "smlal2   v14.8h,  v2.16b,  v5.16b\n"
+        "smlal2   v15.8h,  v3.16b,  v5.16b\n"
+
+        "bne loop_%=\n"
+
+        // Final code for the last 16 levels of depth.
+        // There is nothing to load anymore, only some arithmetic to finish.
+        "after_loop_last16_%=:\n"
+
+        // Some multiplications and 16-bit accumulation were already done above,
+        // so we start right away in the middle.
+        "sadalp  v16.4s, v8.8h\n"
+        "smull    v8.8h,  v0.8b,  v6.8b\n"
+        "sadalp  v17.4s, v9.8h\n"
+        "smull    v9.8h,  v1.8b,  v6.8b\n"
+        "sadalp  v18.4s, v10.8h\n"
+        "smull    v10.8h,  v2.8b,  v6.8b\n"
+        "sadalp  v19.4s, v11.8h\n"
+        "smull    v11.8h,  v3.8b,  v6.8b\n"
+        "sadalp  v20.4s, v12.8h\n"
+        "smull    v12.8h,  v0.8b,  v7.8b\n"
+        "sadalp  v21.4s, v13.8h\n"
+        "smull    v13.8h,  v1.8b,  v7.8b\n"
+        "sadalp  v22.4s, v14.8h\n"
+        "smull    v14.8h,  v2.8b,  v7.8b\n"
+        "sadalp  v23.4s, v15.8h\n"
+        "smull    v15.8h,  v3.8b,  v7.8b\n"
+
+        // Multiply-accumulate second-half, again into the same
+        // 16bit local accumulator registers. This is where we
+        // take advantage of having int8 instead of uint8 and therefore
+        // being able to accumulate two products into int16.
+        "smlal2   v8.8h,  v0.16b,  v6.16b\n"
+        "smlal2   v9.8h,  v1.16b,  v6.16b\n"
+        "smlal2   v10.8h,  v2.16b,  v6.16b\n"
+        "smlal2   v11.8h,  v3.16b,  v6.16b\n"
+        "smlal2   v12.8h,  v0.16b,  v7.16b\n"
+        "smlal2   v13.8h,  v1.16b,  v7.16b\n"
+        "smlal2   v14.8h,  v2.16b,  v7.16b\n"
+        "smlal2   v15.8h,  v3.16b,  v7.16b\n"
+
+        "sadalp  v24.4s, v8.8h\n"
+        "sadalp  v25.4s, v9.8h\n"
+        "sadalp  v26.4s, v10.8h\n"
+        "sadalp  v27.4s, v11.8h\n"
+        "sadalp  v28.4s, v12.8h\n"
+        "sadalp  v29.4s, v13.8h\n"
+        "sadalp  v30.4s, v14.8h\n"
+        "sadalp  v31.4s, v15.8h\n"
+
+        // Reduce 32bit accumulators horizontally.
+        "addp v0.4s, v16.4s, v20.4s\n"
+        "addp v2.4s, v17.4s, v21.4s\n"
+        "addp v4.4s, v18.4s, v22.4s\n"
+        "addp v6.4s, v19.4s, v23.4s\n"
+        "addp v1.4s, v24.4s, v28.4s\n"
+        "addp v3.4s, v25.4s, v29.4s\n"
+        "addp v5.4s, v26.4s, v30.4s\n"
+        "addp v7.4s, v27.4s, v31.4s\n"
+
+        "cmp %[start_depth], #0\n"
+        "bne accumulate_existing_dst_values_%=\n"
+
+        // Reduce 32bit accumulators horizontally, second pass
+        // (each pass adds pairwise. we need to add 4-wise).
+        "addp v12.4s, v0.4s, v1.4s\n"
+        "addp v13.4s, v2.4s, v3.4s\n"
+        "addp v14.4s, v4.4s, v5.4s\n"
+        "addp v15.4s, v6.4s, v7.4s\n"
+
+        "b store_%=\n"
+
+        "accumulate_existing_dst_values_%=:\n"
+
+        // Reduce 32bit accumulators horizontally, second pass
+        // (each pass adds pairwise. we need to add 4-wise),
+        // and load destination values from memory.
+        "mov x0, %[dst_ptr]\n"
+        "ld1 {v12.16b}, [x0], %[dst_col_stride]\n"
+        "addp v8.4s, v0.4s, v1.4s\n"
+        "ld1 {v13.16b}, [x0], %[dst_col_stride]\n"
+        "addp v9.4s, v2.4s, v3.4s\n"
+        "ld1 {v14.16b}, [x0], %[dst_col_stride]\n"
+        "addp v10.4s, v4.4s, v5.4s\n"
+        "ld1 {v15.16b}, [x0]\n"
+        "addp v11.4s, v6.4s, v7.4s\n"
+
+        // Add horizontally-reduced accumulators into
+        // the values loaded from memory
+        "add v12.4s, v12.4s, v8.4s\n"
+        "add v13.4s, v13.4s, v9.4s\n"
+        "add v14.4s, v14.4s, v10.4s\n"
+        "add v15.4s, v15.4s, v11.4s\n"
+
+        "store_%=:\n"
+        // Store back into memory
+        "mov x0, %[dst_ptr]\n"
+        "st1 {v12.16b}, [x0], %[dst_col_stride]\n"
+        "st1 {v13.16b}, [x0], %[dst_col_stride]\n"
+        "st1 {v14.16b}, [x0], %[dst_col_stride]\n"
+        "st1 {v15.16b}, [x0]\n"
+        :  // outputs
+        [lhs_ptr] "+r"(lhs_ptr), [rhs_ptr] "+r"(rhs_ptr),
+        [dst_ptr] "+r"(dst_ptr), [run_depth] "+r"(run_depth),
+        [dst_col_stride] "+r"(dst_col_stride)
+        :  // inputs
+        [start_depth] "r"(start_depth)
+        :  // clobbers
+        "cc", "memory", "x0", "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
+        "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15", "v16", "v17",
+        "v18", "v19", "v20", "v21", "v22", "v23", "v24", "v25", "v26", "v27",
+        "v28", "v29", "v30", "v31");
+  }
+};
+
 // Our main GEMM kernel.
 struct NEON_64_Kernel12x8Depth2 : KernelBase {
   typedef KernelFormat<KernelSideFormat<CellFormat<4, 2>, 3>,
@@ -806,7 +1128,7 @@ struct NEON_64_Kernel12x8Depth2 : KernelBase {
         /* end of main loop */
 
         /* Accumulate our local accumulator registers into the destination block
-           */
+         */
 
         // Compute stride between consecutive columns, in bytes
         "mov x0, #4\n"  // multiply by 4 = sizeof(int32)

--- a/internal/multi_thread_gemm.h
+++ b/internal/multi_thread_gemm.h
@@ -456,7 +456,7 @@ struct GemmWithPackedRhsTask : Task {
 
         auto curr_result_block = MatrixBlockBounds(
             result_block.start_row + r, result_block.start_col + c, rs, cs);
-        UnpackResult(
+        UnpackResult<KernelFormat>(
             &result, curr_result_block, packed_result, depth,
             packed_lhs.sums_of_each_slice(), packed_rhs.sums_of_each_slice(),
             lhs_offset.block(curr_result_block.start_row, rs),

--- a/internal/pack.h
+++ b/internal/pack.h
@@ -208,12 +208,15 @@ class PackingRegisterBlockBase {
  public:
   typedef typename PackedSideBlock::KernelSideFormat KernelSideFormat;
   typedef typename KernelSideFormat::Cell CellFormat;
+  typedef typename KernelSideFormat::Scalar KernelScalar;
   static const int kCells = KernelSideFormat::kCells;
   static const int kCellWidth = CellFormat::kWidth;
   static const int kKernelWidth = CellFormat::kWidth * kCells;
   static const int kCellDepth = CellFormat::kDepth;
   static const int kCellSize = CellFormat::kSize;
   static const SideMapOrder kSrcOrder = SrcMapType::kOrder;
+  static const int kZeroPointInputValue =
+      ZeroPointInputValue<KernelScalar>::kValue;
 
   PackingRegisterBlockBase() : complete_src_(nullptr, 0, 0, 0) {}
 
@@ -235,7 +238,7 @@ class PackingRegisterBlockBase {
   // Copies an incomplete block of source data into a local temporary
   // complete block by zero-extending it.
   void MakeCompleteSrc(const SrcMapType& src) {
-    memset(buf_, 0, kKernelWidth * kRegisterSize);
+    memset(buf_, kZeroPointInputValue, kKernelWidth * kRegisterSize);
     if (kSrcOrder == SideMapOrder::WidthMajor) {
       for (int w = 0; w < src.width(); w++) {
         memcpy(buf_ + w * kRegisterSize, src.data(w, 0), src.depth());
@@ -266,8 +269,11 @@ class PackingRegisterBlockBase {
           std::int32_t sum = 0;
           for (int d = 0; d < kCellDepth; d++) {
             const std::uint8_t src_val = src_cell_map(w, d);
-            dst_ptr[OffsetIntoCell<CellFormat>(w, d)] = src_val;
-            sum += src_val;
+            const std::int16_t kernel_val_unwrapped =
+                src_val - kZeroPointInputValue;
+            const std::uint8_t kernel_val_uint8 = kernel_val_unwrapped;
+            dst_ptr[OffsetIntoCell<CellFormat>(w, d)] = kernel_val_uint8;
+            sum += kernel_val_unwrapped;
           }
           cell_sums_of_each_slice_ptr[w] += sum;
         }

--- a/internal/simd_wrappers.h
+++ b/internal/simd_wrappers.h
@@ -465,6 +465,29 @@ LoadForBroadcasting(const SrcObjectType& src, int pos) {
                                                                         pos);
 }
 
+template <int ConstantValue, typename RegisterBlockType>
+struct AddConstantImpl {
+  static void Run(RegisterBlockType* block) {
+    using RegisterType = typename RegisterBlockType::RegisterType;
+    const RegisterType dup = Dup<RegisterType>(ConstantValue);
+    for (int i = 0; i < RegisterBlockType::kRegisterCount; i++) {
+      block->buf.reg[i] = Add(block->buf.reg[i], dup);
+    }
+  }
+};
+
+template <typename RegisterBlockType>
+struct AddConstantImpl<0, RegisterBlockType> {
+  static void Run(RegisterBlockType*) {
+    // This is a no-op.
+  }
+};
+
+template <int ConstantValue, typename RegisterBlockType>
+void AddConstant(RegisterBlockType* block) {
+  AddConstantImpl<ConstantValue, RegisterBlockType>::Run(block);
+}
+
 template <int N>
 using RegBufferInt32 = RegisterBuffer<std::int32_t, N>;
 template <int N>

--- a/internal/single_thread_gemm.h
+++ b/internal/single_thread_gemm.h
@@ -127,10 +127,10 @@ void SingleThreadGemm(SingleThreadGemmContext* context,
       Compute(kernel, block_params, &packed_result, packed_lhs, packed_rhs,
               depth);
 
-      UnpackResult(result, MatrixBlockBounds(r, c, rs, cs), packed_result,
-                   depth, packed_lhs.sums_of_each_slice(),
-                   packed_rhs.sums_of_each_slice(), lhs_offset.block(r, rs),
-                   rhs_offset.block(c, cs), output_pipeline);
+      UnpackResult<KernelFormat>(
+          result, MatrixBlockBounds(r, c, rs, cs), packed_result, depth,
+          packed_lhs.sums_of_each_slice(), packed_rhs.sums_of_each_slice(),
+          lhs_offset.block(r, rs), rhs_offset.block(c, cs), output_pipeline);
     }
   }
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -502,11 +502,12 @@ void test_gemm(typename GemmWrapper::Context* context, int rows, int depth,
                int cols, WhatParamsToTest params_to_test) {
   typedef std::uint8_t Scalar;
   typedef Matrix<Scalar, LhsOrder> LhsType;
+  using BitDepthParams = typename GemmWrapper::BitDepthParams;
   LhsType lhs(rows, depth);
-  MakeRandom(&lhs, 8);
+  MakeRandom<typename BitDepthParams::LhsRange>(&lhs);
   typedef Matrix<Scalar, RhsOrder> RhsType;
   RhsType rhs(depth, cols);
-  MakeRandom(&rhs, 8);
+  MakeRandom<typename BitDepthParams::RhsRange>(&rhs);
   typedef Matrix<Scalar, ResultOrder> ResultType;
   ResultType result(rows, cols);
   MakeZero(&result);
@@ -1189,14 +1190,14 @@ void TestWithRealData(eight_bit_int_gemm::BitDepthSetting BitDepth,
   Check(good);
 }
 
-template <MapOrder ResultOrder>
+template <typename BitDepthParams, MapOrder ResultOrder>
 void TestOutputStages(int rows, int depth, int cols, int result_offset,
                       int result_mult_int, int result_shift) {
   Matrix<std::uint8_t, MapOrder::RowMajor> lhs(rows, depth);
   Matrix<std::uint8_t, MapOrder::ColMajor> rhs(depth, cols);
   Matrix<std::int32_t, ResultOrder> result_raw_int32(rows, cols);
-  MakeRandom(&lhs, 8);
-  MakeRandom(&rhs, 8);
+  MakeRandom<typename BitDepthParams::LhsRange>(&lhs);
+  MakeRandom<typename BitDepthParams::RhsRange>(&rhs);
   const int lhs_offset = 12;
   const int rhs_offset = -34;
 
@@ -1271,8 +1272,10 @@ void TestOutputStages(int rows, int depth, int cols, int result_offset,
 
   // Test a bias-addition with row-vector
   std::vector<std::int32_t> row_vector_data(cols);
+  std::uniform_int_distribution<std::int32_t> uniform_minus_500_plus_500(-500,
+                                                                         500);
   for (int i = 0; i < cols; i++) {
-    row_vector_data[i] = (Random() % 1000) - 500;
+    row_vector_data[i] = uniform_minus_500_plus_500(RandomEngine());
   }
   typedef VectorMap<std::int32_t, VectorShape::Row> RowVectorMap;
   RowVectorMap row_vector_map(row_vector_data.data(), cols);
@@ -1293,7 +1296,7 @@ void TestOutputStages(int rows, int depth, int cols, int result_offset,
   // Test a bias-addition with column-vector
   std::vector<std::int32_t> col_vector_data(rows);
   for (int i = 0; i < rows; i++) {
-    col_vector_data[i] = (Random() % 1000) - 500;
+    col_vector_data[i] = uniform_minus_500_plus_500(RandomEngine());
   }
   typedef VectorMap<std::int32_t, VectorShape::Col> ColVectorMap;
   ColVectorMap col_vector_map(col_vector_data.data(), rows);
@@ -1479,57 +1482,45 @@ void TestOutputStages(int rows, int depth, int cols, int result_offset,
 }
 
 #ifndef GEMMLOWP_SKIP_EXHAUSTIVE_TESTS
+template <typename BitDepthParams>
 void TestExhaustively() {
   GemmContext context;
 
   // Test the internal GEMM interfaces
-  test_gemm<SingleThreadGemmWrapper<
-      DefaultKernel<KernelFamily::Gemm, DefaultL8R8BitDepthParams>,
-      std::uint8_t, DefaultL8R8BitDepthParams>>(&context);
+  test_gemm<
+      SingleThreadGemmWrapper<DefaultKernel<KernelFamily::Gemm, BitDepthParams>,
+                              std::uint8_t, BitDepthParams>>(&context);
 
-  test_gemm<MultiThreadGemmWrapper<
-      DefaultKernel<KernelFamily::Gemm, DefaultL8R8BitDepthParams>,
-      std::uint8_t, DefaultL8R8BitDepthParams>>(&context);
+  test_gemm<
+      MultiThreadGemmWrapper<DefaultKernel<KernelFamily::Gemm, BitDepthParams>,
+                             std::uint8_t, BitDepthParams>>(&context);
 
   // Test the public GEMM interfaces
-  test_gemm<PublicGemmWrapper<std::uint8_t, DefaultL8R8BitDepthParams>>(
-      &context);
-
-  test_gemm<EightBitIntGemmWrapper<std::uint8_t,
-                                   eight_bit_int_gemm::BitDepthSetting::A8B8>>(
-      &context);
+  test_gemm<PublicGemmWrapper<std::uint8_t, BitDepthParams>>(&context);
 
   // Test GEMV cases (internal interfaces)
-  test_gemv<SingleThreadGemmWrapper<
-      DefaultKernel<KernelFamily::Gemv, DefaultL8R8BitDepthParams>,
-      std::uint8_t, DefaultL8R8BitDepthParams>>(&context);
+  test_gemv<
+      SingleThreadGemmWrapper<DefaultKernel<KernelFamily::Gemv, BitDepthParams>,
+                              std::uint8_t, BitDepthParams>>(&context);
 
-  test_gemv<MultiThreadGemmWrapper<
-      DefaultKernel<KernelFamily::Gemv, DefaultL8R8BitDepthParams>,
-      std::uint8_t, DefaultL8R8BitDepthParams>>(&context);
+  test_gemv<
+      MultiThreadGemmWrapper<DefaultKernel<KernelFamily::Gemv, BitDepthParams>,
+                             std::uint8_t, BitDepthParams>>(&context);
 
   // Test GEMV cases (public interfaces)
-  test_gemv<PublicGemmWrapper<std::uint8_t, DefaultL8R8BitDepthParams>>(
-      &context);
+  test_gemv<PublicGemmWrapper<std::uint8_t, BitDepthParams>>(&context);
+}
 
-  test_gemv<EightBitIntGemmWrapper<std::uint8_t,
-                                   eight_bit_int_gemm::BitDepthSetting::A8B8>>(
-      &context);
+template <eight_bit_int_gemm::BitDepthSetting BitDepthSetting>
+void TestExhaustivelyEightBitIntGemm() {
+  GemmContext context;
+  test_gemv<EightBitIntGemmWrapper<std::uint8_t, BitDepthSetting>>(&context);
+  test_gemv<EightBitIntGemmWrapper<std::uint8_t, BitDepthSetting>>(&context);
+  test_gemm<EightBitIntGemmWrapper<std::uint8_t, BitDepthSetting>>(&context);
+}
 
-  // Test other bit depths:
-  // L7R5 (legacy old requantizing path, no longer actually requantizing,
-  // now just an alias for the default 8 bit depth).
-  test_gemm<SingleThreadGemmWrapper<
-      DefaultKernel<KernelFamily::Gemm, DefaultL7R5BitDepthParams>,
-      std::uint8_t, DefaultL7R5BitDepthParams>>(&context);
-
-  test_gemv<SingleThreadGemmWrapper<
-      DefaultKernel<KernelFamily::Gemv, DefaultL7R5BitDepthParams>,
-      std::uint8_t, DefaultL7R5BitDepthParams>>(&context);
-
-  test_gemm<EightBitIntGemmWrapper<std::uint8_t,
-                                   eight_bit_int_gemm::BitDepthSetting::A5B7>>(
-      &context);
+void TestKernels() {
+  GemmContext context;
 
   // Test specific kernels with various different formats,
   // to exercises corner cases especially in the packing code.
@@ -1572,7 +1563,20 @@ void TestExhaustively() {
       KernelSideFormat<CellFormat<1, 4, CellOrder::DepthMajor>, 1>,
       KernelSideFormat<CellFormat<4, 4, CellOrder::Diagonal>, 1>>>>(&context);
 }
+
 #endif  // not GEMMLOWP_SKIP_EXHAUSTIVE_TESTS
+
+template <typename BitDepthParams>
+void TestOutputStages() {
+  // Test non-default output pipelines with various combinations of
+  // output stages.
+  TestOutputStages<BitDepthParams, MapOrder::RowMajor>(63, 10, 127, 5, 17, 14);
+  TestOutputStages<BitDepthParams, MapOrder::ColMajor>(63, 10, 127, 5, 17, 14);
+  TestOutputStages<BitDepthParams, MapOrder::RowMajor>(630, 10, 1270, 5, 17,
+                                                       14);
+  TestOutputStages<BitDepthParams, MapOrder::ColMajor>(630, 10, 1270, 5, 17,
+                                                       14);
+}
 
 void test() {
 #ifdef GEMMLOWP_TEST_PROFILE
@@ -1584,7 +1588,12 @@ void test() {
   TestWithSmallData();
 
 #ifndef GEMMLOWP_SKIP_EXHAUSTIVE_TESTS
-  TestExhaustively();
+  TestExhaustively<DefaultL8R8BitDepthParams>();
+  TestExhaustively<L8R8WithLhsNonzeroBitDepthParams>();
+  TestExhaustively<DefaultL7R5BitDepthParams>();  // legacy, same as L8R8
+  TestExhaustivelyEightBitIntGemm<eight_bit_int_gemm::BitDepthSetting::A8B8>();
+  TestExhaustivelyEightBitIntGemm<eight_bit_int_gemm::BitDepthSetting::A5B7>();
+  TestKernels();
 #endif
 
   // Run against actual data from a network evaluation.
@@ -1593,10 +1602,8 @@ void test() {
 
   // Test non-default output pipelines with various combinations of
   // output stages.
-  TestOutputStages<MapOrder::RowMajor>(63, 10, 127, 5, 17, 14);
-  TestOutputStages<MapOrder::ColMajor>(63, 10, 127, 5, 17, 14);
-  TestOutputStages<MapOrder::RowMajor>(630, 10, 1270, 5, 17, 14);
-  TestOutputStages<MapOrder::ColMajor>(630, 10, 1270, 5, 17, 14);
+  TestOutputStages<DefaultL8R8BitDepthParams>();
+  TestOutputStages<L8R8WithLhsNonzeroBitDepthParams>();
 
   // Test per channel quantization.
   TestWithSmallDataPerChannelQuantization();

--- a/test/test.h
+++ b/test/test.h
@@ -22,19 +22,14 @@
 #include "../profiling/profiler.h"
 #endif
 
-#include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <random>
 #include <vector>
 
 #include "../public/gemmlowp.h"
 
 namespace gemmlowp {
-
-inline int Random() {
-  // Use ugly old rand() since this doesn't need to be high quality.
-  return rand();
-}
 
 #define GEMMLOWP_STRINGIFY2(x) #x
 #define GEMMLOWP_STRINGIFY(x) GEMMLOWP_STRINGIFY2(x)
@@ -97,13 +92,19 @@ class Matrix : public MatrixMap<tScalar, tOrder> {
   std::vector<Scalar> storage;
 };
 
-template <typename MatrixType>
-void MakeRandom(MatrixType* m, int bits) {
+std::mt19937& RandomEngine() {
+  static std::mt19937 engine;
+  return engine;
+}
+
+template <typename OperandRange, typename MatrixType>
+void MakeRandom(MatrixType* m) {
   typedef typename MatrixType::Scalar Scalar;
-  const Scalar mask = (1 << bits) - 1;
+  std::uniform_int_distribution<Scalar> dist(OperandRange::kMinValue,
+                                             OperandRange::kMaxValue);
   for (int c = 0; c < m->cols(); c++) {
     for (int r = 0; r < m->rows(); r++) {
-      (*m)(r, c) = Random() & mask;
+      (*m)(r, c) = dist(RandomEngine());
     }
   }
 }


### PR DESCRIPTION
The way that this kernel is faster, is that it treats its 8bit operands
as signed int8 and takes advantage of the fact that a product of int8
values is in the [-2^14 ; 2^14] range, therefore it is *almost* safe
to add two of them in a int16 accumulator.

Unfortunately that is not always safe: -128*-128 == 2^14, and adding
that value twice would overflow int16.

Therefore, we cannot just switch everyone's default kernel to that.
Instead, we add that new BitDepthParam whereby the user may specify
that one of the operands will never take the minimum representable 8bit
value. Then gemmlowp can pick up this kernel.

Note that I/O 8-bit values remain uint8, so when using a int8 kernel,
there is some work in the pack/unpack stages to bridge that difference.
The pack stage has to XOR the top bit to convert uint8 input values
to int8 values (e.g. 0 becomes -128, 255 becomes 127). The unpack stage
has to correspondingly add 128 to the lhs_offset, rhs_offset.

The test is cleaned up and refactored a bit to consistently test
all BitDepthParams, etc.