### PR TITLE
Support aarch64-pc-windows-msvc

### DIFF
--- a/internal/detect_platform.h
+++ b/internal/detect_platform.h
@@ -20,7 +20,7 @@
 
 // Our inline assembly path assume GCC/Clang syntax.
 // Native Client doesn't seem to support inline assembly(?).
-#if defined(__GNUC__) && !defined(__native_client__)
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(__native_client__)
 #define GEMMLOWP_ALLOW_INLINE_ASM
 #endif
 


### PR DESCRIPTION
It build failed for aarch64-pc-windows-msvc because the __GNUC__ is not definition in the clang for windows.
So It must be add __clang__ to enable GEMMLOWP_ALLOW_INLINE_ASM