### PR TITLE
Build static or shared libraries for all platforms

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -48,6 +48,7 @@ file(GLOB fixedpoint_private_headers "${gemmlowp_src}/fixedpoint/*.h")
 list(APPEND fixedpoint_private_headers "${gemmlowp_src}/internal/common.h")
 
 add_library(eight_bit_int_gemm ${eight_bit_int_gemm_sources_with_no_headers})
+set_target_properties(eight_bit_int_gemm PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 target_link_libraries(eight_bit_int_gemm ${EXTERNAL_LIBRARIES})
 
 # INTERFACE target to help header include


### PR DESCRIPTION
Allow building static or shared libraries for all platforms instead of hardcoding this option in the cmake file. Allows the client to choose the configuration based on the value of the standard CMake option `BUILD_SHARED_LIBS`.

Tested on local git workflow (see https://github.com/planetmarshall/gemmlowp/actions/runs/1392699171)