### PR TITLE
Make gemmlowp multithreading correct:

### DIFF
--- a/flags.bzl
+++ b/flags.bzl
@@ -7,8 +7,5 @@ LIB_LINKOPTS = select({
     "//conditions:default": ["-lpthread"],
 })
 
-BIN_LINKOPTS = select({
-    ":android": [],
-    ":windows": [],
-    "//conditions:default": ["-lpthread"],
-})
+BIN_LINKOPTS = LIB_LINKOPTS
+

--- a/profiling/instrumentation.h
+++ b/profiling/instrumentation.h
@@ -185,7 +185,7 @@ inline ThreadInfo& ThreadLocalThreadInfo() {
     }
   };
 
-  static int key_result = pthread_key_create(&key, DeleteThreadInfo);
+  pthread_key_create(&key, DeleteThreadInfo);
 
   ThreadInfo* threadInfo = static_cast<ThreadInfo*>(pthread_getspecific(key));
   if (!threadInfo) {

--- a/profiling/pthread_everywhere.h
+++ b/profiling/pthread_everywhere.h
@@ -60,6 +60,9 @@ inline void pthread_cond_init(pthread_cond_t *cond, std::nullptr_t) {
   *cond = new std::condition_variable;
 }
 inline void pthread_cond_signal(pthread_cond_t *cond) { (*cond)->notify_one(); }
+inline void pthread_cond_broadcast(pthread_cond_t *cond) {
+  (*cond)->notify_all();
+}
 inline void pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex) {
   std::unique_lock<std::mutex> lock(**mutex, std::adopt_lock);
   (*cond)->wait(lock);


### PR DESCRIPTION
- std::memory_order_{acquire,release} in BlockingCounter
- a mutex and std::memory_order_relaxed in Worker

Tweak kMaxBusyWaitNOPs.

Thanks to Hans Boehm.