### PR TITLE
Fix the type to avoid comparison of integers of different signs.

### DIFF
--- a/internal/multi_thread_gemm.h
+++ b/internal/multi_thread_gemm.h
@@ -382,7 +382,7 @@ class WorkersPool {
     CreateWorkers(workers_count);
     assert(workers_count <= workers_.size());
     counter_to_decrement_when_ready_.Reset(workers_count);
-    for (int i = 0; i < tasks_count - 1; i++) {
+    for (std::size_t i = 0; i < tasks_count - 1; i++) {
       workers_[i]->StartWork(&tasks[i]);
     }
     // Execute the remaining workload immediately on the current thread.


### PR DESCRIPTION
Fix the type to avoid comparison of integers of different signs. The compiling error is reported when "-Wsign-compared" is added.