### PR TITLE
explicitly enable testing of multi-threading

### DIFF
--- a/test/benchmark.cc
+++ b/test/benchmark.cc
@@ -353,8 +353,8 @@ void benchmark_all() {
 
   {
     gemmlowp::GemmContext context;
-    std::cout << "Benchmarking default mode (typically multi-threaded)..."
-              << std::endl;
+    context.set_max_num_threads(0);
+    std::cout << "Benchmarking multi-threaded mode..." << std::endl;
     gemmlowp::benchmark(&context);
   }
 


### PR DESCRIPTION
The new default is to run with a single core, which disabled testing of multi-threading in benchmark.cc. This fixes that.