### PR TITLE
Change #error to #message on ARMv5.

### DIFF
--- a/internal/kernel_default.h
+++ b/internal/kernel_default.h
@@ -80,11 +80,17 @@ GEMMLOWP_SET_DEFAULT_KERNEL(false, false, SSE4_32_Kernel4x4Depth2)
 GEMMLOWP_SET_DEFAULT_KERNEL(false, false, SSE4_64_Kernel12x4Depth2)
 #else
 #ifndef GEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK
+#if defined __ARM_ARCH_5TE__
+// SIMD is not available on this platform. The slow fallback will be used.
+// Don't require GEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK because there's nothing
+// the user can do about it.
+#else
 #error \
     "SIMD not enabled, you'd be getting a slow software fallback. Consider \
 enabling SIMD extensions (for example using -msse4 if you're on modern x86). \
 If that's not an option, and you would like to continue with the \
 slow fallback, define GEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK."
+#endif
 #endif
 #include "kernel_reference.h"
 namespace gemmlowp {


### PR DESCRIPTION
Turn the no-SIMD #error into a #message when SIMD (Neon) isn't available.

An alternative would be to automatically define GEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK on ARMv5 (cpu=armeabi). There's little value to insisting that clients define this when targeting a platform on which there's nothing they can do about it.

I used #message instead of #warning so that it doesn't interfere with any builds using -Werror.