### PR TITLE
Use mutexes instead of memory barriers in the profiler.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,6 +16,7 @@ Miao Wang <miaowang@google.com>
 David Andersen <dga@google.com>
 Maciek Chociej <maciekc@google.com>
 Justine Tunney <jart@google.com>
+Mark J. Matthews <mjmatthews@google.com>
 
 Intel:
 Sagi Marcovich <sagi.marcovich@intel.com>

--- a/eight_bit_int_gemm/eight_bit_int_gemm.cc
+++ b/eight_bit_int_gemm/eight_bit_int_gemm.cc
@@ -307,7 +307,7 @@ void EightBitIntGemm(bool transpose_a, bool transpose_b, bool transpose_c,
                      std::int32_t b_offset, int ldb, std::uint8_t* c,
                      std::int32_t c_offset, std::int32_t c_mult_int,
                      std::int32_t c_shift, int ldc, BitDepthSetting bit_depth) {
-  AutoGlobalLock<EightBitIntGemmLockId> lock;
+  ScopedLock sl(GlobalMutexes::EightBitIntGemm());
   GemmContext* context = GetOrCreateGlobalContext();
 
 #if defined(GEMMLOWP_USE_META_FASTPATH) && defined(GEMMLOWP_NEON)
@@ -344,7 +344,7 @@ void EightBitIntGemm(bool transpose_a, bool transpose_b, bool transpose_c,
                      const std::uint8_t* b, std::int32_t b_offset,
                      std::int32_t ldb, float* c, float c_offset,
                      std::int32_t ldc, BitDepthSetting bit_depth) {
-  AutoGlobalLock<EightBitIntGemmLockId> lock;
+  ScopedLock sl(GlobalMutexes::EightBitIntGemm());
   GemmContext* context = GetOrCreateGlobalContext();
 
 #if defined(GEMMLOWP_USE_META_FASTPATH) && defined(GEMMLOWP_NEON)
@@ -405,13 +405,13 @@ void EightBitIntGemm(bool transpose_a, bool transpose_b, bool transpose_c,
 }
 
 void SetMaxNumThreads(int n) {
-  AutoGlobalLock<EightBitIntGemmLockId> lock;
+  ScopedLock sl(GlobalMutexes::EightBitIntGemm());
   GemmContext* context = GetOrCreateGlobalContext();
   context->set_max_num_threads(n);
 }
 
 void FreePersistentResources() {
-  AutoGlobalLock<EightBitIntGemmLockId> lock;
+  ScopedLock sl(GlobalMutexes::EightBitIntGemm());
   DestroyGlobalContext();
   DestroyGlobalScratch();
 }


### PR DESCRIPTION
Ok, I believe this should be a proper pull request from my forked gemmlowp repository. 
We've looked at all these changes together, and I've built and tested it successfully. Hope it works just as well for you. Let me know if you have any issues.

-Mark