### PR TITLE
Type fix to avoid comparison of int with size_t

### DIFF
--- a/internal/multi_thread_gemm.h
+++ b/internal/multi_thread_gemm.h
@@ -402,7 +402,7 @@ class WorkersPool {
     CreateWorkers(workers_count);
     assert(workers_count <= workers_.size());
     counter_to_decrement_when_ready_.Reset(workers_count);
-    for (int i = 0; i < tasks_count - 1; i++) {
+    for (size_t i = 0; i < tasks_count - 1; i++) {
       workers_[i]->StartWork(tasks[i]);
     }
     // Execute the remaining workload immediately on the current thread.


### PR DESCRIPTION
Similar to a227af1fdb47f250b5df07d6936366b0f8113b65. The compilation error is reported with `-Wsign-compare`