### PR TITLE
Fix markdown format in kernel.md

### DIFF
--- a/doc/kernel.md
+++ b/doc/kernel.md
@@ -40,11 +40,15 @@ NEONKernel12x4Depth2 kernel, which specifies its format as
 
 The meaning of these terms is explained in the lengthy comment at the top of
 internal/kernel.h. Here, they mean that this kernel handles at each iteration
-(along the depth dimension): - 3 'cells' of size 4x2 each of the lhs, so a total
-lhs block of size 12x2 - 1 'cell' of size 2x4 of the rhs. In other words, this
-kernel handles 12 rows of the lhs and 4 columns of the rhs, and handles two
-levels of depth at once. The 'cells' and `CellFormat` detail the layout of these
-12x2 and 2x4 blocks.
+(along the depth dimension):
+
+- 3 'cells' of size 4x2 each of the lhs, so a total lhs block of size 12x2
+
+- 1 'cell' of size 2x4 of the rhs.
+
+In other words, this kernel handles 12 rows of the lhs and 4 columns of the
+rhs, and handles two levels of depth at once. The 'cells' and `CellFormat`
+detail the layout of these 12x2 and 2x4 blocks.
 
 This kernel then loads these 12x2 and 2x4 blocks and computes the corresponding
 12x4 GEMM; for ease of reference let us paste the critical comment and code


### PR DESCRIPTION
This tries to fix the markdown format to represent a bullet list. Minus signs are used in the middle of the sentences without newlines, which can be confusing for the readers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/gemmlowp/169)
<!-- Reviewable:end -->
