### PR TITLE
Arm transform functions: generator changes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,5 +8,5 @@
 
 Google Inc.
 Intel Corporation
-ARM Ltd.
+Arm Ltd.
 Silk Labs Inc.

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -23,8 +23,9 @@ Murat Efe Guney <murat.e.guney@intel.com>
 Sarah Knepper <sarah.knepper@intel.com>
 Mourad Gouicem <mourad.gouicem@intel.com>
 
-ARM:
+Arm:
 David Mansell <David.Mansell@arm.com>
+Andrew Mundy <Andrew.Mundy@arm.com>
 
 Silk Labs:
 Andreas Gal <andreas@silklabs.com>

--- a/meta/generators/neon_emitter.py
+++ b/meta/generators/neon_emitter.py
@@ -386,6 +386,10 @@ class NeonEmitter(object):
   def EmitVMulScalar(self, mul_type, destination, source_1, source_2):
     self.EmitOp3('vmul.%s' % mul_type, destination, source_1, source_2)
 
+  def EmitVMulAcc(self, mla_type, acc, source_1, source_2):
+    acc, source_1, source_2 = _MakeCompatible(acc, source_1, source_2)
+    self.EmitOp3('vfma.%s' % mla_type, acc, source_1, source_2)
+
   def EmitVMull(self, mul_type, destination, source_1, source_2):
     self.EmitOp3('vmull.%s' % mul_type, destination, source_1, source_2)
 

--- a/meta/generators/neon_emitter.py
+++ b/meta/generators/neon_emitter.py
@@ -299,6 +299,12 @@ class NeonEmitter(object):
   def EmitMov(self, param1, param2):
     self.EmitOp2('mov', param1, param2)
 
+  def EmitBBack(self, label):
+    self.EmitOp1('b', '%db' % label)
+
+  def EmitBFront(self, label):
+    self.EmitOp1('b', '%df' % label)
+
   def EmitBeqBack(self, label):
     self.EmitOp1('beq', '%db' % label)
 

--- a/meta/generators/neon_emitter_64.py
+++ b/meta/generators/neon_emitter_64.py
@@ -760,6 +760,17 @@ class NeonEmitter64(object):
                  _AppendType(mul_type, source_1),
                  _AppendType(mul_type, source_2))
 
+  def EmitVMulAcc(self, mla_type, acc, source_1, source_2):
+    acc, source_1, source_2 = _MakeCompatibleDown(acc, source_1, source_2)
+
+    if _FloatType(mla_type):
+      self.EmitOp3('fmla',
+                   _AppendType(mla_type, acc),
+                   _AppendType(mla_type, source_1),
+                   _AppendType(mla_type, source_2))
+    else:
+      raise NotImplementedError
+
   def EmitVMull(self, mul_type, destination, source_1, source_2):
     wide_type = _WideType(mul_type)
     if _UnsignedType(mul_type):

--- a/meta/generators/neon_emitter_64.py
+++ b/meta/generators/neon_emitter_64.py
@@ -590,6 +590,12 @@ class NeonEmitter64(object):
                    _AppendType(min_type, source_1),
                    _AppendType(min_type, source_2))
 
+  def EmitBBack(self, label):
+    self.EmitOp1('b', '%db' % label)
+
+  def EmitBFront(self, label):
+    self.EmitOp1('b', '%df' % label)
+
   def EmitBeqBack(self, label):
     self.EmitOp1('beq', '%db' % label)
 

--- a/meta/generators/neon_emitter_64.py
+++ b/meta/generators/neon_emitter_64.py
@@ -942,6 +942,10 @@ class NeonEmitter64(object):
     self.EmitOp2('prfm', 'pldl1keep',
                  '[%s, %s]' % (load_address_register, offset))
 
