### PR TITLE
use GEMMLOWP_NOINLINE to avoid windows build break.

### DIFF
--- a/internal/multi_thread_gemm.h
+++ b/internal/multi_thread_gemm.h
@@ -78,7 +78,7 @@ inline int DoSomeNOPs() {
 
 // If we can't use NOPs, let's use a non-inline function call as a basic
 // thing that has some vaguely known, nonzero cost.
-__attribute__((noinline))
+GEMMLOWP_NOINLINE
 inline int DoSomeNOPs() {
   // Pretend that calling an empty function takes as long as 16 NOPs...
   return 16;


### PR DESCRIPTION
@bjacob can you help to review it please?