### PR TITLE
UBSAN: Fix fixedpoint.h::ShiftLeft to not invoke undefined behaviour

### DIFF
--- a/fixedpoint/fixedpoint.h
+++ b/fixedpoint/fixedpoint.h
@@ -109,11 +109,12 @@ tIntegerType Neg(tIntegerType a) {
   return -a;
 }
 
-// Integer arithmetic left-shift, equivalent to multiplying with a
-// power of two. Not saturating. Overflow is undefined behavior.
+// Integer arithmetic left-shift, equivalent to multiplying with a power of two.
+// Not saturating. Negative inputs do not necessarily invoke undefined
+// behaviour. Overflow is undefined behavior.
 template <typename tIntegerType>
 tIntegerType ShiftLeft(tIntegerType a, int offset) {
-  return a << offset;
+  return a * (static_cast<tIntegerType>(1) << offset);
 }
 
 // Integer arithmetic right-shift. Not rounding.


### PR DESCRIPTION
In certain cases (e.g. in `exp_on_negative_values`, via [`Rescale<0>`](https://github.com/google/gemmlowp/blob/5b40e389e56969ce75839412e8f9a56ac83bcaa6/fixedpoint/fixedpoint.h#L734)), we can pass a negative signed value to the `ShiftLeft` function, which we then left shift. This is technically undefined behaviour in C++, and this UB is detected by modern versions of UBSAN, which is unfortunate.  For the reference, see [Section 5.8 Shift Operators](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3690.pdf)

> The value of E1 << E2 is E1 left-shifted E2 bit positions; vacated bits are zero-filled. If E1 has an unsigned type, the value of the result is E1 × 2^E2, reduced modulo one more than the maximum value representable in the result type. Otherwise, if E1 has a signed type and non-negative value, and E1 × 2^E2 is representable in the corresponding unsigned type of the result type, then that value, converted to the result type, is the resulting value; otherwise, the behavior is undefined

It's pretty trivial to fix the UB without any performance degradation, as modern compilers generate identical code for `a * (1 << shift)` as `a << shift`, with the advantage the the former doesn't invoke UB when `a` is a signed negative value. See [this godbolt session](https://godbolt.org/g/8C6osR) for details and to play (you can also add `-fsanitize=shift-base`), but Clang 5.0 on x86-64 generates:

```
        movl    %esi, %ecx
        shll    %cl, %edi
        movl    %edi, %eax
        retq
```

in both cases, and GCC on ARM and ARM64 generates:

```
        lsl     r0, r0, r1
        bx      lr
```

in both cases as well.

I believe we have a CLA already, but LMK.