### PR TITLE
Fix compilation error in Windows

### DIFF
--- a/internal/platform.h
+++ b/internal/platform.h
@@ -19,6 +19,7 @@
 
 #ifdef _WIN32
 #include <windows.h>
+#include <malloc.h>
 #else
 #include <stdlib.h>
 #include <time.h>

--- a/meta/multi_thread_common.h
+++ b/meta/multi_thread_common.h
@@ -22,9 +22,15 @@ namespace meta {
 
 inline int ResolveMaxThreads(int max_threads) {
   if (max_threads == 0) {
+#ifdef _WIN32
+    SYSTEM_INFO sysinfo;
+    GetSystemInfo(&sysinfo);
+    return sysinfo.dwNumberOfProcessors;
+#else
     static const int hardware_threads_count =
         static_cast<int>(sysconf(_SC_NPROCESSORS_CONF));
     return hardware_threads_count;
+#endif
   }
   return max_threads;
 }


### PR DESCRIPTION
This fix tries to fix compilation error in Windows for `meta/multi_thread_common.h`.

In `meta/multi_thread_common.h` the `sysconf(_SC_NPROCESSORS_CONF)` was used which is not available in Windows. This fix adds Windows alternative to address the build error.

```
+#ifdef _WIN32
+    SYSTEM_INFO sysinfo;
+    GetSystemInfo(&sysinfo);
+    return sysinfo.dwNumberOfProcessors;
+#else
     static const int hardware_threads_count =
         static_cast<int>(sysconf(_SC_NPROCESSORS_CONF));
     return hardware_threads_count;
+#endif
```

The PR (WIP) https://github.com/tensorflow/tensorflow/pull/18563 in TF repo is related to this fix.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>