### PR TITLE
fix warnings about unused parameters

### DIFF
--- a/internal/kernel_sse.h
+++ b/internal/kernel_sse.h
@@ -43,6 +43,7 @@ struct SSE4_32_Kernel4x4Depth2 : KernelBase {
            std::size_t run_depth) const override {
     ScopedProfilingLabel label("optimized kernel");
     assert(dst_row_stride == 1);
+    (void)dst_row_stride;
     std::int32_t run_depth_cells = run_depth / Format::kDepth;
     /* Main loop */
 
@@ -217,6 +218,7 @@ struct SSE4_64_Kernel12x4Depth2 : KernelBase {
            std::size_t run_depth) const override {
     ScopedProfilingLabel label("optimized kernel");
     assert(dst_row_stride == 1);
+    (void)dst_row_stride;
     const std::int64_t run_depth_cells = run_depth / Format::kDepth;
     const std::int64_t dst_col_stride_q = dst_col_stride;
 


### PR DESCRIPTION
Addresses an issue when running with -Werror,-Wunused-parameter
lee-bin@07eb865f35d6357ef9233a8fc41a5e2984958a46