### PR TITLE
Reduce register use in armv7-a, fix aarch64 ldr syntax, clang-format.

### DIFF
--- a/test/correctness_meta_gemm.cc
+++ b/test/correctness_meta_gemm.cc
@@ -286,55 +286,55 @@ int main(int argc, char* argv[]) {
     std::cout << "Quantized 8 bit." << std::endl << std::flush;
 
     std::cout << "Small." << std::endl << std::flush;
-    q_suite(1, 1, 8, 16, 16, 32, 1, 1, 1, scratch, left, right, result, &pool,
+    q_suite(1, 1, 1, 16, 16, 32, 1, 1, 1, scratch, left, right, result, &pool,
             t);
 
     if (run_long_test) {
       std::cout << "Big." << std::endl << std::flush;
-      q_suite(1, 1, 8, 512, 512, 2048, 111, 111, 111, scratch, left, right,
+      q_suite(1, 1, 1, 512, 512, 2048, 111, 111, 111, scratch, left, right,
               result, &pool, t);
     }
 
     std::cout << "Gemv." << std::endl << std::flush;
-    q_suite(1, 1, 8, 2, 512, 2048, 1, 111, 111, scratch, left, right, result,
+    q_suite(1, 1, 1, 2, 512, 2048, 1, 111, 111, scratch, left, right, result,
             &pool, t);
-    q_suite(1, 1, 8, 512, 2, 2048, 111, 1, 111, scratch, left, right, result,
+    q_suite(1, 1, 1, 512, 2, 2048, 111, 1, 111, scratch, left, right, result,
             &pool, t);
 
     std::cout << std::endl << "Floats." << std::endl << std::flush;
 
     std::cout << "Small." << std::endl << std::flush;
-    f_suite(1, 1, 8, 16, 16, 32, 1, 1, 1, scratch, left, right, result_float,
+    f_suite(1, 1, 1, 16, 16, 32, 1, 1, 1, scratch, left, right, result_float,
             &pool, t);
 
     if (run_long_test) {
       std::cout << "Big." << std::endl << std::flush;
-      f_suite(1, 1, 8, 512, 512, 2048, 111, 111, 111, scratch, left, right,
+      f_suite(1, 1, 1, 512, 512, 2048, 111, 111, 111, scratch, left, right,
               result_float, &pool, t);
     }
 
     std::cout << "Gemv." << std::endl << std::flush;
-    f_suite(1, 1, 8, 2, 512, 2048, 1, 111, 111, scratch, left, right,
+    f_suite(1, 1, 1, 2, 512, 2048, 1, 111, 111, scratch, left, right,
             result_float, &pool, t);
-    f_suite(1, 1, 8, 512, 2, 2048, 111, 1, 111, scratch, left, right,
+    f_suite(1, 1, 1, 512, 2, 2048, 111, 1, 111, scratch, left, right,
             result_float, &pool, t);
 
     std::cout << std::endl << "Int32." << std::endl << std::flush;
 
     std::cout << "Small." << std::endl << std::flush;
-    i32_suite(1, 1, 8, 16, 16, 32, 1, 1, 1, scratch, left, right, result_i32,
+    i32_suite(1, 1, 1, 16, 16, 32, 1, 1, 1, scratch, left, right, result_i32,
               &pool, t);
 
     if (run_long_test) {
       std::cout << "Big." << std::endl << std::flush;
-      i32_suite(1, 1, 8, 512, 512, 2048, 111, 111, 111, scratch, left, right,
+      i32_suite(1, 1, 1, 512, 512, 2048, 111, 111, 111, scratch, left, right,
                 result_i32, &pool, t);
     }
 
     std::cout << "Gemv." << std::endl << std::flush;
-    i32_suite(1, 1, 8, 2, 512, 2048, 1, 111, 111, scratch, left, right,
+    i32_suite(1, 1, 1, 2, 512, 2048, 1, 111, 111, scratch, left, right,
               result_i32, &pool, t);
-    i32_suite(1, 1, 8, 512, 2, 2048, 111, 1, 111, scratch, left, right,
+    i32_suite(1, 1, 1, 512, 2, 2048, 111, 1, 111, scratch, left, right,
               result_i32, &pool, t);
 
     std::cout << std::endl << std::flush;

--- a/test/correctness_meta_gemm.cc
+++ b/test/correctness_meta_gemm.cc
@@ -277,10 +277,10 @@ int main(int argc, char* argv[]) {
 
   gemmlowp::WorkersPool pool;
 
-  int max_repetitions = run_long_test ? 11 : 5;
+  int max_repetitions = run_long_test ? 10 : 1;
 
-  for (int repetitions = 1; repetitions < max_repetitions; ++repetitions) {
-    int t = std::min(repetitions, 4);
+  for (int repetitions = 0; repetitions < max_repetitions; ++repetitions) {
+    int t = std::min(repetitions + 1, 4);
     std::cout << "Threads: " << t << std::endl << std::flush;
 
     std::cout << "Quantized 8 bit." << std::endl << std::flush;


### PR DESCRIPTION
Fixing: tensorflow/tensorflow#5303
Moving the ad-hoc fix to the generator code: #75

Re-PR of #87 