### PR TITLE
Allow building on PowerPC without requiring macro define

### DIFF
--- a/internal/kernel_default.h
+++ b/internal/kernel_default.h
@@ -84,6 +84,10 @@ GEMMLOWP_SET_DEFAULT_KERNEL(false, false, SSE4_64_Kernel12x4Depth2)
 // SIMD is not available on this platform. The slow fallback will be used.
 // Don't require GEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK because there's nothing
 // the user can do about it.
+#elif defined __powerpc__
+// There is currently no fast kernel using SIMD instructions on POWER. Don't
+// require GEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK because there's nothing the user
+// can do about it.
 #else
 #error \
     "SIMD not enabled, you'd be getting a slow software fallback. Consider \


### PR DESCRIPTION
There is no SIMD fast-path on POWER that could be enabled with compiler flags, so we don't require GEMMLOWP_ALLOW_SLOW_SCALAR_FALLBACK to build on PPC.