### PR TITLE
Fix build error on Android

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -13,6 +13,9 @@ include(GNUInstallDirs)
 # Set C++11 as default standard
 set(CMAKE_CXX_STANDARD 11)
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 get_filename_component(gemmlowp_src ${gemmlowp_SOURCE_DIR} PATH)
 
 if(WIN32)
@@ -24,7 +27,7 @@ if(WIN32)
     add_definitions(-DGEMMLOWP_ALLOW_INLINE_ASM)
   endif()
 else()
-  set(EXTERNAL_LIBRARIES "pthread")
+  set(EXTERNAL_LIBRARIES Threads::Threads)
 endif()
 
 # Glob header files


### PR DESCRIPTION
Hi there,

I'm encountering a build error on the Android platform.

In `contrib/CMakeLists.txt`, the `-lpthread` linker flag is added for non-Windows platforms. However, on certain platforms like Android, the `-lpthread` flag is unnecessary and is causing build errors.

This is simple script to reproduce.
```bash
mkdir _build
cd _build
cmake -DCMAKE_TOOLCHAIN_FILE=<NDK-path>/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a ../contrib
cmake --build .

# [  5%] Building CXX object 
# CMakeFiles/eight_bit_int_gemm.dir/Users/yoshio.soma/gemmlowp/eight_bit_int_gemm/eight_bit_int_gemm.cc.o
# [ 11%] Linking CXX static library libeight_bit_int_gemm.a
# [ 11%] Built target eight_bit_int_gemm
# [ 17%] Building CXX object CMakeFiles/benchmark.dir/Users/yoshio.soma/gemmlowp/test/benchmark.cc.o
# [ 23%] Linking CXX executable benchmark
# ld: error: unable to find library -lpthread
# clang++: error: linker command failed with exit code 1 (use -v to see invocation)
# make[2]: *** [benchmark] Error 1
# make[1]: *** [CMakeFiles/benchmark.dir/all] Error 2
# make: *** [all] Error 2
```

### Changes
Instead of hard-coding the `-lpthread` flag, I propose using `find_package()` to link with pthread. By employing `find_package()`, CMake will automatically detect the platform and set the appropriate flags accordingly.

### Related Issue
- [GitHub Issue #61839](https://github.com/tensorflow/tensorflow/issues/61839)

I believe this change will resolve the build error on the Android platform. Your feedback and review are much appreciated.

Thank you!