### PR TITLE
multi_thread_gemm.h::WaitForVariableChange: Handle spurious wakeups correctly

### DIFF
--- a/internal/multi_thread_gemm.h
+++ b/internal/multi_thread_gemm.h
@@ -134,12 +134,11 @@ T WaitForVariableChange(volatile T* var, T initial_value, pthread_cond_t* cond,
 
   // Finally, do real passive waiting.
   pthread_mutex_lock(mutex);
-  T new_value = *var;
-  if (new_value == initial_value) {
+  T new_value;
+  while ((new_value = *var) == initial_value) {
     pthread_cond_wait(cond, mutex);
-    new_value = *var;
-    assert(new_value != initial_value);
   }
+  assert(new_value != initial_value);
   pthread_mutex_unlock(mutex);
   return new_value;
 }


### PR DESCRIPTION
From the documentation of [`pthread_cond_wait`](pubs.opengroup.org/onlinepubs/7908799/xsh/pthread_cond_wait.html), we have:

> When using condition variables there is always a boolean predicate involving shared variables associated with each condition wait that is true if the thread should proceed. Spurious wakeups from the pthread_cond_wait() or pthread_cond_timedwait() functions may occur. Since the return from pthread_cond_wait() or pthread_cond_timedwait() does not imply anything about the value of this predicate, the predicate should be re-evaluated upon such return.

See also https://en.wikipedia.org/wiki/Spurious_wakeup. 

I actually observed this happening in practice on some platforms (e.g. iOS), which leads to deadlocks or assertion failures. 

I ended up doing a rewrite of the WorkersPool to use C++11 atomics/thread/mutex abstractions (removing need for volatile or raw pthread code) with some minor performance improvements if that's of interest, but this is a pretty minimal diff that fixes the root cause.

Generated code is basically what you'd expect: https://godbolt.org/g/Brg2FZ

I believe we have a CLA already, but LMK.