### PR TITLE
Fix typo in comments

### DIFF
--- a/internal/output.h
+++ b/internal/output.h
@@ -452,7 +452,7 @@ struct OutputPipelineExecutor {
   OutputPipelineExecutor(const OutputPipelineType& output_pipeline)
       : output_pipeline_eval_impl_(output_pipeline) {}
 
-  // RunOutputPipeline is the entry point into the output pipeline evaluation
+  // Execute is the entry point into the output pipeline evaluation
   // code. It should be the only thing that unpack code calls. It takes the
   // result
   // of the unpack stage and stores it into the destination matrix.


### PR DESCRIPTION
Commit 07a7b864 renamed `OutputPipelineExecutor::RunOutputPipeline` to `OutputPipelineExecutor::Execute`. The comments were not updated accordingly.
This updates the comments to reflect the current method name. 