### PR TITLE
Increase ProfilingStack::kMaxSize

### DIFF
--- a/profiling/instrumentation.h
+++ b/profiling/instrumentation.h
@@ -108,7 +108,7 @@ struct ScopedLock {
 // contains pointers to literal strings that were manually entered
 // in the instrumented code (see ScopedProfilingLabel).
 struct ProfilingStack {
-  static const std::size_t kMaxSize = 14;
+  static const std::size_t kMaxSize = 30;
   typedef const char* LabelsArrayType[kMaxSize];
   LabelsArrayType labels;
   std::size_t size;


### PR DESCRIPTION
I ran into this limit with a real application that was hooking into gemmlowp's instrumentation.

30 is the next available number after 14, due to the static_assert that sizeof(ProfilingStack) must be a power of 2.
There are 2 pointer-sized objects in Profiling stack, and then kMaxSize pointers. Thus, 14+2 == 16, to increase it, the next available total size is 32, hence kMaxSize == 30.