+  def EmitPld2Offset(self, load_address_register, offset):
+    self.EmitOp2('prfm', 'pldl2keep',
+                 '[%s, %s]' % (load_address_register, offset))
+
   def EmitVShl(self, shift_type, destination, source, shift):
     self.EmitOp3('sshl',
                  _AppendType(shift_type, destination),

--- a/meta/generators/transform_kernels_common.py
+++ b/meta/generators/transform_kernels_common.py
@@ -502,37 +502,43 @@ class BiasAdd(common.Transform1DKernelGenerator):
     emitter.EmitVLoadAE(8, elements, load_input, input_address, None)
     emitter.EmitVLoadAE(8, elements, load_bias, bias, None)
 
-    # Extend the UINT8s to INT16
+    # Extend the UINT8s to INT16 while copying the offset into the accumulators
     if len(load_input) is 1:
       emitter.EmitVMovl('u8', load_input[0], load_input[0])
+      emitter.EmitVMov('f32', outputs[0], self.offset)  # Offset
       emitter.EmitVMovl('u8', load_bias[0], load_bias[0])
       emitter.EmitVMovl('s16', load_input[0], load_input[0])
       emitter.EmitVMovl('s16', load_bias[0], load_bias[0])
     elif len(load_input) is 2:
       emitter.EmitVMovl('u8', load_input[0], load_input[0])
+      emitter.EmitVMov('f32', outputs[0], self.offset)  # Offset
       emitter.EmitVMovl('u8', load_bias[0], load_bias[0])
+      emitter.EmitVMov('f32', outputs[1], self.offset)  # Offset
       emitter.EmitVMovl2('s16', load_input[0], load_input[1], load_input[0])
       emitter.EmitVMovl2('s16', load_bias[0], load_bias[1], load_bias[0])
     elif len(load_input) is 3:
       emitter.EmitVMovl2('u8', load_input[0], load_input[1], load_input[0])
+      emitter.EmitVMov('f32', outputs[0], self.offset)  # Offset
       emitter.EmitVMovl2('u8', load_bias[0], load_bias[1], load_bias[0])
+      emitter.EmitVMov('f32', outputs[1], self.offset)  # Offset
       emitter.EmitVMovl('s16', load_input[2], load_input[1])
+      emitter.EmitVMov('f32', outputs[2], self.offset)  # Offset
       emitter.EmitVMovl('s16', load_bias[2], load_bias[1])
       emitter.EmitVMovl2('s16', load_input[0], load_input[1], load_input[0])
       emitter.EmitVMovl2('s16', load_bias[0], load_bias[1], load_bias[0])
     elif len(load_input) is 4:
       emitter.EmitVMovl2('u8', load_input[0], load_input[1], load_input[0])
+      emitter.EmitVMov('f32', outputs[0], self.offset)  # Offset
       emitter.EmitVMovl2('u8', load_bias[0], load_bias[1], load_bias[0])
+      emitter.EmitVMov('f32', outputs[1], self.offset)  # Offset
       emitter.EmitVMovl2('s16', load_input[2], load_input[3], load_input[1])
+      emitter.EmitVMov('f32', outputs[2], self.offset)  # Offset
       emitter.EmitVMovl2('s16', load_bias[2], load_bias[3], load_bias[1])
+      emitter.EmitVMov('f32', outputs[3], self.offset)  # Offset
       emitter.EmitVMovl2('s16', load_input[0], load_input[1], load_input[0])
       emitter.EmitVMovl2('s16', load_bias[0], load_bias[1], load_bias[0])
     else:
       assert False
-
-    # Copy the offset into the accumulators
-    for register in outputs:
-      emitter.EmitVMov('f32', register, self.offset)
 
     # Convert read values into appropriate format
     for register in load_input + load_bias:

--- a/meta/generators/transform_kernels_common.py
+++ b/meta/generators/transform_kernels_common.py
@@ -32,6 +32,27 @@ def _DuplicateGeneralMemoryRegister(size, emitter, registers, value,
   return register
 
 
+class _Indent(object):
+  def __init__(self, emitter, comment=None, label=None):
+    self._emitter = emitter
+    self._comment = comment
+    self._label = label
+
+  def __enter__(self):
+    self._emitter.EmitNewline()
+
+    if self._comment is not None:
+      self._emitter.EmitComment(self._comment)
+
+    if self._label is not None:
+      self._emitter.EmitNumericalLabel(self._label)
+
+    self._emitter.PushIndent()
+
+  def __exit__(self, *args, **kwargs):
+    self._emitter.PopIndent()
+
+
 class MinMaxTransformation(object):
   """."""
 
@@ -214,85 +235,6 @@ class QuantizeTransformation(object):
     registers.FreeRegisters(load)
 
 
-class RequantizeTransformation(object):
-  """."""
-  # Additional declarations made in the C++ at the start of each specialized
-  # header.
-  declarations = (
-    ("const float", "coefficient",
-     "params.one_over_output_range_scale * params.input_range_scale"),
-    ("const float", "offset",
-     """params.one_over_output_range_scale * (
-       params.input_range_min - params.output_range_min -
-       params.input_range_scale*params.input_range_offset
-     )"""),
-  )
-
-  def Check(self, in_type, out_type, kernel_size, leftovers):
-    assert in_type is 'int32_t'
-    assert out_type is 'uint8_t'
-    assert kernel_size is 16
-    assert leftovers < 16
-
-  def Prepare(self, emitter, registers, unused_kernel_size):
-    """Duplicate quantization parameters to vector registers."""
-    emitter.EmitNewline()
-    emitter.EmitComment('Requantize::Prepare')
-
-    self.coefficient = _DuplicateGeneralRegister(
-        32, emitter, registers,
-        registers.MapParameter('coefficient', 'coefficient'), 4)
-
-    self.offset = _DuplicateGeneralRegister(
-        32, emitter, registers,
-        registers.MapParameter('offset', 'offset'), 4)
-
-  def Transform(self, emitter, registers, input_address, elements,
-                output_address):
-    """Emit requantization inner loop code."""
-    emitter.EmitNewline()
-    emitter.EmitComment('Requantize::Transform')
-    register_count = (elements + 3) / 4
-    load = [registers.QuadRegister() for unused_i in range(register_count)]
-    outputs = [registers.QuadRegister() for unused_i in range(register_count)]
-    emitter.EmitVLoadAE(32, elements, load, input_address, None)
-
-    for register in load:
-      emitter.EmitVCvt('f32', 's32', register, register)
-
-    # Copy in the offset
-    for register in outputs:
-      emitter.EmitVMov('f32', register, self.offset)
-
-    # Perform the multiply-accumulate
-    for acc_reg, input_reg in zip(outputs, load):
-      emitter.EmitVMulAcc('f32', acc_reg, input_reg, self.coefficient)
-
-    for register in outputs:
-      emitter.EmitVCvt('s32', 'f32', register, register)
-
-    if len(outputs) is 1:
-      emitter.EmitVQmovn('s32', outputs[0], outputs[0])
-      emitter.EmitVQmovun('s16', outputs[0], outputs[0])
-    elif len(outputs) is 2:
-      emitter.EmitVQmovn2('s32', outputs[0], outputs[0], outputs[1])
-      emitter.EmitVQmovun('s16', outputs[0], outputs[0])
-    elif len(outputs) is 3:
-      emitter.EmitVQmovn2('s32', outputs[0], outputs[0], outputs[1])
-      emitter.EmitVQmovn('s32', outputs[2], outputs[2])
-      emitter.EmitVQmovun2('s16', outputs[0], outputs[0], outputs[2])
-    elif len(outputs) is 4:
-      emitter.EmitVQmovn2('s32', outputs[0], outputs[0], outputs[1])
-      emitter.EmitVQmovn2('s32', outputs[2], outputs[2], outputs[3])
-      emitter.EmitVQmovun2('s16', outputs[0], outputs[0], outputs[2])
-    else:
-      assert False
-
-    emitter.EmitNewline()
-    emitter.EmitVStoreAE(8, elements, outputs, output_address, None)
-    registers.FreeRegisters(load + outputs)
-
-
 class BaseTransform(common.Transform1DKernelGenerator):
   """."""
 
@@ -351,14 +293,6 @@ class BaseTransform(common.Transform1DKernelGenerator):
     self.asm_emitter.PopIndent(len(self.emitter.indent))
 
 
-class Requantize(BaseTransform):
-  """."""
-
-  def __init__(self, cc_emitter, asm_emitter):
-    BaseTransform.__init__(self, cc_emitter, 'Requantize', asm_emitter,
-                           RequantizeTransformation())
-
-
 class Quantize(BaseTransform):
   """."""
 
@@ -381,6 +315,189 @@ class MinMax(BaseTransform):
   def __init__(self, numerical_type, cc_emitter, asm_emitter):
     BaseTransform.__init__(self, cc_emitter, 'MinMax<%s>' % numerical_type,
                            asm_emitter, MinMaxTransformation())
+
+
+class Requantize(common.Transform1DKernelGenerator):
+  def __init__(self, cc_emitter, asm_emitter):
+    super(Requantize, self).__init__(cc_emitter, "Requantize")
+    self.asm_emitter = asm_emitter
+
+  def EmitTransform(self, in_type, out_type, kernel_size, leftovers):
+    # Check arguments are appropriate
+    assert in_type == 'int32_t'
+    assert out_type == 'uint8_t'
+    assert kernel_size == 16
+    assert leftovers < 16
+
+    # Emit declarations required for the later assembly.
+    self.emitter.EmitDeclare('int', 'params_count_copy', 'params.count')
+    self.emitter.EmitDeclare(
+      "const float", "coefficient",
+      "params.one_over_output_range_scale * params.input_range_scale")
+    self.emitter.EmitDeclare(
+      "const float", "offset",
+      """params.one_over_output_range_scale * (
+       params.input_range_min - params.output_range_min -
+       params.input_range_scale*params.input_range_offset
+     )""")
+
+    # Assign registers, we use 4 registers as "load" registers and two banks of
+    # 4 as "output" registers. The two output banks are labelled "A" and "B".
+    registers = self.asm_emitter.CreateRegisters()
+    load_registers = [registers.QuadRegister() for _ in range(4)]
+    registers_a = [registers.QuadRegister() for _ in range(4)]
+    registers_b = [registers.QuadRegister() for _ in range(4)]
+
+    # Modified registers
+    self.count_register = registers.MapOutputParameter('count', 'params_count_copy')
+    self.input_address = registers.MapOutputParameter('input')
+    self.output_address = registers.MapOutputParameter('output')
+
+    # Begin assembly
+    self.asm_emitter.PushIndent(self.emitter.indent)
+    self.asm_emitter.EmitAsmBegin()
+    self._Prepare(registers)
+    self.asm_emitter.EmitNewline()
+
+    # Begin loop
+    self.asm_emitter.EmitComment("Reduce count by leftovers")
+    self.asm_emitter.EmitSubs(self.count_register, self.count_register, "#{:d}".format(leftovers))
+    self.asm_emitter.EmitBeqFront(4)
+    self.asm_emitter.EmitNewline()
+
+    # Load A before entering loop
+    self.asm_emitter.EmitComment("Prepare initial values")
+    self.asm_emitter.EmitSubs(self.count_register, self.count_register, "#16")
+    self._EmitCode(load_registers, registers_b, registers_a, 0, 16)
+    self.asm_emitter.EmitBeqFront(2)
+    self.asm_emitter.EmitNewline()
+
+    # Looped portion of the code, process A while loading B then process B
+    # while loading A.
+    with _Indent(self.asm_emitter, "Requantize::Transform", label=1):
+      self.asm_emitter.EmitComment("Requantize::Transform::Loop part A")
+      self.asm_emitter.EmitSubs(self.count_register, self.count_register, "#16")
+      self._EmitCode(load_registers, registers_a, registers_b)
+
+      # If there are no more blocks of 16-values to load then jump to the tail to
+      # finish processing the last loaded block of 16 and to load and process the
+      # tail.
+      self.asm_emitter.EmitNewline()
+      self.asm_emitter.EmitBeqFront(3)
+      self.asm_emitter.EmitNewline()
+
+      self.asm_emitter.EmitComment("Requantize::Transform::Loop part B")
+      self.asm_emitter.EmitSubs(self.count_register, self.count_register, "#16")
+      self._EmitCode(load_registers, registers_b, registers_a)
+
+      # If there are no more blocks of 16-values to load then fall through to
+      # finish processing the last loaded block of 16 and to load and process the
+      # tail - otherwise loop.
+      self.asm_emitter.EmitNewline()
+      self.asm_emitter.EmitBneBack(1)  # Loop
+
+    # Tails
+    # First tail: process remaining A while loading and processing tail in B
+    # Second tail: process remaining B while loading and processing tail in A
+    tails = (("A", registers_a, registers_b), ("B", registers_b, registers_a))
+    for i, (label, first, second) in enumerate(tails, 2):
+        comment = "Requantize::Transform::Tail {}".format(label)
+        with _Indent(self.asm_emitter, comment, label=i):
+          self._EmitCode(load_registers, first, second, load_number=leftovers)
+          self.asm_emitter.EmitNewline()
+
+          self._EmitCode(load_registers, second, first,
+                         process_number=leftovers, load_number=0)
+
+          self.asm_emitter.EmitNewline()
+          self.asm_emitter.EmitBFront(5)
+
+    # Third tail, process nothing, load and then process leftovers in A
+    with _Indent(self.asm_emitter, "Requantize::Transform::Tail C", 4):
+      self._EmitCode(load_registers, registers_b, registers_a, 0, leftovers)
+      self._EmitCode(load_registers, registers_a, registers_b, leftovers, 0)
+
+    # Explicit end of function, jumped to after end of first tail to avoid
+    # running into second tail.
+    self.asm_emitter.EmitNewline()
+    self.asm_emitter.EmitComment("Requantize::Return")
+    self.asm_emitter.EmitNumericalLabel(5)  # End of function
+
+    registers.FreeRegisters(load_registers + registers_a + registers_b)
+    self.asm_emitter.EmitAsmEnd(registers)
+    self.asm_emitter.PopIndent(len(self.emitter.indent))
+
+  def _Prepare(self, registers):
+    """Prepare by duplicating parameters for later use."""
+    self.asm_emitter.EmitComment("Requantize::Prepare")
+
+    # Duplicate the constants required for the transformation
+    self.coefficient = _DuplicateGeneralRegister(
+        32, self.asm_emitter, registers,
+        registers.MapParameter('coefficient'), 0
+    )
+    self.offset = _DuplicateGeneralRegister(
+        32, self.asm_emitter, registers,
+        registers.MapParameter('offset'), 0
+    )
+
+  def _EmitCode(self, load_registers, process_registers, next_registers,
+                process_number=16, load_number=16):
+    # Compute the number of registers to load and to process
+    n_loads = (load_number + 3) / 4
+    n_procs = (process_number + 3) / 4
+    assert n_loads <= 4
+    assert n_procs <= 4
+
+    # Start by processing loaded and prepared values, while simultaneously
+    # loading new values and copying the offset into the next set of registers
+    # to process.
+    loads_remaining = load_number
+    for i in range(max(n_loads, n_procs)):
+      # Extract registers relevant to this loop
+      ra = process_registers[i]
+      rb = next_registers[i]
+      rl = load_registers[i]
+
+      if i < n_procs:
+        self.asm_emitter.EmitVMulAcc('f32', ra, rl, self.coefficient)
+
+      if i < n_loads:
+        # Update the number of loads to perform
+        to_load = min(loads_remaining, 4)
+        loads_remaining -= to_load
+
+        # Perform a copy and a load of the appropriate width
+        self.asm_emitter.EmitVMov('f32', rb, self.offset)
+        self.asm_emitter.EmitVLoadAE(32, to_load, [rl], self.input_address, None)
+
+      self.asm_emitter.EmitNewline()
+
+    # Perform some housekeeping while processing (A) and preparing (B) for use.
+    for ra in process_registers[:n_procs]:
+      self.asm_emitter.EmitVCvt('s32', 'f32', ra, ra)
+
+    for rl in load_registers[:n_loads]:
+      self.asm_emitter.EmitVCvt('f32', 's32', rl, rl)
+
+    # Store (A)
+    if n_procs == 1:
+      self.asm_emitter.EmitVQmovn('s32', process_registers[0], process_registers[0])
+      self.asm_emitter.EmitVQmovun('s16', process_registers[0], process_registers[0])
+    elif n_procs == 2:
+      self.asm_emitter.EmitVQmovn2('s32', process_registers[0], process_registers[0], process_registers[1])
+      self.asm_emitter.EmitVQmovun('s16', process_registers[0], process_registers[0])
+    elif n_procs == 3:
+      self.asm_emitter.EmitVQmovn2('s32', process_registers[0], process_registers[0], process_registers[1])
+      self.asm_emitter.EmitVQmovn('s32', process_registers[2], process_registers[2])
+      self.asm_emitter.EmitVQmovun2('s16', process_registers[0], process_registers[0], process_registers[2])
+    elif n_procs == 4:
+      self.asm_emitter.EmitVQmovn2('s32', process_registers[0], process_registers[0], process_registers[1])
+      self.asm_emitter.EmitVQmovn2('s32', process_registers[2], process_registers[2], process_registers[3])
+      self.asm_emitter.EmitVQmovun2('s16', process_registers[0], process_registers[0], process_registers[2])
+
+    self.asm_emitter.EmitNewline()
+    self.asm_emitter.EmitVStoreAE(8, process_number, process_registers, self.output_address, None)
 
 
 class BiasAdd(common.Transform1DKernelGenerator):

--- a/meta/test_transform_correctness.cc
+++ b/meta/test_transform_correctness.cc
@@ -73,6 +73,7 @@ void prepare_data_biasadd(int count, std::uint8_t* data) {
 }
 
 void verify_requantize(const RequantizeParams& params) {
+  unsigned int incorrect = 0;
   for (int i = 0; i < params.kernel.count; ++i) {
     std::uint8_t actual = params.output[i];
     float expected = static_cast<float>(params.input[i]);
@@ -84,13 +85,21 @@ void verify_requantize(const RequantizeParams& params) {
     expected += params.kernel.output_range_offset;
     std::uint8_t expected_uint8 = static_cast<std::uint8_t>(expected);
 
-    if (actual != expected_uint8) {
-      std::cout << "Wrong: " << i << " : " << actual << " vs. "
-                << expected_uint8 << std::endl;
-      std::exit(1);
+    if (std::abs(actual - expected_uint8) > 1) {
+      std::cout << "Wrong: " << i << " : "
+                << static_cast<unsigned int>(actual) << " vs. "
+                << static_cast<unsigned int>(expected_uint8)
+                << std::endl;
+      incorrect++;
     }
   }
-  std::cout << "Requantize: OK" << std::endl;
+  if (!incorrect) {
+    std::cout << "Requantize: OK" << std::endl;
+  }
+  else {
+    std::cout << "Requantize: " << incorrect << " incorrect." << std::endl;
+    std::exit(1);
+  }
 }
 
 void verify_quantize(const QuantizeParams& params) {


### PR DESCRIPTION
Changes to the generators in `meta` to match changes made to the optimized Arm assembly in #93.

The formatting of the code that is produced by the generators doesn't match that of `meta/transform_kernels_arm_{32|64}.h`, so to keep this PR simple I've not included the generated headers. #99 contains both these changes and the generated headers.

Note: I've made some minor changes to `test_transform_correctness` to allow for slight differences between the actual and expected values which occur as a result of changing the order of some floating point operations.